### PR TITLE
GTT-401: Frontend to display homepage with no auth

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,61 +15,88 @@ import EditTable from "./containers/EditTable";
 import AddText from "./containers/AddText";
 import EditText from "./containers/EditText";
 
-import { library } from "@fortawesome/fontawesome-svg-core";
-import {
-  faGripLinesVertical,
-  faCaretUp,
-  faCaretDown,
-} from "@fortawesome/free-solid-svg-icons";
+interface BadgerRoute {
+  path: string;
+  component: React.FunctionComponent<any>;
+  public?: boolean;
+}
 
-library.add(faGripLinesVertical, faCaretUp, faCaretDown);
+const routes: Array<BadgerRoute> = [
+  {
+    path: "/",
+    component: Home,
+    public: true,
+  },
+  {
+    path: "/admin",
+    component: DashboardListing,
+  },
+  {
+    path: "/admin/dashboards",
+    component: DashboardListing,
+  },
+  {
+    path: "/admin/dashboard/create",
+    component: CreateDashboard,
+  },
+  {
+    path: "/admin/dashboard/edit/:dashboardId",
+    component: EditDashboard,
+  },
+  {
+    path: "/admin/dashboard/edit/:dashboardId/details",
+    component: EditDetails,
+  },
+  {
+    path: "/admin/dashboard/:dashboardId/edit-table/:widgetId",
+    component: EditTable,
+  },
+  {
+    path: "/admin/dashboard/:dashboardId/add-table",
+    component: AddTable,
+  },
+  {
+    path: "/admin/dashboard/:dashboardId/edit-chart/:widgetId",
+    component: EditChart,
+  },
+  {
+    path: "/admin/dashboard/:dashboardId/add-chart",
+    component: AddChart,
+  },
+  {
+    path: "/admin/dashboard/:dashboardId/edit-text/:widgetId",
+    component: EditText,
+  },
+  {
+    path: "/admin/dashboard/:dashboardId/add-text",
+    component: AddText,
+  },
+  {
+    path: "/admin/dashboard/:dashboardId/add-content",
+    component: AddContent,
+  },
+];
 
 function App() {
   return (
     <Router>
       <Switch>
-        <Route path="/admin/dashboard/:dashboardId/add-content">
-          <AddContent />
-        </Route>
-        <Route path="/admin/dashboard/:dashboardId/add-text">
-          <AddText />
-        </Route>
-        <Route path="/admin/dashboard/:dashboardId/edit-text/:widgetId">
-          <EditText />
-        </Route>
-        <Route path="/admin/dashboard/:dashboardId/add-chart">
-          <AddChart />
-        </Route>
-        <Route path="/admin/dashboard/:dashboardId/edit-chart/:widgetId">
-          <EditChart />
-        </Route>
-        <Route path="/admin/dashboard/:dashboardId/add-table">
-          <AddTable />
-        </Route>
-        <Route path="/admin/dashboard/:dashboardId/edit-table/:widgetId">
-          <EditTable />
-        </Route>
-        <Route path="/admin/dashboard/edit/:dashboardId/details">
-          <EditDetails />
-        </Route>
-        <Route path="/admin/dashboard/edit/:dashboardId">
-          <EditDashboard />
-        </Route>
-        <Route path="/admin/dashboards">
-          <DashboardListing />
-        </Route>
-        <Route path="/admin/dashboard/create">
-          <CreateDashboard />
-        </Route>
-        <Route path="/admin">
-          <DashboardListing />
-        </Route>
-        <Route path="/">
-          <Home />
-        </Route>
+        {routes.map((route) => {
+          const component = route.public
+            ? route.component
+            : withAuthenticator(route.component);
+          return (
+            <Route
+              exact
+              key={route.path}
+              component={component}
+              path={route.path}
+            />
+          );
+        })}
       </Switch>
     </Router>
   );
 }
 
-export default withAuthenticator(App);
+export default App;

--- a/frontend/src/containers/Home.tsx
+++ b/frontend/src/containers/Home.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import MainLayout from "../layouts/Main";
-import { useDashboards } from "../hooks";
+import { useDashboards, useHomepage } from "../hooks";
 
 function Home() {
   const { dashboards } = useDashboards();
+  const { homepage } = useHomepage();
   return (
     <MainLayout>
-      <h1>Dashboards</h1>
+      <h1 className="font-sans-3xl width-tablet">{homepage.title}</h1>
+      <p className="font-sans-lg measure-3 usa-prose">{homepage.description}</p>
       <ul className="usa-list">
         {dashboards.map((dashboard) => (
           <li key={dashboard.id}>{dashboard.name}</li>

--- a/frontend/src/containers/__tests__/EditDashboard.test.tsx
+++ b/frontend/src/containers/__tests__/EditDashboard.test.tsx
@@ -2,17 +2,9 @@ import React from "react";
 import { render, fireEvent, act } from "@testing-library/react";
 import { createMemoryHistory } from "history";
 import { MemoryRouter, Router } from "react-router-dom";
-import { library } from "@fortawesome/fontawesome-svg-core";
-import {
-  faGripLinesVertical,
-  faCaretUp,
-  faCaretDown,
-} from "@fortawesome/free-solid-svg-icons";
 
 import EditDashboard from "../EditDashboard";
 import BadgerService from "../../services/BadgerService";
-
-library.add(faGripLinesVertical, faCaretUp, faCaretDown);
 
 jest.mock("../../hooks");
 jest.mock("../../services/BadgerService");

--- a/frontend/src/containers/__tests__/Home.test.tsx
+++ b/frontend/src/containers/__tests__/Home.test.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import Home from "../Home";
+
+jest.mock("../../hooks");
+
+test("renders homepage title", async () => {
+  const { getByRole } = render(<Home />, {
+    wrapper: MemoryRouter,
+  });
+  expect(
+    getByRole("heading", { name: "Kingdom of Wakanda" })
+  ).toBeInTheDocument();
+});
+
+test("renders homepage description", async () => {
+  const { getByText } = render(<Home />, { wrapper: MemoryRouter });
+  expect(getByText("Welcome to our dashboard")).toBeInTheDocument();
+});

--- a/frontend/src/hooks/__mocks__/index.tsx
+++ b/frontend/src/hooks/__mocks__/index.tsx
@@ -105,3 +105,13 @@ export function useWidgets(dashboardId: string) {
     setWidgets: () => {},
   };
 }
+
+export function useHomepage() {
+  return {
+    loading: false,
+    homepage: {
+      title: "Kingdom of Wakanda",
+      description: "Welcome to our dashboard",
+    },
+  };
+}

--- a/frontend/src/hooks/dashboard-hooks.ts
+++ b/frontend/src/hooks/dashboard-hooks.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState, useCallback } from "react";
+import { Dashboard } from "../models";
+import BadgerService from "../services/BadgerService";
+
+type UseDashboardHook = {
+  loading: boolean;
+  dashboard?: Dashboard;
+  reloadDashboard: Function;
+  setDashboard: Function;
+};
+
+export function useDashboard(dashboardId: string): UseDashboardHook {
+  const [loading, setLoading] = useState(false);
+  const [dashboard, setDashboard] = useState<Dashboard | undefined>(undefined);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    const data = await BadgerService.fetchDashboardById(dashboardId);
+    setLoading(false);
+    if (data) {
+      data.widgets.sort((a, b) => a.order - b.order);
+      setDashboard(data);
+    }
+  }, [dashboardId]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return {
+    loading,
+    dashboard,
+    setDashboard,
+    reloadDashboard: fetchData,
+  };
+}
+
+type UseDashboardsHook = {
+  loading: boolean;
+  dashboards: Array<Dashboard>;
+};
+
+export function useDashboards(): UseDashboardsHook {
+  const [loading, setLoading] = useState(false);
+  const [dashboards, setDashboards] = useState([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true);
+      const data = await BadgerService.fetchDashboards();
+      setDashboards(data);
+      setLoading(false);
+    };
+    fetchData();
+  }, []);
+
+  return {
+    loading,
+    dashboards,
+  };
+}

--- a/frontend/src/hooks/homepage-hooks.ts
+++ b/frontend/src/hooks/homepage-hooks.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+import { Homepage } from "../models";
+import BadgerService from "../services/BadgerService";
+
+type UseHomepageHook = {
+  loading: boolean;
+  homepage: Homepage;
+};
+
+export function useHomepage(): UseHomepageHook {
+  const [loading, setLoading] = useState<boolean>(false);
+  const [homepage, setHomepage] = useState<Homepage>({
+    title: "",
+    description: "",
+  });
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true);
+      const data = await BadgerService.fetchHomepage();
+      setHomepage(data);
+      setLoading(false);
+    };
+    fetchData();
+  }, []);
+
+  return {
+    loading,
+    homepage,
+  };
+}

--- a/frontend/src/hooks/index.tsx
+++ b/frontend/src/hooks/index.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState, useCallback } from "react";
-import { TopicArea, Dashboard, Widget } from "../models";
-import BadgerService from "../services/BadgerService";
-import StorageService from "../services/StorageService";
+import { useDashboard, useDashboards } from "./dashboard-hooks";
+import { useWidget, useWidgets, useColors } from "./widget-hooks";
+import { useTopicAreas } from "./topicarea-hooks";
+import { useHomepage } from "./homepage-hooks";
 
 /**
  * No unit tests for custom hooks?
@@ -12,189 +12,12 @@ import StorageService from "../services/StorageService";
  * https://reactjs.org/warnings/invalid-hook-call-warning.html.
  */
 
-type UseTopicAreasHook = {
-  loading: boolean;
-  topicareas: Array<TopicArea>;
+export {
+  useDashboard,
+  useDashboards,
+  useWidget,
+  useWidgets,
+  useColors,
+  useTopicAreas,
+  useHomepage,
 };
-
-export function useTopicAreas(): UseTopicAreasHook {
-  const [loading, setLoading] = useState(false);
-  const [topicareas, setTopicAreas] = useState([]);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      setLoading(true);
-      const data = await BadgerService.fetchTopicAreas();
-      setTopicAreas(data);
-      setLoading(false);
-    };
-    fetchData();
-  }, []);
-
-  return {
-    loading,
-    topicareas,
-  };
-}
-
-type UseDashboardHook = {
-  loading: boolean;
-  dashboard?: Dashboard;
-  reloadDashboard: Function;
-  setDashboard: Function;
-};
-
-export function useDashboard(dashboardId: string): UseDashboardHook {
-  const [loading, setLoading] = useState(false);
-  const [dashboard, setDashboard] = useState<Dashboard | undefined>(undefined);
-
-  const fetchData = useCallback(async () => {
-    setLoading(true);
-    const data = await BadgerService.fetchDashboardById(dashboardId);
-    setLoading(false);
-    if (data) {
-      data.widgets.sort((a, b) => a.order - b.order);
-      setDashboard(data);
-    }
-  }, [dashboardId]);
-
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
-
-  return {
-    loading,
-    dashboard,
-    setDashboard,
-    reloadDashboard: fetchData,
-  };
-}
-
-type UseDashboardsHook = {
-  loading: boolean;
-  dashboards: Array<Dashboard>;
-};
-
-export function useDashboards(): UseDashboardsHook {
-  const [loading, setLoading] = useState(false);
-  const [dashboards, setDashboards] = useState([]);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      setLoading(true);
-      const data = await BadgerService.fetchDashboards();
-      setDashboards(data);
-      setLoading(false);
-    };
-    fetchData();
-  }, []);
-
-  return {
-    loading,
-    dashboards,
-  };
-}
-
-type UseWidgetHook = {
-  loading: boolean;
-  widget?: Widget;
-};
-
-export function useWidget(
-  dashboardId: string,
-  widgetId: string,
-  onWidgetFetched: Function
-): UseWidgetHook {
-  const [loading, setLoading] = useState(false);
-  const [widget, setWidget] = useState<Widget | undefined>(undefined);
-
-  const fetchData = useCallback(async () => {
-    setLoading(true);
-    const data = await BadgerService.fetchWidgetById(dashboardId, widgetId);
-    let fileDownloaded;
-    if (data.widgetType === "Chart" || data.widgetType === "Table") {
-      fileDownloaded = await StorageService.downloadDataset(
-        data.content.s3Key.raw,
-        data.content.title
-      );
-    }
-    setLoading(false);
-    if (data) {
-      setWidget(data);
-    }
-    if (fileDownloaded && onWidgetFetched) {
-      onWidgetFetched(fileDownloaded, data.name, data.content.chartType);
-    } else if (onWidgetFetched) {
-      onWidgetFetched(data.name, data.content.text);
-    }
-  }, [dashboardId, widgetId, onWidgetFetched]);
-
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
-
-  return {
-    loading,
-    widget,
-  };
-}
-
-type UseWidgetsHook = {
-  loading: boolean;
-  widgets: Array<Widget>;
-  setWidgets: Function;
-};
-
-export function useWidgets(dashboardId: string): UseWidgetsHook {
-  const [loading, setLoading] = useState(false);
-  const [widgets, setWidgets] = useState([]);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      setLoading(true);
-      const data = await BadgerService.fetchWidgets(dashboardId);
-      setWidgets(data);
-      setLoading(false);
-    };
-    fetchData();
-  }, [dashboardId]);
-
-  return {
-    loading,
-    widgets,
-    setWidgets,
-  };
-}
-
-const sprectrumColors = [
-  "#29B4BB",
-  "#3F29C8",
-  "#E17316",
-  "#CE167E",
-  "#7D70F9",
-  "#40E15D",
-  "#2168E5",
-  "#5B20A2",
-  "#D7B40A",
-  "#BE5B0F",
-  "#217C59",
-  "#8DED43",
-];
-
-const getColors = (numberOfColors: number): Array<string> => {
-  const colors = new Array<string>();
-  for (let i = 0; i < numberOfColors; i++) {
-    colors.push(sprectrumColors[i % sprectrumColors.length]);
-  }
-  return colors;
-};
-
-export function useColors(numberOfColors: number): Array<string> {
-  const [colors, setColors] = useState<Array<string>>([]);
-
-  useEffect(() => {
-    setColors(getColors(numberOfColors));
-  }, [numberOfColors]);
-
-  return colors;
-}

--- a/frontend/src/hooks/topicarea-hooks.ts
+++ b/frontend/src/hooks/topicarea-hooks.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import { TopicArea } from "../models";
+import BadgerService from "../services/BadgerService";
+
+type UseTopicAreasHook = {
+  loading: boolean;
+  topicareas: Array<TopicArea>;
+};
+
+export function useTopicAreas(): UseTopicAreasHook {
+  const [loading, setLoading] = useState(false);
+  const [topicareas, setTopicAreas] = useState([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true);
+      const data = await BadgerService.fetchTopicAreas();
+      setTopicAreas(data);
+      setLoading(false);
+    };
+    fetchData();
+  }, []);
+
+  return {
+    loading,
+    topicareas,
+  };
+}

--- a/frontend/src/hooks/widget-hooks.ts
+++ b/frontend/src/hooks/widget-hooks.ts
@@ -1,0 +1,108 @@
+import { useEffect, useState, useCallback } from "react";
+import { Widget } from "../models";
+import BadgerService from "../services/BadgerService";
+import StorageService from "../services/StorageService";
+
+type UseWidgetHook = {
+  loading: boolean;
+  widget?: Widget;
+};
+
+export function useWidget(
+  dashboardId: string,
+  widgetId: string,
+  onWidgetFetched: Function
+): UseWidgetHook {
+  const [loading, setLoading] = useState(false);
+  const [widget, setWidget] = useState<Widget | undefined>(undefined);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    const data = await BadgerService.fetchWidgetById(dashboardId, widgetId);
+    let fileDownloaded;
+    if (data.widgetType === "Chart" || data.widgetType === "Table") {
+      fileDownloaded = await StorageService.downloadDataset(
+        data.content.s3Key.raw,
+        data.content.title
+      );
+    }
+    setLoading(false);
+    if (data) {
+      setWidget(data);
+    }
+    if (fileDownloaded && onWidgetFetched) {
+      onWidgetFetched(fileDownloaded, data.name, data.content.chartType);
+    } else if (onWidgetFetched) {
+      onWidgetFetched(data.name, data.content.text);
+    }
+  }, [dashboardId, widgetId, onWidgetFetched]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return {
+    loading,
+    widget,
+  };
+}
+
+type UseWidgetsHook = {
+  loading: boolean;
+  widgets: Array<Widget>;
+  setWidgets: Function;
+};
+
+export function useWidgets(dashboardId: string): UseWidgetsHook {
+  const [loading, setLoading] = useState(false);
+  const [widgets, setWidgets] = useState([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true);
+      const data = await BadgerService.fetchWidgets(dashboardId);
+      setWidgets(data);
+      setLoading(false);
+    };
+    fetchData();
+  }, [dashboardId]);
+
+  return {
+    loading,
+    widgets,
+    setWidgets,
+  };
+}
+
+const sprectrumColors = [
+  "#29B4BB",
+  "#3F29C8",
+  "#E17316",
+  "#CE167E",
+  "#7D70F9",
+  "#40E15D",
+  "#2168E5",
+  "#5B20A2",
+  "#D7B40A",
+  "#BE5B0F",
+  "#217C59",
+  "#8DED43",
+];
+
+const getColors = (numberOfColors: number): Array<string> => {
+  const colors = new Array<string>();
+  for (let i = 0; i < numberOfColors; i++) {
+    colors.push(sprectrumColors[i % sprectrumColors.length]);
+  }
+  return colors;
+};
+
+export function useColors(numberOfColors: number): Array<string> {
+  const [colors, setColors] = useState<Array<string>>([]);
+
+  useEffect(() => {
+    setColors(getColors(numberOfColors));
+  }, [numberOfColors]);
+
+  return colors;
+}

--- a/frontend/src/layouts/Main.tsx
+++ b/frontend/src/layouts/Main.tsx
@@ -8,22 +8,22 @@ function MainLayout(props: LayoutProps) {
   return (
     <>
       <div className="usa-overlay"></div>
-      <section className="usa-hero">
-        <div className="grid-container">
-          <div className="usa-hero__callout">
-            <h1 className="usa-hero__heading">Performance Dashboard</h1>
-            <p>Find information about your government digital services</p>
+      <header className="usa-header usa-header--basic">
+        <div className="usa-nav-container">
+          <div className="usa-navbar">
+            <div className="usa-logo" id="basic-logo">
+              <em className="usa-logo__text">
+                <a href="/" title="Home" aria-label="Home">
+                  Performance Dashboard
+                </a>
+              </em>
+            </div>
           </div>
         </div>
-      </section>
-      <main className="minh-mobile">
+      </header>
+      <main className="padding-y-3">
         <div className="grid-container">{props.children}</div>
       </main>
-      <footer className="usa-footer">
-        <div className="usa-footer__secondary-section">
-          <div className="grid-container">Amazon Web Services</div>
-        </div>
-      </footer>
     </>
   );
 }

--- a/frontend/src/models/index.tsx
+++ b/frontend/src/models/index.tsx
@@ -32,3 +32,8 @@ export type Dataset = {
     json: string;
   };
 };
+
+export type Homepage = {
+  title: string;
+  description: string;
+};

--- a/frontend/src/services/BadgerService.ts
+++ b/frontend/src/services/BadgerService.ts
@@ -161,6 +161,10 @@ async function setWidgetOrder(
   });
 }
 
+async function fetchHomepage() {
+  return API.get(apiName, "/homepage", {});
+}
+
 export default {
   fetchDashboards,
   fetchDashboardById,
@@ -175,4 +179,5 @@ export default {
   setWidgetOrder,
   createDataset,
   getAuthToken,
+  fetchHomepage,
 };

--- a/frontend/src/services/__tests__/BadgerService.test.ts
+++ b/frontend/src/services/__tests__/BadgerService.test.ts
@@ -132,3 +132,8 @@ test("setWidgetOrder makes a PUT request to widget API", async () => {
     })
   );
 });
+
+test("fetchHomepage makes a GET request to widget API", async () => {
+  await BadgerService.fetchHomepage();
+  expect(API.get).toHaveBeenCalledWith("BadgerApi", "/homepage", {});
+});


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Displaying homepage as a React component without authentication. 
- Refactored hooks folder to split into separate files for better organization. 

You can test in my personal environment by navigating to this page in a Incognito Browser: http://fdingler.badger.wwps.aws.dev and you will see that no authentication is required to load the homepage title and description. 

**Note** that listing dashboards in the homepage does require authentication. We need to create a new endpoint to get a list of dashboards that is open to the public as well. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
