### PR TITLE
Added `pino` logging library in the backend

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1030,6 +1030,26 @@
       "resolved": "https://registry.npmjs.org/@types/pg-types/-/pg-types-1.11.5.tgz",
       "integrity": "sha512-L8ogeT6vDzT1vxlW3KITTCt+BVXXVkLXfZ/XNm6UqbcJgxf+KPO7yjWx7dQQE8RW07KopL10x2gNMs41+IkMGQ=="
     },
+    "@types/pino": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-6.3.4.tgz",
+      "integrity": "sha512-03MpZ/HP6GlG0oo5dcb8NBpI21zNESswTbaA0VB4uuigXfVy+XLmzh39CY6VCAahPMxCPtuqSEdhwGeA3AOYXg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/pino-std-serializers": "*",
+        "@types/sonic-boom": "*"
+      }
+    },
+    "@types/pino-std-serializers": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/pino-std-serializers/-/pino-std-serializers-2.4.1.tgz",
+      "integrity": "sha512-17XcksO47M24IVTVKPeAByWUd3Oez7EbIjXpSbzMPhXVzgjGtrOa49gKBwxH9hb8dKv58OelsWQ+A1G1l9S3wQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/prettier": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.0.1.tgz",
@@ -1053,6 +1073,15 @@
       "requires": {
         "@types/express-serve-static-core": "*",
         "@types/mime": "*"
+      }
+    },
+    "@types/sonic-boom": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@types/sonic-boom/-/sonic-boom-0.7.0.tgz",
+      "integrity": "sha512-AfqR0fZMoUXUNwusgXKxcE9DPlHNDHQp6nKYUd4PSRpLobF5CCevSpyTEBcVZreqaWKCnGBr9KI1fHMTttoB7A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/stack-utils": {
@@ -1263,6 +1292,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/atomic-batcher/-/atomic-batcher-1.0.2.tgz",
       "integrity": "sha1-0WkB0QzOxZUWwZe5zNiTBom4E7Q="
+    },
+    "atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
     },
     "aws-sdk": {
       "version": "2.714.0",
@@ -2448,6 +2482,16 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-redact": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.0.tgz",
+      "integrity": "sha512-a/S/Hp6aoIjx7EmugtzLqXmcNsyFszqbt6qQ99BdG61QjBZF6shNis0BYR6TsZOQ1twYc0FN2Xdhwwbv6+KD0w=="
+    },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+    },
     "fb-watchman": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
@@ -2504,6 +2548,11 @@
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       }
+    },
+    "flatstr": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
+      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -4831,6 +4880,24 @@
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
+    "pino": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.7.0.tgz",
+      "integrity": "sha512-vPXJ4P9rWCwzlTJt+f0Ni4THc3DWyt8iDDCO4edQ8narTu6hnpzdXu8FqeSJCGndl1W6lfbYQUQihUO54y66Lw==",
+      "requires": {
+        "fast-redact": "^3.0.0",
+        "fast-safe-stringify": "^2.0.7",
+        "flatstr": "^1.0.12",
+        "pino-std-serializers": "^2.4.2",
+        "quick-format-unescaped": "^4.0.1",
+        "sonic-boom": "^1.0.2"
+      }
+    },
+    "pino-std-serializers": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.5.0.tgz",
+      "integrity": "sha512-wXqbqSrIhE58TdrxxlfLwU9eDhrzppQDvGhBEr1gYbzzM4KKo3Y63gSjiDXRKLVS2UOXdPNR2v+KnQgNrs+xUg=="
+    },
     "pirates": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
@@ -4929,6 +4996,11 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "quick-format-unescaped": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
+      "integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A=="
     },
     "range-parser": {
       "version": "1.2.1",
@@ -5589,6 +5661,15 @@
             "is-buffer": "^1.1.5"
           }
         }
+      }
+    },
+    "sonic-boom": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.3.0.tgz",
+      "integrity": "sha512-4nX6OYvOYr6R76xfQKi6cZpTO3YSWe/vd+QdIfoH0lBy0MnPkeAbb2rRWgmgADkXUeCKPwO1FZAKlAVWAadELw==",
+      "requires": {
+        "atomic-sleep": "^1.0.0",
+        "flatstr": "^1.0.12"
       }
     },
     "source-map": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
     "@types/express": "^4.17.6",
     "@types/jest": "^26.0.3",
     "@types/node": "^14.0.14",
+    "@types/pino": "^6.3.4",
     "@types/uuid": "^8.0.0",
     "jest": "^26.1.0",
     "ts-jest": "^26.1.1",
@@ -31,6 +32,7 @@
     "aws-xray-sdk": "^3.1.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
+    "pino": "^6.7.0",
     "uuid": "^8.2.0"
   }
 }

--- a/backend/src/lib/services/dynamodb.ts
+++ b/backend/src/lib/services/dynamodb.ts
@@ -1,5 +1,6 @@
 import AWSXRay from "aws-xray-sdk";
 import { DocumentClient } from "aws-sdk/clients/dynamodb";
+import logger from "./logger";
 
 /**
  * This class serves as a wrapper to the DynamoDB DocumentClient.
@@ -33,26 +34,32 @@ class DynamoDBService {
   }
 
   async get(input: DocumentClient.GetItemInput) {
+    logger.debug("DynamoDB GetItem %o", input);
     return this.client.get(input).promise();
   }
 
   async put(input: DocumentClient.PutItemInput) {
+    logger.debug("DynamoDB PutItem %o", input);
     return this.client.put(input).promise();
   }
 
   async query(input: DocumentClient.QueryInput) {
+    logger.debug("DynamoDB Query %o", input);
     return this.client.query(input).promise();
   }
 
   async update(input: DocumentClient.UpdateItemInput) {
+    logger.debug("DynamoDB UpdateItem %o", input);
     return this.client.update(input).promise();
   }
 
   async delete(input: DocumentClient.DeleteItemInput) {
+    logger.debug("DynamoDB DeleteItem %o", input);
     return this.client.delete(input).promise();
   }
 
   async transactWrite(input: DocumentClient.TransactWriteItemsInput) {
+    logger.debug("DynamoDB TransactWrite %o", input);
     if (!input.TransactItems) {
       return;
     }
@@ -68,6 +75,7 @@ class DynamoDBService {
       i += batchSize;
     }
 
+    logger.debug("DynamoDB TransactWrite batches = %d", batches.length);
     for await (const batch of batches) {
       await this.client
         .transactWrite({

--- a/backend/src/lib/services/logger.ts
+++ b/backend/src/lib/services/logger.ts
@@ -1,0 +1,9 @@
+import pino from "pino";
+
+const logLevel = process.env.LOG_LEVEL || "info";
+const logger = pino({
+  level: logLevel.toLocaleLowerCase(),
+  base: null,
+});
+
+export default logger;

--- a/cdk/lib/constructs/lambdas.ts
+++ b/cdk/lib/constructs/lambdas.ts
@@ -28,6 +28,7 @@ export class LambdaFunctions extends cdk.Construct {
       environment: {
         MAIN_TABLE: props.mainTable.tableName,
         DATASETS_BUCKET: props.datasetsBucket.bucketName,
+        LOG_LEVEL: "info",
       },
     });
 
@@ -45,6 +46,7 @@ export class LambdaFunctions extends cdk.Construct {
       environment: {
         MAIN_TABLE: props.mainTable.tableName,
         DATASETS_BUCKET: props.datasetsBucket.bucketName,
+        LOG_LEVEL: "info",
       },
     });
 


### PR DESCRIPTION
## Description

Added a library to do logging as well as an environment variable to control the logging level or disable it entirely in the Lambda functions. I also added `logger.debug()` in the DynamoDB Service just as an example of how to use the logger. 

## Testing

Deployed to my personal environment and verified it works. I also verified that CloudWatch Logs Insights is able to parse the logs in JSON format and identify the different fields in the log so that you can use those fields in your queries. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
