### PR TITLE
GTT-398: Backend to retrieve homepage

### DIFF
--- a/backend/src/lib/api/homepage-api.ts
+++ b/backend/src/lib/api/homepage-api.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import HomepageCtrl from "../controllers/homepage-ctrl";
+import withErrorHandler from "./middleware/error-handler";
+
+const router = Router();
+
+router.get("/", withErrorHandler(HomepageCtrl.getHomepage));
+
+export default router;

--- a/backend/src/lib/api/index.ts
+++ b/backend/src/lib/api/index.ts
@@ -4,6 +4,7 @@ import cors from "cors";
 import dashboard from "./dashboard-api";
 import topicarea from "./topicarea-api";
 import dataset from "./dataset-api";
+import homepage from "./homepage-api";
 
 const app = express();
 app.use(express.json());
@@ -12,5 +13,6 @@ app.use(cors());
 app.use("/dashboard", dashboard);
 app.use("/topicarea", topicarea);
 app.use("/dataset", dataset);
+app.use("/homepage", homepage);
 
 export default app;

--- a/backend/src/lib/controllers/__tests__/homepage-ctrl.test.ts
+++ b/backend/src/lib/controllers/__tests__/homepage-ctrl.test.ts
@@ -1,0 +1,55 @@
+import { Request, Response } from "express";
+import { mocked } from "ts-jest/utils";
+import HomepageFactory from "../../factories/homepage-factory";
+import HomepageRepository from "../../repositories/homepage-repo";
+import HomepageCtrl from "../homepage-ctrl";
+
+jest.mock("../../repositories/homepage-repo");
+jest.mock("../../factories/homepage-factory");
+
+const repository = mocked(HomepageRepository.prototype);
+const req = ({} as any) as Request;
+const res = ({
+  send: jest.fn().mockReturnThis(),
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn().mockReturnThis(),
+} as any) as Response;
+
+beforeEach(() => {
+  HomepageRepository.getInstance = jest.fn().mockReturnValue(repository);
+});
+
+describe("getHomepage", () => {
+  it("returns default values for homepage", async () => {
+    // No Homepage found on the database
+    repository.getHomepage = jest.fn().mockReturnValueOnce(undefined);
+
+    // Homepage factory should provide the default homepage
+    HomepageFactory.getDefaultHomepage = jest.fn().mockReturnValueOnce({
+      title: "Performance Dashboard",
+      description: "Welcome to the performance dashboard",
+    });
+
+    await HomepageCtrl.getHomepage(req, res);
+    expect(HomepageFactory.getDefaultHomepage).toBeCalled();
+    expect(res.json).toBeCalledWith({
+      title: "Performance Dashboard",
+      description: "Welcome to the performance dashboard",
+    });
+  });
+
+  it("returns homepage when available in the database", async () => {
+    HomepageFactory.getDefaultHomepage = jest.fn();
+    repository.getHomepage = jest.fn().mockReturnValueOnce({
+      title: "Kingdom of Wakanda",
+      description: "Welcome to the performance dashboard of our kingdom",
+    });
+
+    await HomepageCtrl.getHomepage(req, res);
+    expect(HomepageFactory.getDefaultHomepage).not.toBeCalled();
+    expect(res.json).toBeCalledWith({
+      title: "Kingdom of Wakanda",
+      description: "Welcome to the performance dashboard of our kingdom",
+    });
+  });
+});

--- a/backend/src/lib/controllers/homepage-ctrl.ts
+++ b/backend/src/lib/controllers/homepage-ctrl.ts
@@ -1,0 +1,18 @@
+import { Request, Response } from "express";
+import HomepageFactory from "../factories/homepage-factory";
+import HomepageRepository from "../repositories/homepage-repo";
+
+async function getHomepage(req: Request, res: Response) {
+  const repo = HomepageRepository.getInstance();
+  const homepage = await repo.getHomepage();
+
+  if (!homepage) {
+    return res.json(HomepageFactory.getDefaultHomepage());
+  }
+
+  return res.json(homepage);
+}
+
+export default {
+  getHomepage,
+};

--- a/backend/src/lib/factories/__tests__/homepage-factory.test.ts
+++ b/backend/src/lib/factories/__tests__/homepage-factory.test.ts
@@ -1,0 +1,30 @@
+import { Homepage, HomepageItem } from "../../models/homepage";
+import HomepageFactory from "../homepage-factory";
+
+describe("getDefaultHomepage", () => {
+  it("returns default values", () => {
+    expect(HomepageFactory.getDefaultHomepage()).toEqual({
+      title: "Performance Dashboard",
+      description:
+        "The Performance Dashboard makes data open " +
+        "and accessible to provide transparency and help drive the " +
+        "ongoing improvement of digital services.",
+    });
+  });
+});
+
+describe("fromItem", () => {
+  it("converts a dynamodb item to a Homepage object", () => {
+    const item: HomepageItem = {
+      pk: "Homepage",
+      sk: "Homepage",
+      type: "Homepage",
+      title: "Kingdom of Wakanda",
+      description: "Welcome to Wakanda",
+    };
+
+    const homepage = HomepageFactory.fromItem(item);
+    expect(homepage.title).toEqual("Kingdom of Wakanda");
+    expect(homepage.description).toEqual("Welcome to Wakanda");
+  });
+});

--- a/backend/src/lib/factories/homepage-factory.ts
+++ b/backend/src/lib/factories/homepage-factory.ts
@@ -1,0 +1,23 @@
+import { Homepage, HomepageItem } from "../models/homepage";
+
+function getDefaultHomepage(): Homepage {
+  return {
+    title: "Performance Dashboard",
+    description:
+      "The Performance Dashboard makes data open " +
+      "and accessible to provide transparency and help drive the " +
+      "ongoing improvement of digital services.",
+  };
+}
+
+function fromItem(item: HomepageItem): Homepage {
+  return {
+    title: item.title,
+    description: item.description,
+  };
+}
+
+export default {
+  getDefaultHomepage,
+  fromItem,
+};

--- a/backend/src/lib/models/homepage.ts
+++ b/backend/src/lib/models/homepage.ts
@@ -1,0 +1,12 @@
+export interface Homepage {
+  title: string;
+  description: string;
+}
+
+export interface HomepageItem {
+  pk: string;
+  sk: string;
+  type: string;
+  title: string;
+  description: string;
+}

--- a/backend/src/lib/repositories/__tests__/homepage-repo.test.ts
+++ b/backend/src/lib/repositories/__tests__/homepage-repo.test.ts
@@ -1,0 +1,47 @@
+import { mocked } from "ts-jest/utils";
+import { Homepage, HomepageItem } from "../../models/homepage";
+import HomepageRepository from "../homepage-repo";
+import DynamoDBService from "../../services/dynamodb";
+import S3Service from "../../services/s3";
+
+jest.mock("../../services/dynamodb");
+jest.mock("../../services/s3");
+jest.mock("../../factories/dataset-factory");
+
+let tableName: string;
+let repo: HomepageRepository;
+let dynamodb = mocked(DynamoDBService.prototype);
+let s3Service = mocked(S3Service.prototype);
+
+beforeAll(() => {
+  tableName = "BadgerTable";
+  process.env.BADGER_TABLE = tableName;
+
+  DynamoDBService.getInstance = jest.fn().mockReturnValue(dynamodb);
+  S3Service.getInstance = jest.fn().mockReturnValue(s3Service);
+  repo = HomepageRepository.getInstance();
+});
+
+describe("getHomepage", () => {
+  it("returns undefined if Homepage is not found", async () => {
+    dynamodb.get = jest.fn().mockReturnValueOnce({ Item: null });
+    const homepage = await repo.getHomepage();
+    expect(homepage).toBeUndefined();
+  });
+
+  it("returns a Homepage if found on database", async () => {
+    const item: HomepageItem = {
+      pk: "Homepage",
+      sk: "Homepage",
+      type: "Homepage",
+      title: "Kingdom of Wakanda",
+      description: "Welcome to our kingdom",
+    };
+
+    dynamodb.get = jest.fn().mockReturnValueOnce({ Item: item });
+    const homepage = (await repo.getHomepage()) as Homepage;
+
+    expect(homepage.title).toEqual("Kingdom of Wakanda");
+    expect(homepage.description).toEqual("Welcome to our kingdom");
+  });
+});

--- a/backend/src/lib/repositories/base.ts
+++ b/backend/src/lib/repositories/base.ts
@@ -1,0 +1,17 @@
+import DynamoDBService from "../services/dynamodb";
+
+abstract class BaseRepository {
+  protected dynamodb: DynamoDBService;
+  protected tableName: string;
+
+  constructor() {
+    if (!process.env.BADGER_TABLE) {
+      throw new Error("Environment variable BADGER_TABLE not found");
+    }
+
+    this.dynamodb = DynamoDBService.getInstance();
+    this.tableName = process.env.BADGER_TABLE;
+  }
+}
+
+export default BaseRepository;

--- a/backend/src/lib/repositories/homepage-repo.ts
+++ b/backend/src/lib/repositories/homepage-repo.ts
@@ -1,0 +1,34 @@
+import { Homepage, HomepageItem } from "../models/homepage";
+import HomepageFactory from "../factories/homepage-factory";
+import BaseRepository from "./base";
+
+class HomepageRepository extends BaseRepository {
+  protected static instance: HomepageRepository;
+  private constructor() {
+    super();
+  }
+
+  static getInstance(): HomepageRepository {
+    return HomepageRepository.instance
+      ? HomepageRepository.instance
+      : new HomepageRepository();
+  }
+
+  public async getHomepage(): Promise<Homepage | undefined> {
+    const result = await this.dynamodb.get({
+      TableName: this.tableName,
+      Key: {
+        pk: "Homepage",
+        sk: "Homepage",
+      },
+    });
+
+    if (!result.Item) {
+      return undefined;
+    }
+
+    return HomepageFactory.fromItem(result.Item as HomepageItem);
+  }
+}
+
+export default HomepageRepository;

--- a/cdk/lib/constructs/api.ts
+++ b/cdk/lib/constructs/api.ts
@@ -69,5 +69,10 @@ export class BadgerApi extends cdk.Construct {
 
     const datasets = this.api.root.addResource("dataset");
     datasets.addMethod("POST", apiIntegration, methodProps);
+
+    // Public endpoints that do not require authentication.
+    // Not passing `methodProps` is what makes the endpoint public.
+    const homepage = this.api.root.addResource("homepage");
+    homepage.addMethod("GET", apiIntegration);
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
New backend endpoint that returns the Homepage information (Title and Description). This is our first public endpoint that doesn't require authentication. It looks for the Homepage in dynamodb and returns default values if entry is not found. 

```
method: GET
endpoint: /homepage

Example response:
{
  "title": "Kingdom of Wakanda",
  "description": "Welcome"
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
