### PR TITLE
Show current user name in logout drop down menu

### DIFF
--- a/frontend/src/hooks/admin-hooks.ts
+++ b/frontend/src/hooks/admin-hooks.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+import { Auth } from "aws-amplify";
+
+type AdminHook = {
+  username: string;
+};
+
+export function useAdmin(): AdminHook {
+  const [username, setUsername] = useState<string>("");
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const user = await Auth.currentAuthenticatedUser();
+      setUsername(user.username);
+    };
+    fetchData();
+  }, []);
+
+  return {
+    username,
+  };
+}

--- a/frontend/src/hooks/index.tsx
+++ b/frontend/src/hooks/index.tsx
@@ -7,6 +7,7 @@ import { useWidget, useColors } from "./widget-hooks";
 import { useTopicAreas } from "./topicarea-hooks";
 import { useHomepage } from "./homepage-hooks";
 import { useJsonDataset } from "./dataset-hooks";
+import {useAdmin} from "./admin-hooks";
 
 /**
  * No unit tests for custom hooks?
@@ -26,4 +27,5 @@ export {
   useTopicAreas,
   useHomepage,
   useJsonDataset,
+  useAdmin,
 };

--- a/frontend/src/layouts/Admin.tsx
+++ b/frontend/src/layouts/Admin.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from "react";
 import { Auth } from "aws-amplify";
+import { useAdmin } from "../hooks";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faWindowClose } from "@fortawesome/free-solid-svg-icons";
 
@@ -17,6 +18,8 @@ async function signOut(event: React.MouseEvent) {
 }
 
 function AdminLayout(props: LayoutProps) {
+  const { username } = useAdmin();
+
   return (
     <>
       <div className="usa-overlay"></div>
@@ -43,7 +46,7 @@ function AdminLayout(props: LayoutProps) {
                   aria-expanded="false"
                   aria-controls="basic-nav-section-one"
                 >
-                  <span>Admin</span>
+                  <span>{username}</span>
                 </button>
                 <ul
                   id="basic-nav-section-one"


### PR DESCRIPTION
## Description

Added admin-hooks.ts to be used with layouts/Admin.tsx.  This hook retrieves the current logged in user using Amplify's Auth.currentAuthenticatedUser()

## Testing

Created 2 users in Cognito.  Logged in as each to view name in drop down menu.  Testing can be done in https://trietlu.badger.wwps.aws.dev/admin

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
