### PR TITLE
Enable logout

### DIFF
--- a/frontend/src/layouts/Admin.tsx
+++ b/frontend/src/layouts/Admin.tsx
@@ -17,8 +17,6 @@ async function signOut(event: React.MouseEvent) {
 }
 
 function AdminLayout(props: LayoutProps) {
-  //const history = useHistory();
-
   return (
     <>
       <div className="usa-overlay"></div>


### PR DESCRIPTION
Add Logout dropdown menu to the header used for Admin pages

## Description

Added Logout dropdown menu to the header used for Admin pages.  Used Amplify signOut to log out, then redirect user to /admin.  User will be prompted for login

## Testing

* Tested on mobile view to make sure Logout menu is visible
* Made sure the user has to login again after logging out. User can't use the browser back button to get in to system
* After logging out, the Id token is still valid on API calls for another hour

Tested on https://trietlu.badger.wwps.aws.dev/admin

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
