### PR TITLE
Refactored layouts to be high-order components

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,9 @@ import React from "react";
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 import { withAuthenticator } from "@aws-amplify/ui-react";
 
+import withMainLayout from "./layouts/Main";
+import withAdminLayout from "./layouts/Admin";
+
 import Home from "./containers/Home";
 import DashboardListing from "./containers/DashboardListing";
 import CreateDashboard from "./containers/CreateDashboard";
@@ -111,8 +114,8 @@ function App() {
       <Switch>
         {routes.map((route) => {
           const component = route.public
-            ? route.component
-            : withAuthenticator(route.component);
+            ? withMainLayout(route.component)
+            : withAuthenticator(withAdminLayout(route.component));
           return (
             <Route
               exact

--- a/frontend/src/containers/AddChart.tsx
+++ b/frontend/src/containers/AddChart.tsx
@@ -5,7 +5,6 @@ import { parse, ParseResult } from "papaparse";
 import { Dataset, ChartType, WidgetType } from "../models";
 import StorageService from "../services/StorageService";
 import BadgerService from "../services/BadgerService";
-import AdminLayout from "../layouts/Admin";
 import Breadcrumbs from "../components/Breadcrumbs";
 import TextField from "../components/TextField";
 import FileInput from "../components/FileInput";
@@ -127,7 +126,7 @@ function AddChart() {
   };
 
   return (
-    <AdminLayout>
+    <>
       <Breadcrumbs />
       <h1>Add content</h1>
       <div className="text-base text-italic">Step 2 of 2</div>
@@ -279,7 +278,7 @@ function AddChart() {
           </div>
         </div>
       </div>
-    </AdminLayout>
+    </>
   );
 }
 

--- a/frontend/src/containers/AddContent.tsx
+++ b/frontend/src/containers/AddContent.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { useHistory, useParams } from "react-router-dom";
 import { useForm } from "react-hook-form";
-import AdminLayout from "../layouts/Admin";
 import Breadcrumbs from "../components/Breadcrumbs";
 import Button from "../components/Button";
 
@@ -9,9 +8,13 @@ interface FormValues {
   widgetType: string;
 }
 
+interface PathParams {
+  dashboardId: string;
+}
+
 function AddContent() {
   const history = useHistory();
-  const { dashboardId } = useParams();
+  const { dashboardId } = useParams<PathParams>();
   const { register, handleSubmit } = useForm<FormValues>();
   const [widgetType, setWidgetType] = useState("");
 
@@ -34,7 +37,7 @@ function AddContent() {
   };
 
   return (
-    <AdminLayout>
+    <>
       <Breadcrumbs />
       <h1>Add content</h1>
       <div className="text-base text-italic">Step 1 of 2</div>
@@ -173,7 +176,7 @@ function AddContent() {
           </Button>
         </form>
       </div>
-    </AdminLayout>
+    </>
   );
 }
 

--- a/frontend/src/containers/AddTable.tsx
+++ b/frontend/src/containers/AddTable.tsx
@@ -4,7 +4,6 @@ import { useHistory, useParams } from "react-router-dom";
 import { Dataset, WidgetType } from "../models";
 import BadgerService from "../services/BadgerService";
 import StorageService from "../services/StorageService";
-import AdminLayout from "../layouts/Admin";
 import Breadcrumbs from "../components/Breadcrumbs";
 import TextField from "../components/TextField";
 import FileInput from "../components/FileInput";
@@ -114,7 +113,7 @@ function AddTable() {
   };
 
   return (
-    <AdminLayout>
+    <>
       <Breadcrumbs />
       <h1>Add content</h1>
       <div className="text-base text-italic">Step 2 of 2</div>
@@ -212,7 +211,7 @@ function AddTable() {
           </div>
         </div>
       </div>
-    </AdminLayout>
+    </>
   );
 }
 

--- a/frontend/src/containers/AddText.tsx
+++ b/frontend/src/containers/AddText.tsx
@@ -3,7 +3,6 @@ import { useForm } from "react-hook-form";
 import { useHistory, useParams } from "react-router-dom";
 import { WidgetType } from "../models";
 import BadgerService from "../services/BadgerService";
-import AdminLayout from "../layouts/Admin";
 import Breadcrumbs from "../components/Breadcrumbs";
 import TextField from "../components/TextField";
 import Button from "../components/Button";
@@ -60,7 +59,7 @@ function AddText() {
   };
 
   return (
-    <AdminLayout>
+    <>
       <Breadcrumbs />
       <h1>Add content</h1>
       <div className="text-base text-italic">Step 2 of 2</div>
@@ -123,7 +122,7 @@ function AddText() {
           )}
         </div>
       </div>
-    </AdminLayout>
+    </>
   );
 }
 

--- a/frontend/src/containers/AdminHome.tsx
+++ b/frontend/src/containers/AdminHome.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
 import { useHistory } from "react-router-dom";
-import AdminLayout from "../layouts/Admin";
 import Button from "../components/Button";
 import CardGroup from "../components/CardGroup";
 
@@ -24,7 +23,7 @@ function AdminHome() {
   };
 
   return (
-    <AdminLayout>
+    <>
       <div className="grid-row">
         <div className="grid-col-12 tablet:grid-col-8">
           <h1 className="font-sans-3xl">
@@ -82,7 +81,7 @@ function AdminHome() {
           </Button>
         </div>
       </div>
-    </AdminLayout>
+    </>
   );
 }
 

--- a/frontend/src/containers/ArchivedDashboard.tsx
+++ b/frontend/src/containers/ArchivedDashboard.tsx
@@ -6,7 +6,6 @@ import { faArrowLeft } from "@fortawesome/free-solid-svg-icons";
 import { useDashboard } from "../hooks";
 import { LocationState } from "../models";
 import BadgerService from "../services/BadgerService";
-import AdminLayout from "../layouts/Admin";
 import WidgetRender from "../components/WidgetRender";
 import Button from "../components/Button";
 import { faCopy } from "@fortawesome/free-solid-svg-icons";
@@ -40,7 +39,7 @@ function ArchivedDashboard() {
   };
 
   return (
-    <AdminLayout>
+    <>
       <div className="position-sticky top-0 bg-white z-index-on-top">
         <Link to="/admin/dashboards?tab=archived">
           <FontAwesomeIcon icon={faArrowLeft} /> Back to dashboards
@@ -96,7 +95,7 @@ function ArchivedDashboard() {
           </div>
         );
       })}
-    </AdminLayout>
+    </>
   );
 }
 

--- a/frontend/src/containers/CreateDashboard.tsx
+++ b/frontend/src/containers/CreateDashboard.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { useHistory } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { useTopicAreas } from "../hooks";
-import AdminLayout from "../layouts/Admin";
 import BadgerService from "../services/BadgerService";
 import Markdown from "../components/Markdown";
 import TextField from "../components/TextField";
@@ -34,7 +33,7 @@ function CreateDashboard() {
   };
 
   return (
-    <AdminLayout>
+    <>
       <h1>Create new dashboard</h1>
       <div className="grid-row">
         <div className="grid-col-12">
@@ -85,7 +84,7 @@ function CreateDashboard() {
           </form>
         </div>
       </div>
-    </AdminLayout>
+    </>
   );
 }
 

--- a/frontend/src/containers/DashboardListing.tsx
+++ b/frontend/src/containers/DashboardListing.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useDashboards } from "../hooks";
 import { LocationState } from "../models";
-import AdminLayout from "../layouts/Admin";
 import Tabs from "../components/Tabs";
 import DraftsTab from "../components/DraftsTab";
 import PublishedTab from "../components/PublishedTab";
@@ -94,7 +93,7 @@ function DashboardListing() {
   }
 
   return (
-    <AdminLayout>
+    <>
       <h1>Dashboards</h1>
       <AlertContainer />
       <Tabs defaultActive={activeTab}>
@@ -117,7 +116,7 @@ function DashboardListing() {
           <ArchivedTab dashboards={archivedDashboards} />
         </div>
       </Tabs>
-    </AdminLayout>
+    </>
   );
 }
 

--- a/frontend/src/containers/DashboardPreview.tsx
+++ b/frontend/src/containers/DashboardPreview.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { useHistory, useParams } from "react-router-dom";
 import { useDashboard } from "../hooks";
 import { DashboardState, LocationState } from "../models";
-import AdminLayout from "../layouts/Admin";
 import ReactMarkdown from "react-markdown";
 import Button from "../components/Button";
 import BadgerService from "../services/BadgerService";
@@ -42,7 +41,7 @@ function DashboardPreview() {
   };
 
   return (
-    <AdminLayout>
+    <>
       <div className="position-sticky top-0 bg-white z-index-on-top">
         <Alert
           type="info"
@@ -91,7 +90,7 @@ function DashboardPreview() {
           </div>
         );
       })}
-    </AdminLayout>
+    </>
   );
 }
 

--- a/frontend/src/containers/EditChart.tsx
+++ b/frontend/src/containers/EditChart.tsx
@@ -5,7 +5,6 @@ import { parse, ParseResult } from "papaparse";
 import { Dataset, ChartType } from "../models";
 import StorageService from "../services/StorageService";
 import BadgerService from "../services/BadgerService";
-import AdminLayout from "../layouts/Admin";
 import Breadcrumbs from "../components/Breadcrumbs";
 import TextField from "../components/TextField";
 import FileInput from "../components/FileInput";
@@ -171,7 +170,7 @@ function EditChart() {
   }
 
   return (
-    <AdminLayout>
+    <>
       <Breadcrumbs />
       <h1>Edit content item</h1>
       <div className="grid-row width-desktop">
@@ -311,7 +310,7 @@ function EditChart() {
           </div>
         </div>
       </div>
-    </AdminLayout>
+    </>
   );
 }
 

--- a/frontend/src/containers/EditDashboard.tsx
+++ b/frontend/src/containers/EditDashboard.tsx
@@ -8,7 +8,6 @@ import { faCopy } from "@fortawesome/free-solid-svg-icons";
 import AlertContainer from "./AlertContainer";
 import BadgerService from "../services/BadgerService";
 import WidgetOrderingService from "../services/WidgetOrdering";
-import AdminLayout from "../layouts/Admin";
 import Breadcrumbs from "../components/Breadcrumbs";
 import WidgetList from "../components/WidgetList";
 import ReactMarkdown from "react-markdown";
@@ -112,7 +111,7 @@ function EditDashboard() {
   };
 
   return (
-    <AdminLayout>
+    <>
       <Breadcrumbs />
       <Modal
         isOpen={isOpen}
@@ -183,7 +182,7 @@ function EditDashboard() {
         onMoveUp={onMoveWidgetUp}
         onMoveDown={onMoveWidgetDown}
       />
-    </AdminLayout>
+    </>
   );
 }
 

--- a/frontend/src/containers/EditDetails.tsx
+++ b/frontend/src/containers/EditDetails.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { useHistory, useParams } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { useTopicAreas, useDashboard } from "../hooks";
-import AdminLayout from "../layouts/Admin";
 import BadgerService from "../services/BadgerService";
 import Markdown from "../components/Markdown";
 import TextField from "../components/TextField";
@@ -46,7 +45,7 @@ function EditDetails() {
   }
 
   return (
-    <AdminLayout>
+    <>
       <h1>Edit Details</h1>
       <div className="grid-row">
         <div className="grid-col-12">
@@ -102,7 +101,7 @@ function EditDetails() {
           </form>
         </div>
       </div>
-    </AdminLayout>
+    </>
   );
 }
 

--- a/frontend/src/containers/EditTable.tsx
+++ b/frontend/src/containers/EditTable.tsx
@@ -4,7 +4,6 @@ import { useHistory, useParams } from "react-router-dom";
 import { Dataset } from "../models";
 import BadgerService from "../services/BadgerService";
 import StorageService from "../services/StorageService";
-import AdminLayout from "../layouts/Admin";
 import Breadcrumbs from "../components/Breadcrumbs";
 import TextField from "../components/TextField";
 import FileInput from "../components/FileInput";
@@ -149,7 +148,7 @@ function EditTable() {
   }
 
   return (
-    <AdminLayout>
+    <>
       <Breadcrumbs />
       <h1>Edit content item</h1>
       <div className="grid-row width-desktop">
@@ -238,7 +237,7 @@ function EditTable() {
           </div>
         </div>
       </div>
-    </AdminLayout>
+    </>
   );
 }
 

--- a/frontend/src/containers/EditText.tsx
+++ b/frontend/src/containers/EditText.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useHistory, useParams } from "react-router-dom";
 import BadgerService from "../services/BadgerService";
-import AdminLayout from "../layouts/Admin";
 import Breadcrumbs from "../components/Breadcrumbs";
 import TextField from "../components/TextField";
 import Button from "../components/Button";
@@ -70,7 +69,7 @@ function EditText() {
   }
 
   return (
-    <AdminLayout>
+    <>
       <Breadcrumbs />
       <h1>Edit content item</h1>
       <div className="grid-row width-desktop">
@@ -128,7 +127,7 @@ function EditText() {
           )}
         </div>
       </div>
-    </AdminLayout>
+    </>
   );
 }
 

--- a/frontend/src/containers/FourZeroFour.tsx
+++ b/frontend/src/containers/FourZeroFour.tsx
@@ -1,10 +1,9 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import MainLayout from "../layouts/Main";
 
 function FourZeroFour() {
   return (
-    <MainLayout>
+    <>
       <div className="text-center">
         <p className="font-sans-3xl text-heavy margin-top-9 margin-bottom-1">
           404 / Page not found
@@ -20,7 +19,7 @@ function FourZeroFour() {
         Having technical issues with the platform?{" "}
         <Link to="/">Contact support</Link>.
       </div>
-    </MainLayout>
+    </>
   );
 }
 

--- a/frontend/src/containers/Home.tsx
+++ b/frontend/src/containers/Home.tsx
@@ -3,7 +3,7 @@ import dayjs from "dayjs";
 import { Link } from "react-router-dom";
 import { useHomepage } from "../hooks";
 import UtilsService from "../services/UtilsService";
-import MainLayout from "../layouts/Main";
+// import MainLayout from "../layouts/Main";
 import Accordion from "../components/Accordion";
 import Search from "../components/Search";
 
@@ -16,11 +16,11 @@ function Home() {
   };
 
   if (loading) {
-    return <MainLayout />;
+    return null;
   }
 
   return (
-    <MainLayout>
+    <>
       <div className="grid-row">
         <div className="grid-col-12 tablet:grid-col-8">
           <h1 className="font-sans-3xl">{homepage.title}</h1>
@@ -63,7 +63,7 @@ function Home() {
           </Accordion>
         </div>
       </div>
-    </MainLayout>
+    </>
   );
 }
 

--- a/frontend/src/containers/PublishDashboard.tsx
+++ b/frontend/src/containers/PublishDashboard.tsx
@@ -7,7 +7,6 @@ import { faArrowLeft } from "@fortawesome/free-solid-svg-icons";
 import { LocationState } from "../models";
 import BadgerService from "../services/BadgerService";
 import AlertContainer from "./AlertContainer";
-import AdminLayout from "../layouts/Admin";
 import StepIndicator from "../components/StepIndicator";
 import TextField from "../components/TextField";
 import Button from "../components/Button";
@@ -80,7 +79,7 @@ function PublishDashboard() {
   }
 
   return (
-    <AdminLayout>
+    <>
       <div>
         <Link to="/admin/dashboards?tab=pending">
           <FontAwesomeIcon icon={faArrowLeft} /> Back to dashboards
@@ -187,7 +186,7 @@ function PublishDashboard() {
           </span>
         </div>
       </form>
-    </AdminLayout>
+    </>
   );
 }
 

--- a/frontend/src/containers/ViewDashboard.tsx
+++ b/frontend/src/containers/ViewDashboard.tsx
@@ -4,7 +4,6 @@ import { Link, useParams } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowLeft } from "@fortawesome/free-solid-svg-icons";
 import { usePublicDashboard } from "../hooks";
-import MainLayout from "../layouts/Main";
 import WidgetRender from "../components/WidgetRender";
 import FourZeroFour from "./FourZeroFour";
 
@@ -21,7 +20,7 @@ function ViewDashboard() {
   }
 
   return dashboard.id ? (
-    <MainLayout>
+    <>
       <Link to="/">
         <FontAwesomeIcon icon={faArrowLeft} /> All Dashboards
       </Link>
@@ -49,7 +48,7 @@ function ViewDashboard() {
           </div>
         );
       })}
-    </MainLayout>
+    </>
   ) : (
     <FourZeroFour />
   );

--- a/frontend/src/containers/ViewDashboardAdmin.tsx
+++ b/frontend/src/containers/ViewDashboardAdmin.tsx
@@ -6,7 +6,6 @@ import { faArrowLeft, faCopy } from "@fortawesome/free-solid-svg-icons";
 import { useDashboard, useDashboardVersions } from "../hooks";
 import { DashboardState, LocationState } from "../models";
 import BadgerService from "../services/BadgerService";
-import AdminLayout from "../layouts/Admin";
 import WidgetRender from "../components/WidgetRender";
 import Button from "../components/Button";
 import Alert from "../components/Alert";
@@ -71,7 +70,7 @@ function ViewDashboardAdmin() {
   };
 
   return (
-    <AdminLayout>
+    <>
       <div className="position-sticky top-0 bg-white z-index-on-top">
         <Link to="/admin/dashboards?tab=published">
           <FontAwesomeIcon icon={faArrowLeft} /> Back to dashboards
@@ -147,7 +146,7 @@ function ViewDashboardAdmin() {
           </div>
         );
       })}
-    </AdminLayout>
+    </>
   );
 }
 

--- a/frontend/src/containers/__tests__/__snapshots__/FourZeroFour.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/FourZeroFour.test.tsx.snap
@@ -3,130 +3,43 @@
 exports[`renders a FourZeroFour component 1`] = `
 <div>
   <div
-    class="usa-overlay"
-  />
-  <header
-    class="usa-header usa-header--basic"
+    class="text-center"
   >
-    <div
-      class="usa-nav-container"
+    <p
+      class="font-sans-3xl text-heavy margin-top-9 margin-bottom-1"
     >
-      <div
-        class="usa-navbar navbar-long"
+      404 / Page not found
+    </p>
+    <hr
+      class="width-tablet border-base-light"
+    />
+    <p
+      class="font-sans-md"
+    >
+      You may want to double-check your link and try again, or return to the
+       
+      <a
+        href="/"
       >
-        <div
-          class="usa-logo"
-          id="basic-logo"
-        >
-          <em
-            class="usa-logo__text display-flex flex-align-center"
-          >
-            <img
-              alt="logo"
-              class="logo"
-              src="logo.svg"
-            />
-            <a
-              aria-label="Home"
-              href="/"
-              title="Home"
-            >
-              Performance Dashboard
-            </a>
-          </em>
-        </div>
-        <button
-          class="usa-menu-btn"
-        >
-          Menu
-        </button>
-      </div>
-      <nav
-        aria-label="Primary navigation"
-        class="usa-nav"
-      >
-        <button
-          class="usa-nav__close"
-        >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-window-close fa-w-16 fa-lg "
-            data-icon="window-close"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M464 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8 12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256 313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4 0l-40.5-40.5c-4.8-4.8-4.8-12.6 0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6 0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1 66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8 4.8 12.6 0 17.4L313.3 256l67.1 66.5z"
-              fill="currentColor"
-            />
-          </svg>
-        </button>
-        <ul
-          class="usa-nav__primary usa-accordion"
-        >
-          <li
-            class="usa-nav__primary-item"
-          >
-            <a
-              class="usa-nav__link"
-              href="mailto:support@example.com"
-            >
-              Contact
-            </a>
-          </li>
-        </ul>
-      </nav>
-    </div>
-  </header>
-  <main
-    class="padding-y-3"
+        homepage
+      </a>
+      .
+    </p>
+    <hr
+      class="margin-top-9 border-base-lightest"
+    />
+  </div>
+  <div
+    class="text-base font-sans-sm"
   >
-    <div
-      class="grid-container"
+    Having technical issues with the platform?
+     
+    <a
+      href="/"
     >
-      <div
-        class="text-center"
-      >
-        <p
-          class="font-sans-3xl text-heavy margin-top-9 margin-bottom-1"
-        >
-          404 / Page not found
-        </p>
-        <hr
-          class="width-tablet border-base-light"
-        />
-        <p
-          class="font-sans-md"
-        >
-          You may want to double-check your link and try again, or return to the
-           
-          <a
-            href="/"
-          >
-            homepage
-          </a>
-          .
-        </p>
-        <hr
-          class="margin-top-9 border-base-lightest"
-        />
-      </div>
-      <div
-        class="text-base font-sans-sm"
-      >
-        Having technical issues with the platform?
-         
-        <a
-          href="/"
-        >
-          Contact support
-        </a>
-        .
-      </div>
-    </div>
-  </main>
+      Contact support
+    </a>
+    .
+  </div>
 </div>
 `;

--- a/frontend/src/layouts/Admin.tsx
+++ b/frontend/src/layouts/Admin.tsx
@@ -73,4 +73,12 @@ function AdminLayout(props: LayoutProps) {
   );
 }
 
-export default AdminLayout;
+export const withAdminLayout = (
+  component: React.ComponentType
+): React.FunctionComponent<{}> => {
+  return function () {
+    return <AdminLayout>{React.createElement(component)}</AdminLayout>;
+  };
+};
+
+export default withAdminLayout;

--- a/frontend/src/layouts/Main.tsx
+++ b/frontend/src/layouts/Main.tsx
@@ -48,4 +48,12 @@ function MainLayout(props: LayoutProps) {
   );
 }
 
-export default MainLayout;
+export const withMainLayout = (
+  component: React.ComponentType
+): React.FunctionComponent<{}> => {
+  return function () {
+    return <MainLayout>{React.createElement(component)}</MainLayout>;
+  };
+};
+
+export default withMainLayout;


### PR DESCRIPTION
## Description

I realized every Container was making use of `<MainLayout>` and `<AdminLayout>` which created a tight coupling between the layout and the component itself. For example, updating the navigation bar would break the `<FourZeroFour>` component tests because the HTML of the layout had changed even though the component itself did not change.

To remove this coupling between the containers and the layouts, I extracted the layouts from all the containers and instead use them in the `App.js` file which is a higher level in the component hieararchy. This way, if the layout changes, the components are not affected. It's also a nice optimization when running the unit tests because it doesn't have to render the Layouts for every test. 

## Testing

Verified that all unit tests pass. Tested all routes render successfully in my localhost. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
