### PR TITLE
GTT-616 Increased lambda timeout to 10 seconds

### DIFF
--- a/cdk/lib/constructs/lambdas.ts
+++ b/cdk/lib/constructs/lambdas.ts
@@ -21,6 +21,7 @@ export class LambdaFunctions extends cdk.Construct {
       code: lambda.Code.fromAsset("../backend/build"),
       handler: "lambda/api.handler",
       tracing: lambda.Tracing.ACTIVE,
+      timeout: cdk.Duration.seconds(10),
       memorySize: 256,
       environment: {
         MAIN_TABLE: props.mainTable.tableName,


### PR DESCRIPTION
## Description

Increased the timeout execution time for Lambda from 3 seconds to 10 seconds as a result of the GameDay exercise. 

## Testing

Deployed to my environment and verified it works. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
