### PR TITLE
Prevent Cognito from showing user doesn't exist error; and add another app-client to be used with Badger CLI

### DIFF
--- a/cdk/lib/auth-stack.ts
+++ b/cdk/lib/auth-stack.ts
@@ -24,8 +24,15 @@ export class AuthStack extends cdk.Stack {
       },
     });
 
-    const client = pool.addClient("BadgerFrontend");
+    const client = pool.addClient("BadgerFrontend", {
+      preventUserExistenceErrors: true,
+    });
     const identityPool = this.buildIdentityPool(pool, client);
+
+    const cliClient = pool.addClient("BadgerCLI", {
+      authFlows: { userPassword: true },
+      preventUserExistenceErrors: true,
+    });
 
     const stack = cdk.Stack.of(this);
     const bucketArn = `arn:${stack.partition}:s3:::${props.datasetsBucketName}`;


### PR DESCRIPTION
## Description

Enable preventUserExistenceErrors when creating app-client for Badger userpool.  Create another app-client that supports UsernamePassword (non SRP) to be used with Badger CLI tools (such as to create topic areas)

## Testing

Verified failed login attempt with a bad username doesn't result in a "user doesn't exist" error

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
