### PR TITLE
Add application/vnd.ms-excel mimeType to fix invalid csv file on Windows

### DIFF
--- a/frontend/src/services/StorageService.ts
+++ b/frontend/src/services/StorageService.ts
@@ -23,6 +23,7 @@ const accessLevel = "public";
 const serverSideEncryption = "aws:kms";
 const rawFileTypes: ValidFileTypes = {
   "text/csv": ".csv",
+  "application/vnd.ms-excel": ".csv",
 };
 
 async function downloadDataset(filename: string, title: string): Promise<File> {


### PR DESCRIPTION
## Description

Add application/vnd.ms-excel mimeType to fix invalid csv file on Windows

## Testing

You can test it here: https://migdizn.badger.wwps.aws.dev/admin/dashboard/edit/228ffc8c-3289-49bb-a452-b3f07f8b5374 on Mac to check everything still works fine. I tested it on my Windows - Amazon Workspace and it is working well now.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
