### PR TITLE
GTT-547 Bug fix for incorrect dashboard version being set

### DIFF
--- a/backend/src/lib/controllers/dashboard-ctrl.ts
+++ b/backend/src/lib/controllers/dashboard-ctrl.ts
@@ -348,7 +348,13 @@ async function createNewDraft(req: Request, res: Response) {
     return res.json(existingDraft);
   }
 
-  const draft = DashboardFactory.createDraftFromDashboard(dashboard, user);
+  const version = await repo.getNextVersionNumber(dashboard.parentDashboardId);
+  const draft = DashboardFactory.createDraftFromDashboard(
+    dashboard,
+    user,
+    version
+  );
+
   await repo.saveDashboardAndWidgets(draft);
   return res.json(draft);
 }

--- a/backend/src/lib/factories/__tests__/dashboard-factory.test.ts
+++ b/backend/src/lib/factories/__tests__/dashboard-factory.test.ts
@@ -189,6 +189,7 @@ describe("toVersion", () => {
 });
 
 describe("createDraftFromDashboard", () => {
+  const nextVersion = 2;
   const dashboard: Dashboard = {
     id: "123",
     version: 1,
@@ -204,27 +205,47 @@ describe("createDraftFromDashboard", () => {
   };
 
   it("should create a dashboard with same parentDashboardId", () => {
-    const draft = factory.createDraftFromDashboard(dashboard, user);
+    const draft = factory.createDraftFromDashboard(
+      dashboard,
+      user,
+      nextVersion
+    );
     expect(draft.parentDashboardId).toEqual(dashboard.parentDashboardId);
   });
 
   it("should create a dashboard on Draft state", () => {
-    const draft = factory.createDraftFromDashboard(dashboard, user);
+    const draft = factory.createDraftFromDashboard(
+      dashboard,
+      user,
+      nextVersion
+    );
     expect(draft.state).toEqual(DashboardState.Draft);
   });
 
   it("should create a dashboard with a new id", () => {
-    const draft = factory.createDraftFromDashboard(dashboard, user);
+    const draft = factory.createDraftFromDashboard(
+      dashboard,
+      user,
+      nextVersion
+    );
     expect(draft.id).not.toEqual(dashboard.id);
   });
 
-  it("should increment the version number", () => {
-    const draft = factory.createDraftFromDashboard(dashboard, user);
-    expect(draft.version).toEqual(dashboard.version + 1);
+  it("should set the version number", () => {
+    const draft = factory.createDraftFromDashboard(
+      dashboard,
+      user,
+      nextVersion
+    );
+    expect(draft.version).toEqual(nextVersion);
   });
 
   it("should create a dashboard with all other attributes", () => {
-    const draft = factory.createDraftFromDashboard(dashboard, user);
+    const draft = factory.createDraftFromDashboard(
+      dashboard,
+      user,
+      nextVersion
+    );
     expect(draft).toEqual(
       expect.objectContaining({
         name: "Dashboard 1",

--- a/backend/src/lib/factories/dashboard-factory.ts
+++ b/backend/src/lib/factories/dashboard-factory.ts
@@ -35,7 +35,11 @@ function createNew(
   };
 }
 
-function createDraftFromDashboard(dashboard: Dashboard, user: User): Dashboard {
+function createDraftFromDashboard(
+  dashboard: Dashboard,
+  user: User,
+  version: number
+): Dashboard {
   const id = uuidv4();
 
   let widgets: Array<Widget> = [];
@@ -49,7 +53,7 @@ function createDraftFromDashboard(dashboard: Dashboard, user: User): Dashboard {
   return {
     id,
     name: dashboard.name,
-    version: dashboard.version + 1,
+    version: version,
     parentDashboardId: dashboard.parentDashboardId,
     topicAreaId: dashboard.topicAreaId,
     topicAreaName: dashboard.topicAreaName,

--- a/backend/src/lib/repositories/__tests__/dashboard-repo.test.ts
+++ b/backend/src/lib/repositories/__tests__/dashboard-repo.test.ts
@@ -738,3 +738,107 @@ describe("DashboardRepository.deleteDashboardsAndWidgets", () => {
     );
   });
 });
+
+describe("getNextVersionNumber", () => {
+  let getDashboardVersions: jest.SpyInstance;
+  beforeEach(() => {
+    getDashboardVersions = jest.spyOn(repo, "getDashboardVersions");
+  });
+
+  afterEach(() => {
+    getDashboardVersions.mockRestore();
+  });
+
+  it("returns 1 when no dashboards are found", async () => {
+    getDashboardVersions.mockImplementation(() => Promise.resolve([]));
+    const nextVersion = await repo.getNextVersionNumber("123");
+    expect(nextVersion).toEqual(1);
+  });
+
+  it("returns the maximum version plus one", async () => {
+    const dashboards: Array<Dashboard> = [
+      {
+        id: "xyz",
+        version: 1,
+        name: "Dashboard v1",
+        topicAreaId: "456",
+        topicAreaName: "Topic1",
+        description: "Description Test",
+        state: DashboardState.Draft,
+        parentDashboardId: "123",
+        createdBy: user.userId,
+        updatedAt: new Date(),
+      },
+      {
+        id: "abc",
+        version: 2,
+        name: "Dashboard v2",
+        topicAreaId: "456",
+        topicAreaName: "Topic1",
+        description: "Description Test",
+        state: DashboardState.Published,
+        parentDashboardId: "123",
+        createdBy: user.userId,
+        updatedAt: new Date(),
+      },
+    ];
+
+    getDashboardVersions.mockImplementation(() => Promise.resolve(dashboards));
+    const nextVersion = await repo.getNextVersionNumber("123");
+    expect(nextVersion).toEqual(3);
+  });
+
+  it("handles incorrect versions gracefully", async () => {
+    const dashboards: Array<Dashboard> = [
+      {
+        id: "xyz",
+        version: (undefined as unknown) as number, // incorrect version
+        name: "Dashboard v1",
+        topicAreaId: "456",
+        topicAreaName: "Topic1",
+        description: "Description Test",
+        state: DashboardState.Draft,
+        parentDashboardId: "123",
+        createdBy: user.userId,
+        updatedAt: new Date(),
+      },
+    ];
+
+    getDashboardVersions.mockImplementation(() => Promise.resolve(dashboards));
+    const nextVersion = await repo.getNextVersionNumber("123");
+    expect(nextVersion).toEqual(1);
+  });
+
+  it("handles a mix of incorrect and correct versions", async () => {
+    const dashboards: Array<Dashboard> = [
+      {
+        id: "xyz",
+        version: (undefined as unknown) as number, // incorrect version
+        name: "Dashboard v1",
+        topicAreaId: "456",
+        topicAreaName: "Topic1",
+        description: "Description Test",
+        state: DashboardState.Draft,
+        parentDashboardId: "123",
+        createdBy: user.userId,
+        updatedAt: new Date(),
+      },
+      {
+        id: "abc",
+        version: 1,
+        name: "Dashboard v1",
+        topicAreaId: "456",
+        topicAreaName: "Topic1",
+        description: "Description Test",
+        state: DashboardState.Draft,
+        parentDashboardId: "123",
+        createdBy: user.userId,
+        updatedAt: new Date(),
+      },
+    ];
+
+    getDashboardVersions.mockImplementation(() => Promise.resolve(dashboards));
+    const nextVersion = await repo.getNextVersionNumber("123");
+    expect(nextVersion).toEqual(2);
+  });
+});

--- a/backend/src/lib/repositories/dashboard-repo.ts
+++ b/backend/src/lib/repositories/dashboard-repo.ts
@@ -95,6 +95,22 @@ class DashboardRepository extends BaseRepository {
     );
   }
 
+  public async getNextVersionNumber(
+    parentDashboardId: string
+  ): Promise<number> {
+    const dashboards = await this.getDashboardVersions(parentDashboardId);
+    if (dashboards.length === 0) {
+      return 1;
+    }
+
+    const versions = dashboards
+      .map((dashboard) => dashboard.version)
+      .filter((version) => !isNaN(version));
+
+    const latest = Math.max(...versions);
+    return !isFinite(latest) ? 1 : latest + 1;
+  }
+
   /**
    * Returns the list of Dashboards within an specified topic area.
    */


### PR DESCRIPTION
## Description

The version number assigned to new drafts was incorrect. It just incremented the version number without considering other versions in the database. Jason discovered a workflow in which you end up with 2 dashboards with the same version number. 

I wrote a new function in the repository to fetch all the versions for a parentDashboard and then return the corresponding next version number. 

## Testing

Wrote unit tests and also ran Postman Integration tests against my localhost to make sure I did not break anything else. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
