### PR TITLE
[Bug Fix] Disabled prune on frontend deployment

### DIFF
--- a/cdk/lib/frontend-stack.ts
+++ b/cdk/lib/frontend-stack.ts
@@ -71,6 +71,7 @@ export class FrontendStack extends cdk.Stack {
       {
         sources: [s3Deploy.Source.asset("../frontend/build")],
         destinationBucket: this.frontendBucket,
+        prune: false,
         distribution,
       }
     );


### PR DESCRIPTION
## Description

Gamma environment keeps breaking after a deployment. I discovered it is because the Lambda function that deploys the `env.js` file doesn't run on every deployment. It only runs when there is a change in the environment variables or the code changes. And the function that deploys the React code was deleting all files on every deployment causing the `env.js` to be deleted as well and never re-created. 

With this PR, I am disabling the `prune` option so that the contents of the bucket are not deleted on every deployment. 

## Testing

Deployed to my personal environment. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
