### PR TITLE
Specifying content-type for env.js

### DIFF
--- a/cdk/lib/envconfig/index.ts
+++ b/cdk/lib/envconfig/index.ts
@@ -30,6 +30,9 @@ const uploadConfig = async () => {
       Bucket: frontendBucket,
       Key: "env.js",
       Body: content,
+      Metadata: {
+        "Content-Type": "application/javascript",
+      },
     })
     .promise();
 


### PR DESCRIPTION
## Description

Specifying mime type of `application/javascript` for the `env.js` file to prevent S3 to assign the default mime type of `application/octet-stream`. The Browser rejected to execute the script without the proper mime type. 

## Testing

Deployed to my personal environment. Verified that `env.js` has the proper mime type. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
