### PR TITLE
GTT-468 Endpoint to create draft from published dashboard

### DIFF
--- a/backend/src/lib/api/dashboard-api.ts
+++ b/backend/src/lib/api/dashboard-api.ts
@@ -7,6 +7,7 @@ const router = Router();
 
 router.get("/", withErrorHandler(DashboardCtrl.listDashboards));
 router.get("/:id", withErrorHandler(DashboardCtrl.getDashboardById));
+router.post("/:id", withErrorHandler(DashboardCtrl.createNewDraft));
 router.post("/", withErrorHandler(DashboardCtrl.createDashboard));
 router.put("/:id/publish", withErrorHandler(DashboardCtrl.publishDashboard));
 router.put("/:id/widgetorder", withErrorHandler(WidgetCtrl.setWidgetOrder));

--- a/backend/src/lib/factories/__tests__/dashboard-factory.test.ts
+++ b/backend/src/lib/factories/__tests__/dashboard-factory.test.ts
@@ -5,6 +5,7 @@ import {
   DashboardState,
 } from "../../models/dashboard";
 import { User } from "../../models/user";
+import dashboardFactory from "../dashboard-factory";
 
 const user: User = {
   userId: "johndoe",
@@ -156,5 +157,52 @@ describe("toPublic", () => {
     expect(publicDashboard.topicAreaName).toEqual(dashboard.topicAreaName);
     expect(publicDashboard.description).toEqual(dashboard.description);
     expect(publicDashboard.updatedAt).toEqual(dashboard.updatedAt);
+  });
+});
+
+describe("createDraftFromDashboard", () => {
+  const dashboard: Dashboard = {
+    id: "123",
+    version: 1,
+    parentDashboardId: "123",
+    name: "Dashboard 1",
+    topicAreaId: "456",
+    topicAreaName: "Topic 1",
+    description: "Description test",
+    createdBy: user.userId,
+    updatedAt: new Date(),
+    state: DashboardState.Draft,
+  };
+
+  it("should create a dashboard with same parentDashboardId", () => {
+    const draft = factory.createDraftFromDashboard(dashboard, user);
+    expect(draft.parentDashboardId).toEqual(dashboard.parentDashboardId);
+  });
+
+  it("should create a dashboard on Draft state", () => {
+    const draft = factory.createDraftFromDashboard(dashboard, user);
+    expect(draft.state).toEqual(DashboardState.Draft);
+  });
+
+  it("should create a dashboard with a new id", () => {
+    const draft = factory.createDraftFromDashboard(dashboard, user);
+    expect(draft.id).not.toEqual(dashboard.id);
+  });
+
+  it("should increment the version number", () => {
+    const draft = factory.createDraftFromDashboard(dashboard, user);
+    expect(draft.version).toEqual(dashboard.version + 1);
+  });
+
+  it("should create a dashboard with all other attributes", () => {
+    const draft = factory.createDraftFromDashboard(dashboard, user);
+    expect(draft).toEqual(
+      expect.objectContaining({
+        name: "Dashboard 1",
+        topicAreaId: "456",
+        topicAreaName: "Topic 1",
+        description: "Description test",
+      })
+    );
   });
 });

--- a/backend/src/lib/factories/dashboard-factory.ts
+++ b/backend/src/lib/factories/dashboard-factory.ts
@@ -32,6 +32,22 @@ function createNew(
   };
 }
 
+function createDraftFromDashboard(dashboard: Dashboard, user: User): Dashboard {
+  const id = uuidv4();
+  return {
+    id,
+    name: dashboard.name,
+    version: dashboard.version + 1,
+    parentDashboardId: dashboard.parentDashboardId,
+    topicAreaId: dashboard.topicAreaId,
+    topicAreaName: dashboard.topicAreaName,
+    description: dashboard.description,
+    state: DashboardState.Draft,
+    createdBy: user.userId,
+    updatedAt: new Date(),
+  };
+}
+
 /**
  * Converts a Dashboard to a DynamoDB item.
  */
@@ -88,6 +104,7 @@ function toPublic(dashboard: Dashboard): PublicDashboard {
 
 export default {
   createNew,
+  createDraftFromDashboard,
   toItem,
   fromItem,
   itemId,

--- a/backend/src/lib/repositories/dashboard-repo.ts
+++ b/backend/src/lib/repositories/dashboard-repo.ts
@@ -280,6 +280,30 @@ class DashboardRepository extends BaseRepository {
       DashboardFactory.fromItem(item as DashboardItem)
     );
   }
+
+  public async getCurrentDraft(
+    parentDashboardId: string
+  ): Promise<Dashboard | null> {
+    const result = await this.dynamodb.query({
+      TableName: this.tableName,
+      IndexName: "byParentDashboard",
+      KeyConditionExpression: "parentDashboardId = :parentDashboardId",
+      FilterExpression: "#state = :state",
+      ExpressionAttributeNames: {
+        "#state": "state",
+      },
+      ExpressionAttributeValues: {
+        ":parentDashboardId": parentDashboardId,
+        ":state": DashboardState.Draft,
+      },
+    });
+
+    if (!result.Items || result.Items.length === 0) {
+      return null;
+    }
+
+    return DashboardFactory.fromItem(result.Items[0] as DashboardItem);
+  }
 }
 
 export default DashboardRepository;

--- a/cdk/lib/constructs/api.ts
+++ b/cdk/lib/constructs/api.ts
@@ -53,6 +53,7 @@ export class BadgerApi extends cdk.Construct {
     const dashboard = dashboards.addResource("{id}");
     dashboard.addMethod("GET", apiIntegration, methodProps);
     dashboard.addMethod("PUT", apiIntegration, methodProps);
+    dashboard.addMethod("POST", apiIntegration, methodProps);
     dashboard.addMethod("DELETE", apiIntegration, methodProps);
 
     const widgetorder = dashboard.addResource("widgetorder");

--- a/cdk/lib/constructs/database.ts
+++ b/cdk/lib/constructs/database.ts
@@ -32,6 +32,19 @@ export class BadgerDatabase extends cdk.Construct {
       },
     });
 
+    table.addGlobalSecondaryIndex({
+      indexName: "byParentDashboard",
+      projectionType: dynamodb.ProjectionType.ALL,
+      partitionKey: {
+        name: "parentDashboardId",
+        type: dynamodb.AttributeType.STRING,
+      },
+      sortKey: {
+        name: "version",
+        type: dynamodb.AttributeType.NUMBER,
+      },
+    });
+
     this.mainTable = table;
   }
 }


### PR DESCRIPTION
## Description

New `POST` endpoint that creates a new Draft dashboard based on a Published one. If there is already a Draft dashboard associated to the parentDashboard, then it returns the current Draft instead of creating a new one. If the dashboard is not in Published state, then it throws an error (HTTP Status Code 409 - Resource Conflict). 

I also added a GSI to the DynamoDB table `byParentDashboard` that returns all versions of a given parentDashboardId. 

## Testing

Deployed to my personal environment and tested with Postman: 

```
method: POST
endpoint: /dashboard/:id
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
