### PR TITLE
GTT-742 Using React Context to create a SettingsProvider

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 import { withAuthenticator } from "@aws-amplify/ui-react";
+import SettingsProvider from "./context/SettingsProvider";
 
 import withMainLayout from "./layouts/Main";
 import withAdminLayout from "./layouts/Admin";
@@ -156,30 +157,32 @@ const routes: Array<AppRoute> = [
 
 function App() {
   return (
-    <Router>
-      <Switch>
-        {routes.map((route) => {
-          const component = route.public
-            ? withMainLayout(route.component)
-            : withAuthenticator(
-                withFooterLayout(withAdminLayout(route.component))
-              );
-          return (
-            <Route
-              exact
-              key={route.path}
-              component={component}
-              path={route.path}
-            />
-          );
-        })}
-        <Route
-          key={"/admin/"}
-          component={withFooterLayout(withAdminLayout(FourZeroFour))}
-          path={"/admin/"}
-        />
-      </Switch>
-    </Router>
+    <SettingsProvider>
+      <Router>
+        <Switch>
+          {routes.map((route) => {
+            const component = route.public
+              ? withMainLayout(route.component)
+              : withAuthenticator(
+                  withFooterLayout(withAdminLayout(route.component))
+                );
+            return (
+              <Route
+                exact
+                key={route.path}
+                component={component}
+                path={route.path}
+              />
+            );
+          })}
+          <Route
+            key={"/admin/"}
+            component={withFooterLayout(withAdminLayout(FourZeroFour))}
+            path={"/admin/"}
+          />
+        </Switch>
+      </Router>
+    </SettingsProvider>
   );
 }
 

--- a/frontend/src/containers/EditPublishingGuidance.tsx
+++ b/frontend/src/containers/EditPublishingGuidance.tsx
@@ -14,15 +14,16 @@ interface FormValues {
 
 function EditPublishingGuidance() {
   const history = useHistory();
-  const { settings, loadingSettings } = useSettings();
+  const { settings, reloadSettings } = useSettings();
   const { register, handleSubmit } = useForm<FormValues>();
 
   const onSubmit = async (values: FormValues) => {
     await BackendService.editSettings(
       values.publishingGuidance,
-      settings ? settings.updatedAt : new Date()
+      settings.updatedAt ? settings.updatedAt : new Date()
     );
 
+    await reloadSettings();
     history.push("/admin/settings/publishingguidance", {
       alert: {
         type: "success",
@@ -62,7 +63,7 @@ function EditPublishingGuidance() {
           guidance specific to your organization.
         </p>
 
-        {loadingSettings ? (
+        {!settings.updatedAt ? (
           <Spinner className="text-center margin-top-9" label="Loading" />
         ) : (
           <>
@@ -81,7 +82,7 @@ function EditPublishingGuidance() {
               />
 
               <br />
-              <Button type="submit" disabled={loadingSettings}>
+              <Button type="submit" disabled={!settings.updatedAt}>
                 Save
               </Button>
               <Button

--- a/frontend/src/containers/PublishDashboard.tsx
+++ b/frontend/src/containers/PublishDashboard.tsx
@@ -30,7 +30,7 @@ function PublishDashboard() {
   const [step, setStep] = useState<number>(0);
   const [acknowledge, setAcknowledge] = useState<boolean>(false);
   const { dashboard, reloadDashboard, loading } = useDashboard(dashboardId);
-  const { settings, loadingSettings } = useSettings();
+  const { settings } = useSettings();
   const { register, errors, handleSubmit, trigger } = useForm<FormValues>();
 
   const { versions } = useDashboardVersions(dashboard?.parentDashboardId);
@@ -105,7 +105,7 @@ function PublishDashboard() {
         ]}
       />
 
-      {loading || loadingSettings ? (
+      {loading ? (
         <Spinner className="text-center margin-top-9" label="Loading" />
       ) : (
         <>

--- a/frontend/src/containers/PublishingGuidanceSettings.tsx
+++ b/frontend/src/containers/PublishingGuidanceSettings.tsx
@@ -2,15 +2,14 @@ import React from "react";
 import { useHistory } from "react-router-dom";
 import { useSettings } from "../hooks";
 import SettingsLayout from "../layouts/Settings";
-import Spinner from "../components/Spinner";
 import Button from "../components/Button";
 import MarkdownRender from "../components/MarkdownRender";
-import "./PublishingGuidanceSettings.css";
 import AlertContainer from "./AlertContainer";
+import "./PublishingGuidanceSettings.css";
 
 function PublishingGuidanceSettings() {
   const history = useHistory();
-  const { settings, loadingSettings } = useSettings();
+  const { settings } = useSettings();
 
   const onEdit = () => {
     history.push("/admin/settings/publishingguidance/edit");
@@ -39,25 +38,14 @@ function PublishingGuidanceSettings() {
         </div>
       </div>
 
-      {loadingSettings ? (
-        <Spinner
-          style={{
-            position: "fixed",
-            top: "30%",
-            left: "50%",
-          }}
-          label="Loading"
-        />
-      ) : (
-        <div className="grid-row margin-top-0-important">
-          <div className="grid-col flex-9">
-            <div className="publishing-guidance font-sans-lg">
-              <MarkdownRender source={settings.publishingGuidance} />
-            </div>
+      <div className="grid-row margin-top-0-important">
+        <div className="grid-col flex-9">
+          <div className="publishing-guidance font-sans-lg">
+            <MarkdownRender source={settings.publishingGuidance} />
           </div>
-          <div className="grid-col flex-3 text-right"></div>
         </div>
-      )}
+        <div className="grid-col flex-3 text-right"></div>
+      </div>
     </SettingsLayout>
   );
 }

--- a/frontend/src/containers/__tests__/EditPublishingGuidance.test.tsx
+++ b/frontend/src/containers/__tests__/EditPublishingGuidance.test.tsx
@@ -32,7 +32,7 @@ test("submits form with the entered values", async () => {
 
   expect(BackendService.editSettings).toBeCalledWith(
     "I acknowledge that I have reviewed the dashboard and it is ready to publish",
-    ""
+    new Date("2020-12-08T22:56:13.721Z")
   );
 });
 

--- a/frontend/src/context/SettingsProvider.tsx
+++ b/frontend/src/context/SettingsProvider.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useState, useCallback } from "react";
+import { Hub } from "aws-amplify";
+import { Settings } from "../models";
+import BackendService from "../services/BackendService";
+
+/**
+ * Default settings to start with while we fetch the actual
+ * Settings from the Backend.
+ */
+const defaultSettings: Settings = {
+  publishingGuidance:
+    "I acknowledge that I have reviewed the dashboard" +
+    " and it is ready to publish",
+};
+
+interface SettingsContextProps {
+  settings: Settings;
+  reloadSettings: Function;
+}
+
+export const SettingsContext = React.createContext<SettingsContextProps>({
+  reloadSettings: () => {},
+  settings: defaultSettings,
+});
+
+/**
+ * This provider wraps the root of our component's tree in <App />
+ * to provide Settings to all the children components in the tree. It
+ * uses React Context so that settings are kept in a global state instead
+ * of fetching them over and over on every screen.
+ */
+function SettingsProvider(props: { children: React.ReactNode }) {
+  const [settings, setSettings] = useState<SettingsContextProps>({
+    reloadSettings: () => {},
+    settings: defaultSettings,
+  });
+
+  const fetchData = useCallback(async () => {
+    try {
+      const data = await BackendService.fetchSettings();
+      setSettings({
+        settings: data,
+        reloadSettings: fetchData,
+      });
+    } catch (err) {
+      console.log("Failed to load settings from backend");
+    }
+  }, []);
+
+  /**
+   * Listen for authentication events so that when users
+   * signIn or their token is refreshed, we refetch the
+   * Settings. This covers an edge case in which we fail
+   * to fetch Settings the first time because the user was
+   * not authenticated yet.
+   */
+  const listenAuthEvents = useCallback(
+    (event: any) => {
+      const { payload } = event;
+      switch (payload.event) {
+        case "signIn":
+        case "tokenRefresh":
+          console.log("Refetching settings", payload);
+          fetchData();
+          break;
+        default:
+          break;
+      }
+    },
+    [fetchData]
+  );
+
+  useEffect(() => {
+    fetchData();
+    Hub.listen("auth", listenAuthEvents);
+    return () => Hub.remove("auth", listenAuthEvents);
+  }, [fetchData, listenAuthEvents]);
+
+  return (
+    <SettingsContext.Provider value={settings}>
+      {props.children}
+    </SettingsContext.Provider>
+  );
+}
+
+export default SettingsProvider;

--- a/frontend/src/context/SettingsProvider.tsx
+++ b/frontend/src/context/SettingsProvider.tsx
@@ -60,7 +60,6 @@ function SettingsProvider(props: { children: React.ReactNode }) {
       switch (payload.event) {
         case "signIn":
         case "tokenRefresh":
-          console.log("Refetching settings", payload);
           fetchData();
           break;
         default:

--- a/frontend/src/hooks/__mocks__/index.tsx
+++ b/frontend/src/hooks/__mocks__/index.tsx
@@ -3,7 +3,7 @@
  * testing easier. Prevents the actual backend API
  * calls to happen and instead returns dummy data.
  */
-
+import { useState } from "react";
 import { DashboardState } from "../../models";
 
 const dummyDashboard = {
@@ -61,13 +61,16 @@ export function useTopicAreas() {
 }
 
 export function useSettings() {
+  const [settings] = useState({
+    publishingGuidance:
+      "I acknowledge that I have reviewed the " +
+      "dashboard and it is ready to publish",
+    updatedAt: new Date("2020-12-08T22:56:13.721Z"),
+  });
+
   return {
-    loadingSettings: false,
-    settings: {
-      publishingGuidance:
-        "I acknowledge that I have reviewed the dashboard and it is ready to publish",
-      updatedAt: "",
-    },
+    reloadSettings: jest.fn(),
+    settings,
   };
 }
 

--- a/frontend/src/hooks/settings-hooks.ts
+++ b/frontend/src/hooks/settings-hooks.ts
@@ -1,31 +1,17 @@
-import { useEffect, useState } from "react";
+import { useContext } from "react";
 import { Settings } from "../models";
-import BackendService from "../services/BackendService";
+import { SettingsContext } from "../context/SettingsProvider";
 
 type UseSettingsHook = {
-  loadingSettings: boolean;
   settings: Settings;
+  reloadSettings: Function;
 };
 
 export function useSettings(): UseSettingsHook {
-  const [loadingSettings, setLoadingSettings] = useState<boolean>(false);
-  const [settings, setSettings] = useState<Settings>({
-    publishingGuidance: "",
-    updatedAt: new Date(),
-  });
-
-  useEffect(() => {
-    const fetchData = async () => {
-      setLoadingSettings(true);
-      const data = await BackendService.fetchSettings();
-      setSettings(data);
-      setLoadingSettings(false);
-    };
-    fetchData();
-  }, []);
+  const { settings, reloadSettings } = useContext(SettingsContext);
 
   return {
-    loadingSettings,
     settings,
+    reloadSettings,
   };
 }

--- a/frontend/src/models/index.tsx
+++ b/frontend/src/models/index.tsx
@@ -120,7 +120,7 @@ export type Homepage = {
 
 export type Settings = {
   publishingGuidance: string;
-  updatedAt: Date;
+  updatedAt?: Date;
 };
 
 // Type for the History object in react-router. Defines the


### PR DESCRIPTION
## Description

Used React Context to create a `SettingsProvider` that fetches the Settings from the backend only once when the application loads. All components in the Tree can consume these settings without having to refetch them. 

**Note**: This doesn't include fetching settings for Public users. We need a separate endpoint for that and we need to handle both cases accordingly in the `SettingsProvider`. 

## Testing

I had to update a few unit tests because `loadingSettings` is no longer a variable that the `useSettings` hook returns. I also tested thoroughly in my personal environment. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
