### PR TITLE
GTT-692 Frontend for rename topic areas

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import EditText from "./containers/EditText";
 import AdminHome from "./containers/AdminHome";
 import TopicareaSettings from "./containers/TopicareaSettings";
 import CreateTopicArea from "./containers/CreateTopicArea";
+import EditTopicArea from "./containers/EditTopicArea";
 import FourZeroFour from "./containers/FourZeroFour";
 import MarkdownSyntax from "./containers/MarkdownSyntax";
 import FormattingCSV from "./containers/FormattingCSV";
@@ -48,6 +49,10 @@ const routes: Array<AppRoute> = [
   {
     path: "/admin/settings/topicarea/create",
     component: CreateTopicArea,
+  },
+  {
+    path: "/admin/settings/topicarea/:topicAreaId/edit",
+    component: EditTopicArea,
   },
   {
     path: "/admin/dashboards",

--- a/frontend/src/containers/EditTopicArea.tsx
+++ b/frontend/src/containers/EditTopicArea.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { useHistory, useParams } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { useTopicArea } from "../hooks";
+import BackendService from "../services/BackendService";
+import EnvConfig from "../services/EnvConfig";
+import TextField from "../components/TextField";
+import Button from "../components/Button";
+import Breadcrumbs from "../components/Breadcrumbs";
+import AlertContainer from "./AlertContainer";
+
+interface FormValues {
+  name: string;
+  topicAreaId: string;
+  description: string;
+}
+
+interface PathParams {
+  topicAreaId: string;
+}
+
+function EditTopicArea() {
+  const history = useHistory();
+  const { topicAreaId } = useParams<PathParams>();
+  const { register, errors, handleSubmit } = useForm<FormValues>();
+  const { topicarea } = useTopicArea(topicAreaId);
+
+  const onSubmit = async (values: FormValues) => {
+    try {
+      await BackendService.renameTopicArea(topicAreaId, values.name);
+      history.push("/admin/settings/topicarea", {
+        alert: {
+          type: "success",
+          message: `"${values.name}" was successfully edited`,
+        },
+      });
+    } catch (err) {
+      history.push(`/admin/settings/topicarea/${topicAreaId}/edit`, {
+        alert: {
+          type: "error",
+          message: `There was a problem editing "${values.name}". Please retry`,
+        },
+      });
+    }
+  };
+
+  const onCancel = () => {
+    history.push("/admin/settings/topicarea");
+  };
+
+  if (!topicarea) {
+    return null;
+  }
+
+  return (
+    <>
+      <Breadcrumbs
+        crumbs={[
+          {
+            label: "Settings",
+            url: "/admin/settings/topicarea",
+          },
+          {
+            label: "Topic areas",
+            url: "/admin/settings/topicarea",
+          },
+          {
+            label: `Edit ${topicarea.name}`,
+          },
+        ]}
+      />
+      <AlertContainer />
+      <h1>{`Edit ${EnvConfig.topicAreaLabel.toLocaleLowerCase()} name`}</h1>
+
+      <div className="grid-row">
+        <div className="grid-col-12">
+          <form
+            onSubmit={handleSubmit(onSubmit)}
+            className="usa-form usa-form--large"
+          >
+            <TextField
+              id="name"
+              name="name"
+              label={`${EnvConfig.topicAreaLabel} name`}
+              register={register}
+              error={errors.name && "Please specify a name"}
+              defaultValue={topicarea?.name}
+              required
+            />
+
+            <br />
+            <Button type="submit">Save</Button>
+            <Button
+              className="margin-left-1 text-base-dark hover:text-base-darker active:text-base-darkest"
+              variant="unstyled"
+              type="button"
+              onClick={onCancel}
+            >
+              Cancel
+            </Button>
+          </form>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default EditTopicArea;

--- a/frontend/src/containers/TopicareaListing.tsx
+++ b/frontend/src/containers/TopicareaListing.tsx
@@ -26,6 +26,12 @@ function TopicareaListing() {
     history.push("/admin/settings/topicarea/create");
   };
 
+  const onEdit = () => {
+    if (selected) {
+      history.push(`/admin/settings/topicarea/${selected.id}/edit`);
+    }
+  };
+
   const onSearch = (query: string) => {
     setFilter(query);
   };
@@ -139,11 +145,7 @@ function TopicareaListing() {
                 />
               )}
               <span>
-                <Button
-                  variant="outline"
-                  disabled={!selected}
-                  onClick={() => {}}
-                >
+                <Button variant="outline" disabled={!selected} onClick={onEdit}>
                   Edit
                 </Button>
               </span>

--- a/frontend/src/containers/__tests__/EditTopicArea.test.tsx
+++ b/frontend/src/containers/__tests__/EditTopicArea.test.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { createMemoryHistory } from "history";
+import { Route, Router } from "react-router-dom";
+import EnvConfig from "../../services/EnvConfig";
+import BackendService from "../../services/BackendService";
+import EditTopicArea from "../EditTopicArea";
+
+jest.mock("../../services/BackendService");
+jest.mock("../../hooks");
+
+const topicAreaId = "123456789";
+
+beforeEach(() => {
+  BackendService.renameTopicArea = jest.fn();
+
+  const history = createMemoryHistory();
+  history.push(`/admin/settings/topicarea/${topicAreaId}/edit`);
+
+  render(
+    <Router history={history}>
+      <Route path="/admin/settings/topicarea/:topicAreaId/edit">
+        <EditTopicArea />
+      </Route>
+    </Router>
+  );
+});
+
+test("saves the new topic area name", async () => {
+  const nameInput = screen.getByLabelText(`${EnvConfig.topicAreaLabel} name`);
+  fireEvent.input(nameInput, {
+    target: {
+      value: "New topic area name",
+    },
+  });
+
+  const submitBtn = screen.getByRole("button", { name: "Save" });
+  await act(async () => {
+    fireEvent.click(submitBtn);
+  });
+
+  expect(BackendService.renameTopicArea).toBeCalledWith(
+    topicAreaId,
+    "New topic area name"
+  );
+});

--- a/frontend/src/hooks/__mocks__/index.tsx
+++ b/frontend/src/hooks/__mocks__/index.tsx
@@ -234,3 +234,14 @@ export function useSampleDataset() {
     },
   };
 }
+
+export function useTopicArea() {
+  return {
+    loading: false,
+    topicarea: {
+      id: "123456789",
+      name: "Health Topic",
+      createdBy: "johndoe",
+    },
+  };
+}

--- a/frontend/src/hooks/index.tsx
+++ b/frontend/src/hooks/index.tsx
@@ -5,7 +5,7 @@ import {
   useDashboardVersions,
 } from "./dashboard-hooks";
 import { useWidget, useColors } from "./widget-hooks";
-import { useTopicAreas } from "./topicarea-hooks";
+import { useTopicAreas, useTopicArea } from "./topicarea-hooks";
 import { useHomepage } from "./homepage-hooks";
 import { useJsonDataset, useSampleDataset } from "./dataset-hooks";
 import { useAdmin } from "./admin-hooks";
@@ -26,6 +26,7 @@ export {
   useWidget,
   useColors,
   useTopicAreas,
+  useTopicArea,
   useHomepage,
   useJsonDataset,
   useAdmin,

--- a/frontend/src/hooks/topicarea-hooks.ts
+++ b/frontend/src/hooks/topicarea-hooks.ts
@@ -29,3 +29,29 @@ export function useTopicAreas(): UseTopicAreasHook {
     reloadTopicAreas: fetchData,
   };
 }
+
+type UseTopicAreaHook = {
+  topicarea: TopicArea | undefined;
+  loading: boolean;
+};
+
+export function useTopicArea(topicAreaId: string): UseTopicAreaHook {
+  const [loading, setLoading] = useState(false);
+  const [topicarea, setTopicArea] = useState<TopicArea | undefined>(undefined);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    const data = await BackendService.fetchTopicAreaById(topicAreaId);
+    setTopicArea(data);
+    setLoading(false);
+  }, [topicAreaId]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return {
+    loading,
+    topicarea,
+  };
+}

--- a/frontend/src/services/BackendService.ts
+++ b/frontend/src/services/BackendService.ts
@@ -46,6 +46,11 @@ async function fetchTopicAreas() {
   return await API.get(apiName, "topicarea", { headers });
 }
 
+async function fetchTopicAreaById(topicAreaId: string) {
+  const headers = await authHeaders();
+  return await API.get(apiName, `topicarea/${topicAreaId}`, { headers });
+}
+
 async function fetchWidgetById(
   dashboardId: string,
   widgetId: string
@@ -123,6 +128,16 @@ async function deleteDashboards(dashboards: Array<string>) {
 async function createTopicArea(name: string) {
   const headers = await authHeaders();
   return await API.post(apiName, "topicarea", {
+    headers,
+    body: {
+      name,
+    },
+  });
+}
+
+async function renameTopicArea(topicAreaId: string, name: string) {
+  const headers = await authHeaders();
+  return await API.put(apiName, `topicarea/${topicAreaId}`, {
     headers,
     body: {
       name,
@@ -275,6 +290,7 @@ export default {
   fetchDashboards,
   fetchDashboardById,
   fetchTopicAreas,
+  fetchTopicAreaById,
   fetchWidgetById,
   fetchWidgets,
   editDashboard,
@@ -282,6 +298,7 @@ export default {
   createDashboard,
   deleteDashboards,
   createTopicArea,
+  renameTopicArea,
   deleteTopicArea,
   createWidget,
   editWidget,

--- a/frontend/src/services/__tests__/BackendService.test.ts
+++ b/frontend/src/services/__tests__/BackendService.test.ts
@@ -250,3 +250,28 @@ test("fetchDashboardVersions makes a GET request to dashboard API", async () => 
     expect.anything()
   );
 });
+
+test("fetchTopicAreaById makes a GET request to topicarea API", async () => {
+  const topicAreaId = "123";
+  await BackendService.fetchTopicAreaById(topicAreaId);
+  expect(API.get).toHaveBeenCalledWith(
+    "BackendApi",
+    `topicarea/${topicAreaId}`,
+    expect.anything()
+  );
+});
+
+test("renameTopicArea makes a PUT request to topicarea API", async () => {
+  const topicAreaId = "123";
+  const newName = "My New Name";
+  await BackendService.renameTopicArea(topicAreaId, newName);
+  expect(API.put).toHaveBeenCalledWith(
+    "BackendApi",
+    `topicarea/${topicAreaId}`,
+    expect.objectContaining({
+      body: {
+        name: newName,
+      },
+    })
+  );
+});


### PR DESCRIPTION
## Description

Frontend screen to rename a topic area. 

## Testing

Wrote unit tests. You can test on my personal environment by renaming any topic area here: https://fdingler.badger.wwps.aws.dev/admin/settings/topicarea 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
