### PR TITLE
Add a custom Cognito invite email for the Badger UserPool

### DIFF
--- a/cdk/lib/auth-stack.ts
+++ b/cdk/lib/auth-stack.ts
@@ -18,9 +18,10 @@ export class AuthStack extends cdk.Stack {
 
     const pool = new cognito.UserPool(this, "BadgerUserPool", {
       userInvitation: {
-        emailSubject: 'You have been invited to the Performance Dashboard on AWS.',
+        emailSubject:
+          "You have been invited to the {Organization} Performance Dashboard on AWS.",
         emailBody: fs.readFileSync("lib/data/email-template.html").toString(),
-      }
+      },
     });
 
     const client = pool.addClient("BadgerFrontend");

--- a/cdk/lib/data/email-template.html
+++ b/cdk/lib/data/email-template.html
@@ -1,52 +1,102 @@
 <html>
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-  <meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=no;">
-</head>
-<body width="100%" style="margin: 0; padding: 0 !important; background-color: #999; font-family: Source Sans Pro Web,Helvetica Neue,Helvetica,Roboto,Arial,sans-serif;">
-  <div style="margin: 0 auto; max-width: 700px; background-color: #fff; "align="center">
-    <div style="border: 1px solid; margin: 0 auto; max-width: 600px; " align="left">
-      <div style="padding: 20; ">
-          <table >
-          <tr>
-            <td width="50">
-                <img align="left" style="border:none;border-radius:0px;display:block;outline:none;text-decoration:none;width:100%;height:auto;" alt="Your Logo" src="https://{your domain}.com}/logo.png" />
-            </td>
-            <td style="padding: 5px; font-size:16px; font-weight:bold">
-              <p align="left" style="Margin-top: 10px;Margin-bottom: 0;">{Organization} Performance Dashboard</p>
-            </td>
-          </tr>
-        </table>
-        <p style="Margin-top: 10px;Margin-bottom: 0;">&nbsp;</p>
-        <h2
-          style="margin-top: 20px; margin-bottom: 0;font-style: normal; color: #000;font-size: 28px;line-height: 32px;">You have been invited to the {Organization} Performance Dashboard on AWS</h2>
-        <p style="Margin-top: 10px;Margin-bottom: 0;font-size: 16px;line-height: 24px; color: #000">{Administrator} has invited you. If you believe that you have gotten this invite in error, please disregard this message. If you are unsure of the message’s authenticity, please reach out to the person who invited you.</p>
-        <p style="Margin-top: 10px;Margin-bottom: 0;font-size: 16px;line-height: 24px; color: #000">Your username is {username} and temporary password is "{####}".  You will have to change your password after you login.</p>
-        <p style="Margin-top: 20px;Margin-bottom: 0;">&nbsp;</p>
-        <div style="Margin-bottom: 20px;">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=no;"
+    />
+  </head>
+  <body
+    width="100%"
+    style="margin: 0; padding: 0 !important; background-color: #999; font-family: Source Sans Pro Web,Helvetica Neue,Helvetica,Roboto,Arial,sans-serif;"
+  >
+    <div
+      style="margin: 0 auto; max-width: 700px; background-color: #fff; "
+      align="center"
+    >
+      <div
+        style="border: 1px solid; margin: 0 auto; max-width: 600px; "
+        align="left"
+      >
+        <div style="padding: 20; ">
+          <table>
+            <tr>
+              <td width="50">
+                <img
+                  align="left"
+                  style="border:none;border-radius:0px;display:block;outline:none;text-decoration:none;width:100%;height:auto;"
+                  alt="Your Logo"
+                  src="https://{your domain}.com}/logo.png"
+                />
+              </td>
+              <td style="padding: 5px; font-size:16px; font-weight:bold">
+                <p align="left" style="Margin-top: 10px;Margin-bottom: 0;">
+                  {Organization} Performance Dashboard
+                </p>
+              </td>
+            </tr>
+          </table>
+
+          <p style="Margin-top: 10px;Margin-bottom: 0;">&nbsp;</p>
+          <h2
+            style="margin-top: 20px; margin-bottom: 0;font-style: normal; color: #000;font-size: 28px;line-height: 32px;"
+          >
+            You have been invited to the {Organization} Performance Dashboard on
+            AWS
+          </h2>
+          <p
+            style="Margin-top: 10px;Margin-bottom: 0;font-size: 16px;line-height: 24px; color: #000"
+          >
+            {Administrator} has invited you. If you believe that you have gotten
+            this invite in error, please disregard this message. If you are
+            unsure of the message’s authenticity, please reach out to the person
+            who invited you.
+          </p>
+          <p
+            style="Margin-top: 10px;Margin-bottom: 0;font-size: 16px;line-height: 24px; color: #000"
+          >
+            Your username is {username} and temporary password is "{####}". You
+            will have to change your password after you login.
+          </p>
+          <p style="Margin-top: 20px;Margin-bottom: 0;">&nbsp;</p>
+          <div style="Margin-bottom: 20px;">
+            <a
+              style="border-radius: 4px;font-size: 14px;font-weight: bold;line-height: 24px;padding: 12px 24px 13px 24px;text-decoration: none !important; text-align: center;color: #ffffff !important;background-color: #3b5998;"
+              href="https://trietlu.badger.wwps.aws.dev/admin"
+              >Accept the invite</a
+            >
+          </div>
           <a
-            style="border-radius: 4px;font-size: 14px;font-weight: bold;line-height: 24px;padding: 12px 24px 13px 24px;text-decoration: none !important; text-align: center;color: #ffffff !important;background-color: #3b5998;"
-            href="https://trietlu.badger.wwps.aws.dev/admin">Accept the invite</a>
+            style="font-size: 12px;line-height: 5px; color: #000;"
+            href="https://{your domain}.com/admin"
+            >https://{your domain}.com/admin</a
+          >
+          <hr style="Margin-top: 30px;" />
+          <p
+            style="font-size: 10px;line-height: 5px; color: #000; font-style: italic"
+          >
+            Please do not reply to this message
+          </p>
         </div>
-        <a style="font-size: 12px;line-height: 5px; color: #000;" href="https://{your domain}.com/admin">https://{your domain}.com/admin</a>
-        <hr style="Margin-top: 30px;">
-        <p style="font-size: 10px;line-height: 5px; color: #000; font-style: italic">Please do not reply to this message</p>
       </div>
+      <table style="font-size: 12px;line-height: 50px;">
+        <tr>
+          <td>
+            <a
+              style="color: #000;"
+              href="https://github.com/awslabs/performance-dashboard-on-aws"
+              >About Performance Dashboard</a
+            >
+          </td>
+          <td>
+            |
+          </td>
+          <td>
+            <a style="color: #000;" href="{Replace}">Privacy</a>
+          </td>
+        </tr>
+      </table>
     </div>
-    <table style="font-size: 12px;line-height: 50px;" >
-      <tr>
-        <td>
-          <a style="color: #000;" href="https://github.com/awslabs/performance-dashboard-on-aws">About Performance Dashboard</a>
-        </td>
-        <td>
-          |
-        </td>
-        <td>
-          <a style="color: #000;" href="{Replace}">Privacy</a>
-        </td>
-      </tr>
-    </table>
-  </div>
-</body>
+  </body>
 </html>


### PR DESCRIPTION
## Description

Add a custom Cognito invite email for the Badger UserPool.  Store the email template in a separate file, and read in the content 

## Testing

* Because the email template is read in, verified that the generated CFT from cdk synth contains the email text
* Tested the email template with Outlook, gmail, and iOS Mail

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
