### PR TITLE
Add optional summary field for chart/table

### DIFF
--- a/backend/src/lib/factories/__tests__/widget-factory.test.ts
+++ b/backend/src/lib/factories/__tests__/widget-factory.test.ts
@@ -75,6 +75,7 @@ describe("createChartWidget", () => {
       title: "Correlation of COVID cases to deaths",
       chartType: "LineChart",
       datasetId: "090b0410",
+      summary: "test summary",
       s3Key: {
         raw: "abc.csv",
         json: "abc.json",
@@ -94,6 +95,7 @@ describe("createChartWidget", () => {
     expect(widget.content.title).toEqual(
       "Correlation of COVID cases to deaths"
     );
+    expect(widget.content.summary).toEqual("test summary");
     expect(widget.content.chartType).toEqual("LineChart");
   });
 
@@ -102,6 +104,7 @@ describe("createChartWidget", () => {
       title: "Correlation of COVID cases to deaths",
       chartType: "LineChart",
       datasetId: "090b0410",
+      summary: "test summary",
       s3Key: {
         raw: "abc.csv",
         json: "abc.json",
@@ -122,6 +125,7 @@ describe("createChartWidget", () => {
     expect(widget.content.title).toEqual(
       "Correlation of COVID cases to deaths"
     );
+    expect(widget.content.summary).toEqual("test summary");
     expect(widget.content.chartType).toEqual("LineChart");
     expect(widget.id).toEqual("123");
   });
@@ -182,6 +186,7 @@ describe("createChartWidget", () => {
       title: "Correlation of COVID cases to deaths",
       chartType: "BarChart",
       datasetId: "090b0410",
+      summary: "test summary",
       s3Key: {
         raw: "abc.csv",
         json: "abc.json",
@@ -203,6 +208,7 @@ describe("createChartWidget", () => {
       title: "Correlation of COVID cases to deaths",
       chartType: "PartWholeChart",
       datasetId: "090b0410",
+      summary: "test summary",
       s3Key: {
         raw: "abc.csv",
         json: "abc.json",
@@ -336,6 +342,7 @@ describe("fromItem", () => {
       content: {
         title: "Correlation of COVID cases to deaths",
         chartType: "LineChart",
+        summary: "test summary",
         datasetId: "090b0410",
       },
     };
@@ -352,6 +359,7 @@ describe("fromItem", () => {
     expect(widget.content.title).toEqual(
       "Correlation of COVID cases to deaths"
     );
+    expect(widget.content.summary).toEqual("test summary");
     expect(widget.content.chartType).toEqual("LineChart");
   });
 
@@ -367,6 +375,7 @@ describe("fromItem", () => {
       content: {
         title: "Correlation of COVID cases to deaths",
         datasetId: "090b0410",
+        summary: "test summary",
       },
     };
 
@@ -382,6 +391,7 @@ describe("fromItem", () => {
     expect(widget.content.title).toEqual(
       "Correlation of COVID cases to deaths"
     );
+    expect(widget.content.summary).toEqual("test summary");
   });
 
   it("handles an invalid widget type gracefully", () => {
@@ -452,6 +462,7 @@ describe("toItem", () => {
         title: "Correlation of COVID cases to deaths",
         chartType: ChartType.LineChart,
         datasetId: "090b0410",
+        summary: "test summary",
         s3Key: {
           raw: "abc.csv",
           json: "abc.json",
@@ -472,6 +483,7 @@ describe("toItem", () => {
       title: "Correlation of COVID cases to deaths",
       chartType: "LineChart",
       datasetId: "090b0410",
+      summary: "test summary",
       s3Key: {
         raw: "abc.csv",
         json: "abc.json",
@@ -491,6 +503,7 @@ describe("toItem", () => {
       content: {
         title: "Correlation of COVID cases to deaths",
         datasetId: "090b0410",
+        summary: "test summary",
         s3Key: {
           raw: "abc.csv",
           json: "abc.json",
@@ -510,6 +523,7 @@ describe("toItem", () => {
     expect(item.content).toEqual({
       title: "Correlation of COVID cases to deaths",
       datasetId: "090b0410",
+      summary: "test summary",
       s3Key: {
         raw: "abc.csv",
         json: "abc.json",

--- a/backend/src/lib/factories/widget-factory.ts
+++ b/backend/src/lib/factories/widget-factory.ts
@@ -148,6 +148,7 @@ function createChartWidget(
       title: content.title,
       chartType: content.chartType,
       datasetId: content.datasetId,
+      summary: content.summary,
       s3Key: content.s3Key,
     },
   };
@@ -181,6 +182,7 @@ function createTableWidget(
     content: {
       title: content.title,
       datasetId: content.datasetId,
+      summary: content.summary,
       s3Key: content.s3Key,
     },
   };

--- a/backend/src/lib/models/widget.ts
+++ b/backend/src/lib/models/widget.ts
@@ -43,6 +43,7 @@ export interface ChartWidget extends Widget {
     title: string;
     chartType: ChartType;
     datasetId: string;
+    summary?: string;
     s3Key: {
       raw: string;
       json: string;
@@ -54,6 +55,7 @@ export interface TableWidget extends Widget {
   content: {
     title: string;
     datasetId: string;
+    summary?: string;
     s3Key: {
       raw: string;
       json: string;

--- a/frontend/src/components/BarChartPreview.tsx
+++ b/frontend/src/components/BarChartPreview.tsx
@@ -13,6 +13,7 @@ import { useColors } from "../hooks";
 
 type Props = {
   title: string;
+  summary: string;
   bars: Array<string>;
   data?: Array<object>;
 };
@@ -21,7 +22,10 @@ const BarChartPreview = (props: Props) => {
   const colors = useColors(props.bars.length);
   return (
     <div>
-      <h2 className="margin-left-2px">{props.title}</h2>
+      <h2 className="margin-left-1 margin-bottom-1">{props.title}</h2>
+      <p className="margin-left-1 margin-top-0 margin-bottom-3">
+        {props.summary}
+      </p>
       <ResponsiveContainer width="100%" height={300}>
         <BarChart
           data={props.data}

--- a/frontend/src/components/ChartWidget.tsx
+++ b/frontend/src/components/ChartWidget.tsx
@@ -22,20 +22,42 @@ function ChartWidgetComponent(props: Props) {
   switch (content.chartType) {
     case ChartType.LineChart:
       return (
-        <LineChartPreview title={content.title} lines={keys} data={json} />
+        <LineChartPreview
+          title={content.title}
+          summary={content.summary}
+          lines={keys}
+          data={json}
+        />
       );
 
     case ChartType.ColumnChart:
       return (
-        <ColumnChartPreview title={content.title} columns={keys} data={json} />
+        <ColumnChartPreview
+          title={content.title}
+          summary={content.summary}
+          columns={keys}
+          data={json}
+        />
       );
 
     case ChartType.BarChart:
-      return <BarChartPreview title={content.title} bars={keys} data={json} />;
+      return (
+        <BarChartPreview
+          title={content.title}
+          summary={content.summary}
+          bars={keys}
+          data={json}
+        />
+      );
 
     case ChartType.PartWholeChart:
       return (
-        <PartWholeChartPreview title={content.title} parts={keys} data={json} />
+        <PartWholeChartPreview
+          title={content.title}
+          summary={content.summary}
+          parts={keys}
+          data={json}
+        />
       );
 
     default:

--- a/frontend/src/components/ColumnChartPreview.tsx
+++ b/frontend/src/components/ColumnChartPreview.tsx
@@ -12,6 +12,7 @@ import { useColors } from "../hooks";
 
 type Props = {
   title: string;
+  summary: string;
   columns: Array<string>;
   data?: Array<object>;
 };
@@ -20,7 +21,10 @@ const ColumnChartPreview = (props: Props) => {
   const colors = useColors(props.columns.length);
   return (
     <div>
-      <h2 className="margin-left-2px">{props.title}</h2>
+      <h2 className="margin-left-1 margin-bottom-1">{props.title}</h2>
+      <p className="margin-left-1 margin-top-0 margin-bottom-3">
+        {props.summary}
+      </p>
       <ResponsiveContainer width="100%" height={300}>
         <BarChart data={props.data} margin={{ right: 0, left: 0 }}>
           <CartesianGrid vertical={false} />

--- a/frontend/src/components/LineChartPreview.tsx
+++ b/frontend/src/components/LineChartPreview.tsx
@@ -12,6 +12,7 @@ import { useColors } from "../hooks";
 
 type Props = {
   title: string;
+  summary: string;
   lines: Array<string>;
   data?: Array<object>;
 };
@@ -20,7 +21,10 @@ const LineChartPreview = (props: Props) => {
   const colors = useColors(props.lines.length);
   return (
     <div>
-      <h2 className="margin-left-2px">{props.title}</h2>
+      <h2 className="margin-left-1 margin-bottom-1">{props.title}</h2>
+      <p className="margin-left-1 margin-top-0 margin-bottom-3">
+        {props.summary}
+      </p>
       <ResponsiveContainer width="100%" height={300}>
         <LineChart data={props.data} margin={{ right: 0, left: 0 }}>
           <CartesianGrid vertical={false} />

--- a/frontend/src/components/PartWholeChartPreview.tsx
+++ b/frontend/src/components/PartWholeChartPreview.tsx
@@ -12,6 +12,7 @@ import { useColors } from "../hooks";
 
 type Props = {
   title: string;
+  summary: string;
   parts: Array<string>;
   data?: Array<object>;
 };
@@ -53,7 +54,10 @@ const PartWholeChartPreview = (props: Props) => {
 
   return (
     <div>
-      <h2 className="margin-left-2px">{props.title}</h2>
+      <h2 className="margin-left-1 margin-bottom-1">{props.title}</h2>
+      <p className="margin-left-1 margin-top-0 margin-bottom-3">
+        {props.summary}
+      </p>
       <ResponsiveContainer width="100%" height={300}>
         <BarChart
           data={partWholeData}

--- a/frontend/src/components/TablePreview.tsx
+++ b/frontend/src/components/TablePreview.tsx
@@ -4,6 +4,7 @@ import { faCaretUp, faCaretDown } from "@fortawesome/free-solid-svg-icons";
 
 type Props = {
   title: string;
+  summary: string;
   headers: Array<string>;
   data?: Array<object>;
 };
@@ -13,7 +14,10 @@ const getKeyValue = (key: string) => (obj: Record<string, any>) => obj[key];
 const TablePreview = (props: Props) => {
   return (
     <div>
-      <h2 className="margin-left-2px">{props.title}</h2>
+      <h2 className="margin-left-1 margin-bottom-1">{props.title}</h2>
+      <p className="margin-left-1 margin-top-0 margin-bottom-3">
+        {props.summary}
+      </p>
       <table className="usa-table usa-table--borderless margin-left-2px">
         <thead>
           <tr>

--- a/frontend/src/components/TableWidget.tsx
+++ b/frontend/src/components/TableWidget.tsx
@@ -16,7 +16,14 @@ function TableWidgetComponent(props: Props) {
   }
 
   const keys = Object.keys(json[0] as Array<string>);
-  return <TablePreview title={content.title} headers={keys} data={json} />;
+  return (
+    <TablePreview
+      title={content.title}
+      summary={content.summary}
+      headers={keys}
+      data={json}
+    />
+  );
 }
 
 export default TableWidgetComponent;

--- a/frontend/src/components/TextWidget.tsx
+++ b/frontend/src/components/TextWidget.tsx
@@ -10,7 +10,7 @@ function TextWidget(props: Props) {
   const { content } = props.widget;
 
   return (
-    <div>
+    <div className="margin-left-1">
       <h2>{props.widget.name}</h2>
       <ReactMarkdown source={content.text} />
     </div>

--- a/frontend/src/components/__tests__/BarChartPreview.test.tsx
+++ b/frontend/src/components/__tests__/BarChartPreview.test.tsx
@@ -3,10 +3,15 @@ import { render } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import BarChartPreview from "../BarChartPreview";
 
-test("renders the title of the bar chart preview component", async () => {
+test("renders the title and summary of the bar chart preview component", async () => {
   const { getByText } = render(
-    <BarChartPreview title="test title" bars={["test"]} />,
+    <BarChartPreview
+      title="test title"
+      summary="test summary"
+      bars={["test"]}
+    />,
     { wrapper: MemoryRouter }
   );
   expect(getByText("test title")).toBeInTheDocument();
+  expect(getByText("test summary")).toBeInTheDocument();
 });

--- a/frontend/src/components/__tests__/ChartWidget.test.tsx
+++ b/frontend/src/components/__tests__/ChartWidget.test.tsx
@@ -16,6 +16,7 @@ const chart: ChartWidget = {
     chartType: ChartType.LineChart,
     title: "Bananas chart",
     datasetId: "0000",
+    summary: "test summary",
     s3Key: {
       json: "123.json",
       raw: "123.csv",

--- a/frontend/src/components/__tests__/ColumnChartPreview.test.tsx
+++ b/frontend/src/components/__tests__/ColumnChartPreview.test.tsx
@@ -3,10 +3,15 @@ import { render } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import ColumnChartPreview from "../ColumnChartPreview";
 
-test("renders the title of the column chart preview component", async () => {
+test("renders the title and summary of the column chart preview component", async () => {
   const { getByText } = render(
-    <ColumnChartPreview title="test title" columns={["test"]} />,
+    <ColumnChartPreview
+      title="test title"
+      summary="test summary"
+      columns={["test"]}
+    />,
     { wrapper: MemoryRouter }
   );
   expect(getByText("test title")).toBeInTheDocument();
+  expect(getByText("test summary")).toBeInTheDocument();
 });

--- a/frontend/src/components/__tests__/LineChartPreview.test.tsx
+++ b/frontend/src/components/__tests__/LineChartPreview.test.tsx
@@ -3,10 +3,15 @@ import { render } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import LineChartPreview from "../LineChartPreview";
 
-test("renders the title of the line chart preview component", async () => {
+test("renders the title and summary of the line chart preview component", async () => {
   const { getByText } = render(
-    <LineChartPreview title="test title" lines={["test"]} />,
+    <LineChartPreview
+      title="test title"
+      summary="test summary"
+      lines={["test"]}
+    />,
     { wrapper: MemoryRouter }
   );
   expect(getByText("test title")).toBeInTheDocument();
+  expect(getByText("test summary")).toBeInTheDocument();
 });

--- a/frontend/src/components/__tests__/PartWholeChartPreview.test.tsx
+++ b/frontend/src/components/__tests__/PartWholeChartPreview.test.tsx
@@ -3,10 +3,15 @@ import { render } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import PartWholeChartPreview from "../PartWholeChartPreview";
 
-test("renders the title of the bar chart preview component", async () => {
+test("renders the title and summary of the bar chart preview component", async () => {
   const { getByText } = render(
-    <PartWholeChartPreview title="test title" parts={["test"]} />,
+    <PartWholeChartPreview
+      title="test title"
+      summary="test summary"
+      parts={["test"]}
+    />,
     { wrapper: MemoryRouter }
   );
   expect(getByText("test title")).toBeInTheDocument();
+  expect(getByText("test summary")).toBeInTheDocument();
 });

--- a/frontend/src/components/__tests__/TablePreview.test.tsx
+++ b/frontend/src/components/__tests__/TablePreview.test.tsx
@@ -8,17 +8,26 @@ import { faCaretUp, faCaretDown } from "@fortawesome/free-solid-svg-icons";
 
 library.add(faCaretUp, faCaretDown);
 
-test("renders the title of the table preview component", async () => {
+test("renders the title and summary of the table preview component", async () => {
   const { getByText } = render(
-    <TablePreview title="test title" headers={["test"]} />,
+    <TablePreview
+      title="test title"
+      summary="test summary"
+      headers={["test"]}
+    />,
     { wrapper: MemoryRouter }
   );
   expect(getByText("test title")).toBeInTheDocument();
+  expect(getByText("test summary")).toBeInTheDocument();
 });
 
 test("table preview should match snapshot", async () => {
   const wrapper = render(
-    <TablePreview title="test title" headers={["test"]} />,
+    <TablePreview
+      title="test title"
+      summary="test summary"
+      headers={["test"]}
+    />,
     { wrapper: MemoryRouter }
   );
   expect(wrapper.container).toMatchSnapshot();

--- a/frontend/src/components/__tests__/__snapshots__/TablePreview.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/TablePreview.test.tsx.snap
@@ -4,10 +4,15 @@ exports[`table preview should match snapshot 1`] = `
 <div>
   <div>
     <h2
-      class="margin-left-2px"
+      class="margin-left-1 margin-bottom-1"
     >
       test title
     </h2>
+    <p
+      class="margin-left-1 margin-top-0 margin-bottom-3"
+    >
+      test summary
+    </p>
     <table
       class="usa-table usa-table--borderless margin-left-2px"
     >

--- a/frontend/src/components/__tests__/__snapshots__/TextWidget.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/TextWidget.test.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`renders markdown text 1`] = `
 <div>
-  <div>
+  <div
+    class="margin-left-1"
+  >
     <h2>
       Benefits of Bananas
     </h2>

--- a/frontend/src/containers/AddChart.tsx
+++ b/frontend/src/containers/AddChart.tsx
@@ -18,6 +18,7 @@ import PartWholeChartPreview from "../components/PartWholeChartPreview";
 
 interface FormValues {
   title: string;
+  summary: string;
   chartType: string;
 }
 
@@ -35,6 +36,7 @@ function AddChart() {
   );
   const [csvFile, setCsvFile] = useState<File | undefined>(undefined);
   const [title, setTitle] = useState("");
+  const [summary, setSummary] = useState("");
   const [chartType, setChartType] = useState<ChartType>(ChartType.LineChart);
   const [loading, setLoading] = useState(false);
 
@@ -67,6 +69,7 @@ function AddChart() {
         WidgetType.Chart,
         {
           title: values.title,
+          summary: values.summary,
           chartType: values.chartType,
           datasetId: newDataset.id,
           s3Key: newDataset.s3Key,
@@ -89,6 +92,10 @@ function AddChart() {
 
   const handleTitleChange = (event: React.FormEvent<HTMLInputElement>) => {
     setTitle((event.target as HTMLInputElement).value);
+  };
+
+  const handleSummaryChange = (event: React.FormEvent<HTMLTextAreaElement>) => {
+    setSummary((event.target as HTMLTextAreaElement).value);
   };
 
   const handleChartTypeChange = (
@@ -189,6 +196,19 @@ function AddChart() {
                     },
                   ]}
                 />
+
+                <TextField
+                  id="summary"
+                  name="summary"
+                  label="Chart summary"
+                  hint="Give your chart a summary to explain it in more depth.
+                  It can also be read by screen readers to describe the chart
+                  for those with visual impairments. What is useful in a chart description?"
+                  register={register}
+                  onChange={handleSummaryChange}
+                  multiline
+                  rows={5}
+                />
               </div>
             </fieldset>
             <br />
@@ -211,6 +231,7 @@ function AddChart() {
             {chartType === ChartType.LineChart && (
               <LineChartPreview
                 title={title}
+                summary={summary}
                 lines={
                   dataset && dataset.length
                     ? (Object.keys(dataset[0]) as Array<string>)
@@ -222,6 +243,7 @@ function AddChart() {
             {chartType === ChartType.ColumnChart && (
               <ColumnChartPreview
                 title={title}
+                summary={summary}
                 columns={
                   dataset && dataset.length
                     ? (Object.keys(dataset[0]) as Array<string>)
@@ -233,6 +255,7 @@ function AddChart() {
             {chartType === ChartType.BarChart && (
               <BarChartPreview
                 title={title}
+                summary={summary}
                 bars={
                   dataset && dataset.length
                     ? (Object.keys(dataset[0]) as Array<string>)
@@ -244,6 +267,7 @@ function AddChart() {
             {chartType === ChartType.PartWholeChart && (
               <PartWholeChartPreview
                 title={title}
+                summary={summary}
                 parts={
                   dataset && dataset.length
                     ? (Object.keys(dataset[0]) as Array<string>)

--- a/frontend/src/containers/AddTable.tsx
+++ b/frontend/src/containers/AddTable.tsx
@@ -14,6 +14,7 @@ import TablePreview from "../components/TablePreview";
 
 interface FormValues {
   title: string;
+  summary: string;
 }
 
 interface PathParams {
@@ -30,6 +31,7 @@ function AddTable() {
   );
   const [csvFile, setCsvFile] = useState<File | undefined>(undefined);
   const [title, setTitle] = useState("");
+  const [summary, setSummary] = useState("");
   const [loading, setLoading] = useState(false);
 
   const uploadDataset = async (): Promise<Dataset> => {
@@ -61,6 +63,7 @@ function AddTable() {
         WidgetType.Table,
         {
           title: values.title,
+          summary: values.summary,
           datasetId: newDataset.id,
           s3Key: newDataset.s3Key,
         }
@@ -80,8 +83,12 @@ function AddTable() {
     history.push(`/admin/dashboard/edit/${dashboardId}`);
   };
 
-  const handleChange = (event: React.FormEvent<HTMLInputElement>) => {
+  const handleChangeTitle = (event: React.FormEvent<HTMLInputElement>) => {
     setTitle((event.target as HTMLInputElement).value);
+  };
+
+  const handleSummaryChange = (event: React.FormEvent<HTMLTextAreaElement>) => {
+    setSummary((event.target as HTMLTextAreaElement).value);
   };
 
   const onFileProcessed = (data: File) => {
@@ -127,7 +134,7 @@ function AddTable() {
                 label="Table title"
                 hint="Give your table a descriptive title."
                 error={errors.title && "Please specify a table title"}
-                onChange={handleChange}
+                onChange={handleChangeTitle}
                 required
                 register={register}
               />
@@ -161,6 +168,19 @@ function AddTable() {
                 ) : (
                   ""
                 )}
+
+                <TextField
+                  id="summary"
+                  name="summary"
+                  label="Table summary"
+                  hint="Give your table a summary to explain it in more depth.
+                  It can also be read by screen readers to describe the table
+                  for those with visual impairments. What is useful in a table description?"
+                  register={register}
+                  onChange={handleSummaryChange}
+                  multiline
+                  rows={5}
+                />
               </div>
             </fieldset>
             <br />
@@ -181,6 +201,7 @@ function AddTable() {
             <h4>Preview</h4>
             <TablePreview
               title={title}
+              summary={summary}
               headers={
                 dataset && dataset.length
                   ? (Object.keys(dataset[0]) as Array<string>)

--- a/frontend/src/containers/EditChart.tsx
+++ b/frontend/src/containers/EditChart.tsx
@@ -19,6 +19,7 @@ import { useWidget } from "../hooks";
 
 interface FormValues {
   title: string;
+  summary: string;
   chartType: string;
 }
 
@@ -108,6 +109,7 @@ function EditChart() {
         values.title,
         {
           title: values.title,
+          summary: values.summary,
           chartType: values.chartType,
           datasetId,
           s3Key,
@@ -129,7 +131,22 @@ function EditChart() {
     if (widget) {
       setWidget({
         ...widget,
-        name: (event.target as HTMLInputElement).value,
+        content: {
+          ...widget.content,
+          title: (event.target as HTMLInputElement).value,
+        },
+      });
+    }
+  };
+
+  const handleSummaryChange = (event: React.FormEvent<HTMLTextAreaElement>) => {
+    if (widget) {
+      setWidget({
+        ...widget,
+        content: {
+          ...widget.content,
+          summary: (event.target as HTMLTextAreaElement).value,
+        },
       });
     }
   };
@@ -171,7 +188,7 @@ function EditChart() {
                 hint="Give your chart a descriptive title."
                 error={errors.title && "Please specify a chart title"}
                 onChange={handleTitleChange}
-                defaultValue={widget.name}
+                defaultValue={widget.content.title}
                 required
                 register={register}
               />
@@ -218,6 +235,20 @@ function EditChart() {
                       },
                     ]}
                   />
+
+                  <TextField
+                    id="summary"
+                    name="summary"
+                    label="Chart summary"
+                    hint="Give your chart a summary to explain it in more depth.
+                    It can also be read by screen readers to describe the chart
+                    for those with visual impairments. What is useful in a chart description?"
+                    register={register}
+                    defaultValue={widget.content.summary}
+                    onChange={handleSummaryChange}
+                    multiline
+                    rows={5}
+                  />
                 </div>
               ) : (
                 ""
@@ -239,7 +270,8 @@ function EditChart() {
             <h4>Preview</h4>
             {widget.content.chartType === ChartType.LineChart && (
               <LineChartPreview
-                title={widget.name}
+                title={widget.content.title}
+                summary={widget.content.summary}
                 lines={
                   json.length > 0 ? (Object.keys(json[0]) as Array<string>) : []
                 }
@@ -249,6 +281,7 @@ function EditChart() {
             {widget.content.chartType === ChartType.ColumnChart && (
               <ColumnChartPreview
                 title={widget.name}
+                summary={widget.content.summary}
                 columns={
                   json.length > 0 ? (Object.keys(json[0]) as Array<string>) : []
                 }
@@ -258,6 +291,7 @@ function EditChart() {
             {widget.content.chartType === ChartType.BarChart && (
               <BarChartPreview
                 title={widget.name}
+                summary={widget.content.summary}
                 bars={
                   json.length > 0 ? (Object.keys(json[0]) as Array<string>) : []
                 }
@@ -267,6 +301,7 @@ function EditChart() {
             {widget.content.chartType === ChartType.PartWholeChart && (
               <PartWholeChartPreview
                 title={widget.name}
+                summary={widget.content.summary}
                 parts={
                   json.length > 0 ? (Object.keys(json[0]) as Array<string>) : []
                 }

--- a/frontend/src/containers/EditTable.tsx
+++ b/frontend/src/containers/EditTable.tsx
@@ -15,6 +15,7 @@ import { useWidget } from "../hooks";
 
 interface FormValues {
   title: string;
+  summary: string;
 }
 
 interface PathParams {
@@ -103,6 +104,7 @@ function EditTable() {
         values.title,
         {
           title: values.title,
+          summary: values.summary,
           datasetId,
           s3Key,
         },
@@ -122,7 +124,22 @@ function EditTable() {
     if (widget) {
       setWidget({
         ...widget,
-        name: (event.target as HTMLInputElement).value,
+        content: {
+          ...widget.content,
+          title: (event.target as HTMLInputElement).value,
+        },
+      });
+    }
+  };
+
+  const handleSummaryChange = (event: React.FormEvent<HTMLTextAreaElement>) => {
+    if (widget) {
+      setWidget({
+        ...widget,
+        content: {
+          ...widget.content,
+          summary: (event.target as HTMLTextAreaElement).value,
+        },
       });
     }
   };
@@ -149,7 +166,7 @@ function EditTable() {
                 hint="Give your table a descriptive title."
                 error={errors.title && "Please specify a table title"}
                 onChange={handleTitleChange}
-                defaultValue={widget.name}
+                defaultValue={widget.content.title}
                 required
                 register={register}
               />
@@ -181,6 +198,20 @@ function EditTable() {
                 ) : (
                   ""
                 )}
+
+                <TextField
+                  id="summary"
+                  name="summary"
+                  label="Table summary"
+                  hint="Give your table a summary to explain it in more depth.
+                  It can also be read by screen readers to describe the table
+                  for those with visual impairments. What is useful in a table description?"
+                  register={register}
+                  defaultValue={widget.content.summary}
+                  onChange={handleSummaryChange}
+                  multiline
+                  rows={5}
+                />
               </div>
             </fieldset>
             <br />
@@ -197,7 +228,8 @@ function EditTable() {
           <div hidden={!json} className="margin-left-4">
             <h4>Preview</h4>
             <TablePreview
-              title={widget.name}
+              title={widget.content.title}
+              summary={widget.content.summary}
               headers={
                 json.length > 0 ? (Object.keys(json[0]) as Array<string>) : []
               }

--- a/frontend/src/models/index.tsx
+++ b/frontend/src/models/index.tsx
@@ -70,6 +70,7 @@ export interface ChartWidget extends Widget {
     title: string;
     chartType: ChartType;
     datasetId: string;
+    summary: string;
     s3Key: {
       raw: string;
       json: string;
@@ -81,6 +82,7 @@ export interface TableWidget extends Widget {
   content: {
     title: string;
     datasetId: string;
+    summary: string;
     s3Key: {
       raw: string;
       json: string;


### PR DESCRIPTION
## Description

Add optional summary field for chart/table

## Testing

Added unit tests. You can test it here: https://migdizn.badger.wwps.aws.dev/admin/dashboard/edit/aa73e0c9-70bf-4981-b0bb-e8a2222bfa3d

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
