### PR TITLE
Update minor version, point to 0.2.0-beta nested stacks in S3

### DIFF
--- a/tools/performance-dashboard-eu-west-2.json
+++ b/tools/performance-dashboard-eu-west-2.json
@@ -4,7 +4,7 @@
     "authStack": {
       "Type": "AWS::CloudFormation::Stack",
       "Properties": {
-        "TemplateURL": "https://performance-dashboard-on-aws-eu-west-2.s3.eu-west-2.amazonaws.com/Auth-0.1.0-beta.json",
+        "TemplateURL": "https://performance-dashboard-on-aws-eu-west-2.s3.eu-west-2.amazonaws.com/Auth-0.2.0-beta.json",
         "TimeoutInMinutes": "60"
       }
     },
@@ -12,7 +12,7 @@
       "Type": "AWS::CloudFormation::Stack",
       "DependsOn": "authStack",
       "Properties": {
-        "TemplateURL": "https://performance-dashboard-on-aws-eu-west-2.s3.eu-west-2.amazonaws.com/Backend-0.1.0-beta.json",
+        "TemplateURL": "https://performance-dashboard-on-aws-eu-west-2.s3.eu-west-2.amazonaws.com/Backend-0.2.0-beta.json",
         "TimeoutInMinutes": "60"
       }
     },
@@ -20,7 +20,7 @@
       "Type": "AWS::CloudFormation::Stack",
       "DependsOn": "backendStack",
       "Properties": {
-        "TemplateURL": "https://performance-dashboard-on-aws-eu-west-2.s3.eu-west-2.amazonaws.com/Frontend-0.1.0-beta.json",
+        "TemplateURL": "https://performance-dashboard-on-aws-eu-west-2.s3.eu-west-2.amazonaws.com/Frontend-0.2.0-beta.json",
         "TimeoutInMinutes": "60"
       }
     },
@@ -28,7 +28,7 @@
       "Type": "AWS::CloudFormation::Stack",
       "DependsOn": "frontendStack",
       "Properties": {
-        "TemplateURL": "https://performance-dashboard-on-aws-eu-west-2.s3.eu-west-2.amazonaws.com/Ops-0.1.0-beta.json",
+        "TemplateURL": "https://performance-dashboard-on-aws-eu-west-2.s3.eu-west-2.amazonaws.com/Ops-0.2.0-beta.json",
         "TimeoutInMinutes": "60"
       }
     }

--- a/tools/performance-dashboard-us-east-1.json
+++ b/tools/performance-dashboard-us-east-1.json
@@ -4,7 +4,7 @@
     "authStack": {
       "Type": "AWS::CloudFormation::Stack",
       "Properties": {
-        "TemplateURL": "https://performance-dashboard-on-aws-us-east-1.s3.us-east-1.amazonaws.com/Auth-0.1.0-beta.json",
+        "TemplateURL": "https://performance-dashboard-on-aws-us-east-1.s3.us-east-1.amazonaws.com/Auth-0.2.0-beta.json",
         "TimeoutInMinutes": "60"
       }
     },
@@ -12,7 +12,7 @@
       "Type": "AWS::CloudFormation::Stack",
       "DependsOn": "authStack",
       "Properties": {
-        "TemplateURL": "https://performance-dashboard-on-aws-us-east-1.s3.us-east-1.amazonaws.com/Backend-0.1.0-beta.json",
+        "TemplateURL": "https://performance-dashboard-on-aws-us-east-1.s3.us-east-1.amazonaws.com/Backend-0.2.0-beta.json",
         "TimeoutInMinutes": "60"
       }
     },
@@ -20,7 +20,7 @@
       "Type": "AWS::CloudFormation::Stack",
       "DependsOn": "backendStack",
       "Properties": {
-        "TemplateURL": "https://performance-dashboard-on-aws-us-east-1.s3.us-east-1.amazonaws.com/LambdaEdge-0.1.0-beta.json",
+        "TemplateURL": "https://performance-dashboard-on-aws-us-east-1.s3.us-east-1.amazonaws.com/LambdaEdge-0.2.0-beta.json",
         "TimeoutInMinutes": "60"
       }
     },
@@ -28,7 +28,7 @@
       "Type": "AWS::CloudFormation::Stack",
       "DependsOn": "lambdaEdgeStack",
       "Properties": {
-        "TemplateURL": "https://performance-dashboard-on-aws-us-east-1.s3.us-east-1.amazonaws.com/Frontend-0.1.0-beta.json",
+        "TemplateURL": "https://performance-dashboard-on-aws-us-east-1.s3.us-east-1.amazonaws.com/Frontend-0.2.0-beta.json",
         "TimeoutInMinutes": "60"
       }
     },
@@ -36,7 +36,7 @@
       "Type": "AWS::CloudFormation::Stack",
       "DependsOn": "frontendStack",
       "Properties": {
-        "TemplateURL": "https://performance-dashboard-on-aws-us-east-1.s3.us-east-1.amazonaws.com/Ops-0.1.0-beta.json",
+        "TemplateURL": "https://performance-dashboard-on-aws-us-east-1.s3.us-east-1.amazonaws.com/Ops-0.2.0-beta.json",
         "TimeoutInMinutes": "60"
       }
     }

--- a/tools/performance-dashboard-us-east-2.json
+++ b/tools/performance-dashboard-us-east-2.json
@@ -4,7 +4,7 @@
     "authStack": {
       "Type": "AWS::CloudFormation::Stack",
       "Properties": {
-        "TemplateURL": "https://performance-dashboard-on-aws-us-east-2.s3.us-east-2.amazonaws.com/Auth-0.1.0-beta.json",
+        "TemplateURL": "https://performance-dashboard-on-aws-us-east-2.s3.us-east-2.amazonaws.com/Auth-0.2.0-beta.json",
         "TimeoutInMinutes": "60"
       }
     },
@@ -12,7 +12,7 @@
       "Type": "AWS::CloudFormation::Stack",
       "DependsOn": "authStack",
       "Properties": {
-        "TemplateURL": "https://performance-dashboard-on-aws-us-east-2.s3.us-east-2.amazonaws.com/Backend-0.1.0-beta.json",
+        "TemplateURL": "https://performance-dashboard-on-aws-us-east-2.s3.us-east-2.amazonaws.com/Backend-0.2.0-beta.json",
         "TimeoutInMinutes": "60"
       }
     },
@@ -20,7 +20,7 @@
       "Type": "AWS::CloudFormation::Stack",
       "DependsOn": "backendStack",
       "Properties": {
-        "TemplateURL": "https://performance-dashboard-on-aws-us-east-2.s3.us-east-2.amazonaws.com/Frontend-0.1.0-beta.json",
+        "TemplateURL": "https://performance-dashboard-on-aws-us-east-2.s3.us-east-2.amazonaws.com/Frontend-0.2.0-beta.json",
         "TimeoutInMinutes": "60"
       }
     },
@@ -28,7 +28,7 @@
       "Type": "AWS::CloudFormation::Stack",
       "DependsOn": "frontendStack",
       "Properties": {
-        "TemplateURL": "https://performance-dashboard-on-aws-us-east-2.s3.us-east-2.amazonaws.com/Ops-0.1.0-beta.json",
+        "TemplateURL": "https://performance-dashboard-on-aws-us-east-2.s3.us-east-2.amazonaws.com/Ops-0.2.0-beta.json",
         "TimeoutInMinutes": "60"
       }
     }

--- a/tools/performance-dashboard-us-west-2.json
+++ b/tools/performance-dashboard-us-west-2.json
@@ -4,7 +4,7 @@
     "authStack": {
       "Type": "AWS::CloudFormation::Stack",
       "Properties": {
-        "TemplateURL": "https://performance-dashboard-on-aws-us-west-2.s3.us-west-2.amazonaws.com/Auth-0.1.0-beta.json",
+        "TemplateURL": "https://performance-dashboard-on-aws-us-west-2.s3.us-west-2.amazonaws.com/Auth-0.2.0-beta.json",
         "TimeoutInMinutes": "60"
       }
     },
@@ -12,7 +12,7 @@
       "Type": "AWS::CloudFormation::Stack",
       "DependsOn": "authStack",
       "Properties": {
-        "TemplateURL": "https://performance-dashboard-on-aws-us-west-2.s3.us-west-2.amazonaws.com/Backend-0.1.0-beta.json",
+        "TemplateURL": "https://performance-dashboard-on-aws-us-west-2.s3.us-west-2.amazonaws.com/Backend-0.2.0-beta.json",
         "TimeoutInMinutes": "60"
       }
     },
@@ -20,7 +20,7 @@
       "Type": "AWS::CloudFormation::Stack",
       "DependsOn": "backendStack",
       "Properties": {
-        "TemplateURL": "https://performance-dashboard-on-aws-us-west-2.s3.us-west-2.amazonaws.com/Frontend-0.1.0-beta.json",
+        "TemplateURL": "https://performance-dashboard-on-aws-us-west-2.s3.us-west-2.amazonaws.com/Frontend-0.2.0-beta.json",
         "TimeoutInMinutes": "60"
       }
     },
@@ -28,7 +28,7 @@
       "Type": "AWS::CloudFormation::Stack",
       "DependsOn": "frontendStack",
       "Properties": {
-        "TemplateURL": "https://performance-dashboard-on-aws-us-west-2.s3.us-west-2.amazonaws.com/Ops-0.1.0-beta.json",
+        "TemplateURL": "https://performance-dashboard-on-aws-us-west-2.s3.us-west-2.amazonaws.com/Ops-0.2.0-beta.json",
         "TimeoutInMinutes": "60"
       }
     }


### PR DESCRIPTION
## Description

Update the parent CFTs for creating Performance Dashboard in us-east-1, us-east-2, us-west-2, and eu-west-2 regions.  The parent CFTs now point to the new version of the nested CFTs in S3 (0.2.0-beta)

## Testing

I deployed Performance Dashboard using the new CFTs in the different regions, and tested by going through the dashboard creation process.  I verified that the new code in this version (e.g. create topic area) was present in the instance

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
