### PR TITLE
GTT-719 Added label for plural of topic areas

### DIFF
--- a/cdk/lib/envconfig/index.ts
+++ b/cdk/lib/envconfig/index.ts
@@ -49,6 +49,7 @@ function getConfigContent(): string {
     contactEmail: process.env.CONTACT_EMAIL,
     brandName: process.env.BRAND_NAME,
     topicAreaLabel: process.env.TOPIC_AREA_LABEL,
+    topicAreasLabel: process.env.TOPIC_AREAS_LABEL,
   };
 
   return `

--- a/cdk/lib/frontend-stack.ts
+++ b/cdk/lib/frontend-stack.ts
@@ -132,7 +132,8 @@ export class FrontendStack extends cdk.Stack {
         IDENTITY_POOL_ID: props.identityPoolId,
         CONTACT_EMAIL: "support@example.com",
         BRAND_NAME: "Performance Dashboard",
-        TOPIC_AREA_LABEL: "Topic Area",
+        TOPIC_AREA_LABEL: "Topic area",
+        TOPIC_AREAS_LABEL: "Topic areas",
       },
     });
 

--- a/frontend/src/components/__tests__/__snapshots__/DashboardsTable.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/DashboardsTable.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`renders a table with dashboards 1`] = `
           <span
             class="font-sans-xs"
           >
-            Topic Area
+            Topic area
           </span>
           <button
             class="usa-button usa-button--unstyled margin-left-1 hover:text-base-light text-white"
@@ -237,7 +237,7 @@ exports[`renders an empty table 1`] = `
           <span
             class="font-sans-xs"
           >
-            Topic Area
+            Topic area
           </span>
           <button
             class="usa-button usa-button--unstyled margin-left-1 hover:text-base-light text-white"

--- a/frontend/src/components/__tests__/__snapshots__/TopicareasTable.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/TopicareasTable.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`renders a table with topic areas 1`] = `
           <span
             class="font-sans-xs"
           >
-            Topic Area
+            Topic area
           </span>
           <button
             class="usa-button usa-button--unstyled margin-left-1 hover:text-base-light text-white"
@@ -143,7 +143,7 @@ exports[`renders an empty table 1`] = `
           <span
             class="font-sans-xs"
           >
-            Topic Area
+            Topic area
           </span>
           <button
             class="usa-button usa-button--unstyled margin-left-1 hover:text-base-light text-white"

--- a/frontend/src/containers/CreateTopicArea.tsx
+++ b/frontend/src/containers/CreateTopicArea.tsx
@@ -43,7 +43,7 @@ function CreateTopicArea() {
             url: "/admin/settings/topicarea",
           },
           {
-            label: "Topic areas",
+            label: EnvConfig.topicAreasLabel,
             url: "/admin/settings/topicarea",
           },
           {

--- a/frontend/src/containers/EditTopicArea.tsx
+++ b/frontend/src/containers/EditTopicArea.tsx
@@ -61,7 +61,7 @@ function EditTopicArea() {
             url: "/admin/settings/topicarea",
           },
           {
-            label: "Topic areas",
+            label: EnvConfig.topicAreasLabel,
             url: "/admin/settings/topicarea",
           },
           {

--- a/frontend/src/containers/TopicareaListing.tsx
+++ b/frontend/src/containers/TopicareaListing.tsx
@@ -106,7 +106,7 @@ function TopicareaListing() {
         <Spinner className="text-center margin-top-9" label="Loading" />
       ) : (
         <>
-          <h3 id="section-heading-h3">{`Topic areas (${topicareas.length})`}</h3>
+          <h3 id="section-heading-h3">{`${EnvConfig.topicAreasLabel} (${topicareas.length})`}</h3>
           <AlertContainer />
           <div className="grid-row margin-y-3">
             <div className="tablet:grid-col-4 padding-top-1px">
@@ -138,7 +138,8 @@ function TopicareaListing() {
                   getContent={() => (
                     <div className="font-sans-sm">
                       <p className="margin-y-0">
-                        {`You can only delete topic areas that have zero dashboards`}
+                        {`You can only delete ${EnvConfig.topicAreasLabel.toLocaleLowerCase()}` +
+                          `that have zero dashboards`}
                       </p>
                     </div>
                   )}

--- a/frontend/src/containers/TopicareaSettings.tsx
+++ b/frontend/src/containers/TopicareaSettings.tsx
@@ -6,10 +6,12 @@ import EnvConfig from "../services/EnvConfig";
 function TopicareaSettings() {
   return (
     <SettingsLayout>
-      <h1>Topic areas</h1>
+      <h1>{EnvConfig.topicAreasLabel}</h1>
 
       <p>
-        {`Dashboards are organized by topic areas. A dashboard must have a ${EnvConfig.topicAreaLabel.toLowerCase()} and can have only on ${EnvConfig.topicAreaLabel.toLowerCase()}.`}
+        {`Dashboards are organized by ${EnvConfig.topicAreasLabel.toLocaleLowerCase()}. ` +
+          `A dashboard must have a ${EnvConfig.topicAreaLabel.toLowerCase()} and can ` +
+          `have only one ${EnvConfig.topicAreaLabel.toLowerCase()}.`}
       </p>
 
       <hr

--- a/frontend/src/containers/__tests__/CreateDashboard.test.tsx
+++ b/frontend/src/containers/__tests__/CreateDashboard.test.tsx
@@ -30,7 +30,7 @@ describe("CreateDashboardForm", () => {
       },
     });
 
-    fireEvent.input(screen.getByLabelText("Topic Area"), {
+    fireEvent.input(screen.getByLabelText("Topic area"), {
       target: {
         value: "123456789",
       },

--- a/frontend/src/containers/__tests__/CreateTopicArea.test.tsx
+++ b/frontend/src/containers/__tests__/CreateTopicArea.test.tsx
@@ -24,7 +24,7 @@ describe("CreateTopicAreaForm", () => {
   });
 
   test("submits form with the entered values", async () => {
-    fireEvent.input(screen.getByLabelText("Topic Area name"), {
+    fireEvent.input(screen.getByLabelText("Topic area name"), {
       target: {
         value: "AWS Topic Area",
       },

--- a/frontend/src/containers/__tests__/TopicareaSettings.test.tsx
+++ b/frontend/src/containers/__tests__/TopicareaSettings.test.tsx
@@ -18,7 +18,7 @@ test("renders the description", async () => {
   });
   expect(
     getByText(
-      "Dashboards are organized by topic areas. A dashboard must have a topic area and can have only on topic area."
+      "Dashboards are organized by topic areas. A dashboard must have a topic area and can have only one topic area."
     )
   ).toBeInTheDocument();
 });

--- a/frontend/src/layouts/Settings.tsx
+++ b/frontend/src/layouts/Settings.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode } from "react";
 import "./Settings.css";
 import { useLocation } from "react-router-dom";
 import Breadcrumbs from "../components/Breadcrumbs";
+import EnvConfig from "../services/EnvConfig";
 import { Link } from "react-router-dom";
 
 interface LayoutProps {
@@ -12,7 +13,7 @@ function SettingsLayout(props: LayoutProps) {
   const { pathname } = useLocation();
   let currentSetting = "topicarea";
   const validSettings: any = {
-    topicarea: "Topic areas",
+    topicarea: EnvConfig.topicAreasLabel,
     publishingguidance: "Publishing guidance",
   };
 

--- a/frontend/src/services/EnvConfig.ts
+++ b/frontend/src/services/EnvConfig.ts
@@ -18,6 +18,7 @@ interface EnvConfig {
   contactEmail: string;
   brandName: string;
   topicAreaLabel: string;
+  topicAreasLabel: string;
 }
 
 const config = window.EnvironmentConfig;
@@ -31,5 +32,6 @@ export default {
   // available, but just in case it doesn't, the app wont crash.
   contactEmail: (config && config.contactEmail) || "support@example.com",
   brandName: (config && config.brandName) || "Performance Dashboard",
-  topicAreaLabel: (config && config.topicAreaLabel) || "Topic Area",
+  topicAreaLabel: (config && config.topicAreaLabel) || "Topic area",
+  topicAreasLabel: (config && config.topicAreasLabel) || "Topic areas",
 } as EnvConfig;

--- a/frontend/src/services/__tests__/EnvConfig.test.ts
+++ b/frontend/src/services/__tests__/EnvConfig.test.ts
@@ -1,7 +1,8 @@
 import EnvConfig from "../EnvConfig";
 
 test("default environment config values", () => {
-  expect(EnvConfig.topicAreaLabel).toEqual("Topic Area");
+  expect(EnvConfig.topicAreaLabel).toEqual("Topic area");
+  expect(EnvConfig.topicAreasLabel).toEqual("Topic areas");
   expect(EnvConfig.contactEmail).toEqual("support@example.com");
   expect(EnvConfig.brandName).toEqual("Performance Dashboard");
 });
@@ -10,6 +11,7 @@ test("non default environment config values", () => {
   // global is equivalent to the window object
   (global as any).EnvironmentConfig = {
     topicAreaLabel: "Category",
+    topicAreasLabel: "Categories",
     contactEmail: "hello@hello.com",
     brandName: "Amazon Web Services",
   };
@@ -19,6 +21,7 @@ test("non default environment config values", () => {
   const EnvConfig = require("../EnvConfig").default;
 
   expect(EnvConfig.topicAreaLabel).toEqual("Category");
+  expect(EnvConfig.topicAreasLabel).toEqual("Categories");
   expect(EnvConfig.contactEmail).toEqual("hello@hello.com");
   expect(EnvConfig.brandName).toEqual("Amazon Web Services");
 });


### PR DESCRIPTION
## Description

- Added label for plural of topic areas. 
- Changed default values to `Topic areas` instead of `Topic Areas`. Had to updated tests. 


## Testing

You can test on my personal environment: https://fdingler.badger.wwps.aws.dev/admin/settings/topicarea . I have the label set to `Category` and `Categories`. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
