### PR TITLE
GTT-691 Get count of dashboards per topic area

### DIFF
--- a/backend/src/lib/models/topicarea.ts
+++ b/backend/src/lib/models/topicarea.ts
@@ -1,8 +1,9 @@
-export type TopicArea = {
+export interface TopicArea {
   id: string;
   name: string;
   createdBy: string;
-};
+  dashboardCount?: number;
+}
 
 export type TopicAreaList = Array<TopicArea>;
 


### PR DESCRIPTION
## Description

New function to get the dashboard count per topic area using the new GSI. Modified the list topic areas to retrieve the count. 

## Testing

Wrote unit tests and deployed in my personal environment. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
