### PR TITLE
Tag AWS resources created for cost allocation and tracking usage

### DIFF
--- a/cdk/bin/badger.ts
+++ b/cdk/bin/badger.ts
@@ -4,8 +4,9 @@ import * as cdk from "@aws-cdk/core";
 import { FrontendStack } from "../lib/frontend-stack";
 import { BackendStack } from "../lib/backend-stack";
 import { AuthStack } from "../lib/auth-stack";
+import { Tag } from "@aws-cdk/core";
 
-const APP_ID = "Performance Dashboard On AWS";
+const APP_ID = "Performance Dashboard on AWS";
 const envName = process.env.CDK_ENV_NAME;
 
 if (!envName) {
@@ -21,14 +22,14 @@ const auth = new AuthStack(app, "Auth", {
   stackName: stackPrefix.concat("-Auth"),
   datasetsBucketName: datasetsBucketName,
 });
-auth.node.applyAspect(new cdk.Tag("app-id", APP_ID));
+Tag.add(auth, "app-id", APP_ID);
 
 const backend = new BackendStack(app, "Backend", {
   stackName: stackPrefix.concat("-Backend"),
   userPoolArn: auth.userPoolArn,
   datasetsBucketName: datasetsBucketName,
 });
-backend.node.applyAspect(new cdk.Tag("app-id", APP_ID));
+Tag.add(backend, "app-id", APP_ID);
 
 const frontend = new FrontendStack(app, "Frontend", {
   stackName: stackPrefix.concat("-Frontend"),
@@ -38,4 +39,4 @@ const frontend = new FrontendStack(app, "Frontend", {
   appClientId: auth.appClientId,
   badgerApiUrl: backend.apiGatewayEndpoint,
 });
-frontend.node.applyAspect(new cdk.Tag("app-id", APP_ID));
+Tag.add(frontend, "app-id", APP_ID);


### PR DESCRIPTION
## Description

In the CDK App, tag the stacks created with the key app-id and value of "Performance Dashboard on AWS".  Per the [Cloud Resource Naming and Tagging Standards](https://amazon.awsapps.com/workdocs/index.html#/document/a178e50ae9aaa67edaeeecc0b5826406e547a788bc075d706b5a92570471759c), use app-id to identify your app

## Testing

After deploying, use Resource Groups and Tag Editor in the Console to query for resources with the tag

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
