### PR TITLE
GTT-484 Banner to display existing draft

### DIFF
--- a/frontend/src/components/Alert.tsx
+++ b/frontend/src/components/Alert.tsx
@@ -2,7 +2,8 @@ import React from "react";
 
 interface Props {
   title?: string;
-  message: string;
+  hideIcon?: boolean;
+  message: string | React.ReactNode;
   type: "info" | "warning" | "error" | "success";
   slim?: boolean;
 }
@@ -13,14 +14,22 @@ function Alert(props: Props) {
     className += " usa-alert--slim";
   }
 
+  if (props.hideIcon) {
+    className += " usa-alert--no-icon";
+  }
+
   return (
     <div className={className}>
-      <div className="usa-alert__body">
-        {props.title && !props.slim && (
-          <h3 className="usa-alert__heading">{props.title}</h3>
-        )}
-        <p className="usa-alert__text">{props.message}</p>
-      </div>
+      {typeof props.message === "object" ? (
+        props.message
+      ) : (
+        <div className="usa-alert__body">
+          {props.title && !props.slim && (
+            <h3 className="usa-alert__heading">{props.title}</h3>
+          )}
+          <p className="usa-alert__text">{props.message}</p>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/__tests__/Alert.test.tsx
+++ b/frontend/src/components/__tests__/Alert.test.tsx
@@ -45,3 +45,22 @@ test("renders a slim alert ignoring title", async () => {
   );
   expect(wrapper.container).toMatchSnapshot();
 });
+
+test("renders an alert without icon", async () => {
+  const wrapper = render(
+    <Alert type="success" message="Hello world" hideIcon slim />
+  );
+  expect(wrapper.container).toMatchSnapshot();
+});
+
+test("renders an alert with HTML content as message", async () => {
+  const wrapper = render(
+    <Alert
+      type="success"
+      message={<a href="#">This is a link</a>}
+      hideIcon
+      slim
+    />
+  );
+  expect(wrapper.container).toMatchSnapshot();
+});

--- a/frontend/src/components/__tests__/__snapshots__/Alert.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/Alert.test.tsx.snap
@@ -90,6 +90,20 @@ exports[`renders a warning alert 1`] = `
 </div>
 `;
 
+exports[`renders an alert with HTML content as message 1`] = `
+<div>
+  <div
+    class="usa-alert usa-alert--success usa-alert--slim usa-alert--no-icon"
+  >
+    <a
+      href="#"
+    >
+      This is a link
+    </a>
+  </div>
+</div>
+`;
+
 exports[`renders an alert with title 1`] = `
 <div>
   <div
@@ -103,6 +117,24 @@ exports[`renders an alert with title 1`] = `
       >
         Informative status
       </h3>
+      <p
+        class="usa-alert__text"
+      >
+        Hello world
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders an alert without icon 1`] = `
+<div>
+  <div
+    class="usa-alert usa-alert--success usa-alert--slim usa-alert--no-icon"
+  >
+    <div
+      class="usa-alert__body"
+    >
       <p
         class="usa-alert__text"
       >

--- a/frontend/src/hooks/__mocks__/index.tsx
+++ b/frontend/src/hooks/__mocks__/index.tsx
@@ -4,6 +4,8 @@
  * calls to happen and instead returns dummy data.
  */
 
+import { DashboardState } from "../../models";
+
 const dummyDashboard = {
   id: "123",
   name: "My AWS Dashboard",
@@ -191,4 +193,22 @@ export function useColors(numberOfColors: number) {
     "#217C59",
     "#8DED43",
   ];
+}
+
+export function useDashboardVersions(parentDashboardId: string) {
+  return {
+    loading: false,
+    versions: [
+      {
+        id: "001",
+        version: 1,
+        state: DashboardState.Draft,
+      },
+      {
+        id: "002",
+        version: 2,
+        state: DashboardState.Published,
+      },
+    ],
+  };
 }

--- a/frontend/src/hooks/dashboard-hooks.ts
+++ b/frontend/src/hooks/dashboard-hooks.ts
@@ -1,5 +1,10 @@
 import { useEffect, useState, useCallback } from "react";
-import { Dashboard, DashboardState, PublicDashboard } from "../models";
+import {
+  Dashboard,
+  DashboardState,
+  DashboardVersion,
+  PublicDashboard,
+} from "../models";
 import BadgerService from "../services/BadgerService";
 
 type UseDashboardHook = {
@@ -121,5 +126,36 @@ export function usePublicDashboard(
     loading,
     dashboard,
     reloadDashboard: fetchData,
+  };
+}
+
+type UseVersionsHook = {
+  loading: boolean;
+  versions: Array<DashboardVersion>;
+};
+
+export function useDashboardVersions(
+  parentDashboardId: string | undefined
+): UseVersionsHook {
+  const [loading, setLoading] = useState<boolean>(false);
+  const [versions, setVersions] = useState<DashboardVersion[]>([]);
+
+  useEffect(() => {
+    if (parentDashboardId) {
+      const fetchData = async () => {
+        setLoading(true);
+        const data = await BadgerService.fetchDashboardVersions(
+          parentDashboardId
+        );
+        setVersions(data);
+        setLoading(false);
+      };
+      fetchData();
+    }
+  }, [parentDashboardId]);
+
+  return {
+    loading,
+    versions,
   };
 }

--- a/frontend/src/hooks/index.tsx
+++ b/frontend/src/hooks/index.tsx
@@ -2,6 +2,7 @@ import {
   useDashboard,
   useDashboards,
   usePublicDashboard,
+  useDashboardVersions,
 } from "./dashboard-hooks";
 import { useWidget, useColors } from "./widget-hooks";
 import { useTopicAreas } from "./topicarea-hooks";
@@ -28,4 +29,5 @@ export {
   useHomepage,
   useJsonDataset,
   useAdmin,
+  useDashboardVersions,
 };

--- a/frontend/src/models/index.tsx
+++ b/frontend/src/models/index.tsx
@@ -35,6 +35,12 @@ export type PublicDashboard = {
   updatedAt: Date;
 };
 
+export type DashboardVersion = {
+  id: string;
+  version: number;
+  state: DashboardState;
+};
+
 export enum WidgetType {
   Text = "Text",
   Chart = "Chart",

--- a/frontend/src/services/BadgerService.ts
+++ b/frontend/src/services/BadgerService.ts
@@ -1,5 +1,11 @@
 import { API, Auth } from "aws-amplify";
-import { Dashboard, Dataset, PublicDashboard, Widget } from "../models";
+import {
+  Dashboard,
+  DashboardVersion,
+  Dataset,
+  PublicDashboard,
+  Widget,
+} from "../models";
 
 const apiName = "BadgerApi";
 
@@ -19,6 +25,15 @@ async function getAuthToken() {
 async function fetchDashboards(): Promise<Array<Dashboard>> {
   const headers = await authHeaders();
   return await API.get(apiName, "dashboard", { headers });
+}
+
+async function fetchDashboardVersions(
+  parentDashboardId: string
+): Promise<Array<DashboardVersion>> {
+  const headers = await authHeaders();
+  return await API.get(apiName, `dashboard/${parentDashboardId}/versions`, {
+    headers,
+  });
 }
 
 async function fetchDashboardById(dashboardId: string): Promise<Dashboard> {
@@ -247,4 +262,5 @@ export default {
   publishPending,
   createDraft,
   moveToDraft,
+  fetchDashboardVersions,
 };

--- a/frontend/src/services/__tests__/BadgerService.test.ts
+++ b/frontend/src/services/__tests__/BadgerService.test.ts
@@ -210,3 +210,12 @@ test("moveToDraft makes a PUT request to dashboard API", async () => {
     })
   );
 });
+
+test("fetchDashboardVersions makes a GET request to dashboard API", async () => {
+  await BadgerService.fetchDashboardVersions("123");
+  expect(API.get).toBeCalledWith(
+    "BadgerApi",
+    "dashboard/123/versions",
+    expect.anything()
+  );
+});


### PR DESCRIPTION
## Description

- Modified `<Alert />` component to allow HTML to be entered as content so that I could add a link. 
- New function in BadgerService to fetch all versions for a given `parentDashboardId`. 
- New hook to retrieve list of versions for a parentDashboardId. 
- Added info banner to notify user there is an existing dashboard according to this wireframe: https://aws-uxdr.invisionapp.com/share/QFVZXJJ8K9V#/screens. 

## Testing

Updated unit tests. Tested on my personal environment that a Banner shows up for dashboards that already have a draft associated to it. And verified that Banner does not show up for dashboard without draft. 

To test, click on a Published dashboard and look for the banner: 
https://fdingler.badger.wwps.aws.dev/admin/dashboards?tab=published

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
