### PR TITLE
GTT-767 Backend to get dashboards by friendlyURL - Part1

### DIFF
--- a/backend/src/lib/api/public-api.ts
+++ b/backend/src/lib/api/public-api.ts
@@ -10,6 +10,11 @@ router.get(
   withErrorHandler(DashboardCtrl.getPublicDashboardById)
 );
 
+router.get(
+  "/dashboard/friendly-url/:friendlyURL",
+  withErrorHandler(DashboardCtrl.getPublicDashboardByFriendlyURL)
+);
+
 router.get("/homepage", withErrorHandler(HomepageCtrl.getPublicHomepage));
 
 export default router;

--- a/backend/src/lib/controllers/dashboard-ctrl.ts
+++ b/backend/src/lib/controllers/dashboard-ctrl.ts
@@ -77,6 +77,31 @@ async function getDashboardById(req: Request, res: Response) {
   }
 }
 
+async function getPublicDashboardByFriendlyURL(req: Request, res: Response) {
+  const { friendlyURL } = req.params;
+
+  const repo = DashboardRepository.getInstance();
+  let dashboard: Dashboard;
+
+  try {
+    dashboard = await repo.getDashboardByFriendlyURL(friendlyURL);
+  } catch (err) {
+    if (err instanceof ItemNotFound) {
+      res.status(404);
+      return res.send("Dashboard not found");
+    }
+    throw err;
+  }
+
+  const publicDashboard = DashboardFactory.toPublic(dashboard);
+  if (dashboard.state !== DashboardState.Published) {
+    res.status(404);
+    return res.send("Dashboard not found");
+  }
+
+  return res.json(publicDashboard);
+}
+
 async function getPublicDashboardById(req: Request, res: Response) {
   const { id } = req.params;
 
@@ -372,6 +397,7 @@ export default {
   listDashboards,
   createDashboard,
   getDashboardById,
+  getPublicDashboardByFriendlyURL,
   getVersions,
   updateDashboard,
   publishDashboard,

--- a/backend/src/lib/factories/__tests__/dashboard-factory.test.ts
+++ b/backend/src/lib/factories/__tests__/dashboard-factory.test.ts
@@ -71,6 +71,7 @@ describe("toItem", () => {
     updatedAt: now,
     state: DashboardState.Draft,
     releaseNotes: "release note test",
+    friendlyURL: "bananas-in-pyjamas",
   };
 
   it("should have a pk that starts with Dashboard", () => {
@@ -100,6 +101,7 @@ describe("toItem", () => {
     expect(item.version).toEqual(1);
     expect(item.parentDashboardId).toEqual("123");
     expect(item.releaseNotes).toEqual("release note test");
+    expect(item.friendlyURL).toEqual("bananas-in-pyjamas");
   });
 });
 
@@ -119,6 +121,7 @@ describe("fromItem", () => {
     updatedAt: now,
     state: "Draft",
     releaseNotes: "release note test",
+    friendlyURL: "bananas-in-pyjamas",
   };
 
   it("should include all attributes of Dashboard", () => {
@@ -134,6 +137,7 @@ describe("fromItem", () => {
     expect(dashboard.version).toEqual(1);
     expect(dashboard.parentDashboardId).toEqual("123");
     expect(dashboard.releaseNotes).toEqual("release note test");
+    expect(dashboard.friendlyURL).toEqual("bananas-in-pyjamas");
   });
 });
 
@@ -151,6 +155,7 @@ describe("toPublic", () => {
     updatedAt: now,
     state: DashboardState.Draft,
     releaseNotes: "release note test",
+    friendlyURL: "my-friendly-url",
   };
 
   it("should expose fields that are not sensitive", () => {
@@ -161,6 +166,7 @@ describe("toPublic", () => {
     expect(publicDashboard.topicAreaName).toEqual(dashboard.topicAreaName);
     expect(publicDashboard.description).toEqual(dashboard.description);
     expect(publicDashboard.updatedAt).toEqual(dashboard.updatedAt);
+    expect(publicDashboard.friendlyURL).toEqual(dashboard.friendlyURL);
   });
 });
 
@@ -254,5 +260,18 @@ describe("createDraftFromDashboard", () => {
         description: "Description test",
       })
     );
+  });
+
+  it("should remove the friendlyURL", () => {
+    const dashboardWithFriendlyURL = {
+      ...dashboard,
+      friendlyURL: "bananas-in-pyjamas",
+    };
+    const draft = factory.createDraftFromDashboard(
+      dashboardWithFriendlyURL,
+      user,
+      nextVersion
+    );
+    expect(draft.friendlyURL).toBeUndefined();
   });
 });

--- a/backend/src/lib/factories/dashboard-factory.ts
+++ b/backend/src/lib/factories/dashboard-factory.ts
@@ -62,6 +62,7 @@ function createDraftFromDashboard(
     createdBy: user.userId,
     updatedAt: new Date(),
     widgets,
+    friendlyURL: undefined, // new draft should not have friendlyURL
   };
 }
 
@@ -83,6 +84,7 @@ function toItem(dashboard: Dashboard): DashboardItem {
     createdBy: dashboard.createdBy,
     updatedAt: dashboard.updatedAt.toISOString(),
     releaseNotes: dashboard.releaseNotes,
+    friendlyURL: dashboard.friendlyURL,
   };
   return item;
 }
@@ -101,6 +103,7 @@ function fromItem(item: DashboardItem): Dashboard {
     updatedAt: item.updatedAt ? new Date(item.updatedAt) : new Date(),
     state: (item.state as DashboardState) || DashboardState.Draft,
     releaseNotes: item.releaseNotes,
+    friendlyURL: item.friendlyURL,
   };
   return dashboard;
 }
@@ -118,6 +121,7 @@ function toPublic(dashboard: Dashboard): PublicDashboard {
     description: dashboard.description,
     updatedAt: dashboard.updatedAt,
     widgets: dashboard.widgets,
+    friendlyURL: dashboard.friendlyURL,
   };
 }
 

--- a/backend/src/lib/models/dashboard.ts
+++ b/backend/src/lib/models/dashboard.ts
@@ -27,6 +27,7 @@ export interface Dashboard {
   state: DashboardState;
   releaseNotes?: string;
   widgets?: Array<Widget>;
+  friendlyURL?: string;
 }
 
 export type DashboardList = Array<Dashboard>;
@@ -45,6 +46,7 @@ export interface DashboardItem {
   updatedAt: string;
   state: string;
   releaseNotes?: string;
+  friendlyURL?: string;
 }
 
 // Public representation of a dashboard. Hides some fields
@@ -58,4 +60,5 @@ export interface PublicDashboard {
   description: string;
   updatedAt: Date;
   widgets?: Array<Widget>;
+  friendlyURL?: string;
 }

--- a/backend/src/lib/repositories/__tests__/dashboard-repo.test.ts
+++ b/backend/src/lib/repositories/__tests__/dashboard-repo.test.ts
@@ -993,3 +993,39 @@ describe("updateTopicAreaName", () => {
     expect(dynamodb.transactWrite).toBeCalled();
   });
 });
+
+describe("getDashboardByFriendlyURL", () => {
+  it("queries the correct GSI", async () => {
+    await repo.getDashboardByFriendlyURL("my-friendly-url");
+    expect(dynamodb.query).toBeCalledWith(
+      expect.objectContaining({
+        TableName: tableName,
+        IndexName: "byFriendlyURL",
+      })
+    );
+  });
+
+  it("returns the dashboard associated to the friendlyURL", async () => {
+    const items: DashboardItem[] = [
+      {
+        pk: "Dashboard#123",
+        sk: "Dashboard#123",
+        type: "Dashboard",
+        parentDashboardId: "123",
+        version: 1,
+        description: "",
+        createdBy: "johndoe",
+        state: "Published",
+        dashboardName: "My Dashboard",
+        topicAreaId: "001",
+        topicAreaName: "Environment",
+        updatedAt: new Date().toISOString(),
+        friendlyURL: "my-friendly-url",
+      },
+    ];
+
+    dynamodb.query = jest.fn().mockReturnValue({ Items: items });
+    const dashboard = await repo.getDashboardByFriendlyURL("my-friendly-url");
+    expect(dashboard?.friendlyURL).toEqual("my-friendly-url");
+  });
+});

--- a/cdk/lib/constructs/api.ts
+++ b/cdk/lib/constructs/api.ts
@@ -120,13 +120,13 @@ export class BackendApi extends cdk.Construct {
     // Not passing `methodProps` is what makes the endpoint public.
     const publicapi = this.api.root.addResource("public");
     const dashboards = publicapi.addResource("dashboard");
+    const friendlyURLs = dashboards.addResource("friendly-url");
 
     const dashboard = dashboards.addResource("{id}");
     dashboard.addMethod("GET", apiIntegration);
 
-    const friendlyURLs = dashboard.addResource("friendly-url");
-    const byFriendlyURL = friendlyURLs.addResource("{friendlyURL}");
-    byFriendlyURL.addMethod("GET", apiIntegration);
+    const byfriendlyURL = friendlyURLs.addResource("{friendlyURL}");
+    byfriendlyURL.addMethod("GET", apiIntegration);
 
     const homepage = publicapi.addResource("homepage");
     homepage.addMethod("GET", apiIntegration);

--- a/cdk/lib/constructs/api.ts
+++ b/cdk/lib/constructs/api.ts
@@ -124,6 +124,10 @@ export class BackendApi extends cdk.Construct {
     const dashboard = dashboards.addResource("{id}");
     dashboard.addMethod("GET", apiIntegration);
 
+    const friendlyURLs = dashboard.addResource("friendly-url");
+    const byFriendlyURL = friendlyURLs.addResource("{friendlyURL}");
+    byFriendlyURL.addMethod("GET", apiIntegration);
+
     const homepage = publicapi.addResource("homepage");
     homepage.addMethod("GET", apiIntegration);
   }

--- a/cdk/lib/constructs/database.ts
+++ b/cdk/lib/constructs/database.ts
@@ -58,6 +58,15 @@ export class Database extends cdk.Construct {
       },
     });
 
+    table.addGlobalSecondaryIndex({
+      indexName: "byFriendlyURL",
+      projectionType: dynamodb.ProjectionType.ALL,
+      partitionKey: {
+        name: "friendlyURL",
+        type: dynamodb.AttributeType.STRING,
+      },
+    });
+
     this.mainTable = table;
   }
 }


### PR DESCRIPTION
## Description

- Added new optional attribute `friendlyURL` in the Dashboard model. 
- New endpoint in the public API to fetch a dashboard by its friendlyURL. 
- New GSI in DynamoDB to query by friendlyURL. 
- New function in repository to query using the GSI.
- Updated DashboardFactory to map friendlyURL accordingly when creating or converting objects. 

In Part 2 I will do the setting the friendlyURL during the Publishing process. 

## Testing

Tested using Postman in my personal environment and manually adding a friendlyURL in a Dashboard in DynamoDB. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
