### PR TITLE
Fixing the GitHub action for security scan

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,6 +1,9 @@
 name: "Security Scan"
 
 on:
+  push:
+    branches:
+      - mainline
   pull_request:
     branches:
       - mainline


### PR DESCRIPTION
## Description

Security scan was not running on mainline which was causing the GitHub action to not have anything to compare against. Documentation here: https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/enabling-code-scanning-for-a-repository#enabling-code-scanning-using-actions

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
