### PR TITLE
Added GitHub action for security scanning

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,41 @@
+name: "Security Scan"
+
+on:
+  pull_request:
+    branches:
+      - mainline
+
+jobs:
+  CodeQL-Build:
+    # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        # Override language selection by uncommenting this and choosing your languages
+        with:
+          languages: javascript
+
+      # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below).
+      # - name: Autobuild
+      #  uses: github/codeql-action/autobuild@v1
+
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
+
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following
+      #    three lines and modify them (or add more) to build your code if your
+      #    project uses a compiled language
+
+      #- run: |
+      #   make bootstrap
+      #   make release
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
## Description

I learned about [CodeQL Security Static Analysis](https://securitylab.github.com/tools/codeql) today. So I'm adding this GitHub action to run security analysis on every pull request. It looks interesting, it already found a potential security concern here: https://github.com/awslabs/performance-dashboard-on-aws/security/code-scanning/1?query=ref%3Arefs%2Fpull%2F163%2Fmerge . 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
