### PR TITLE
GTT-775 Frontend to load dashboard by URL

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -162,7 +162,7 @@ const routes: Array<AppRoute> = [
     component: FormattingCSV,
   },
   {
-    path: "/:dashboardId",
+    path: "/:friendlyURL",
     component: ViewDashboard,
     public: true,
   },

--- a/frontend/src/containers/Home.tsx
+++ b/frontend/src/containers/Home.tsx
@@ -86,7 +86,14 @@ function Home() {
                       key={dashboard.id}
                       className="border-bottom border-base-light padding-2"
                     >
-                      <Link to={`/${dashboard.id}`}>{dashboard.name}</Link>
+                      {dashboard.friendlyURL ? (
+                        <Link to={`/${dashboard.friendlyURL}`}>
+                          {dashboard.name}
+                        </Link>
+                      ) : (
+                        // If dashboard doesn't have a friendlyURL, use the dashboardId.
+                        <Link to={`/${dashboard.id}`}>{dashboard.name}</Link>
+                      )}
                       <br />
                       <span className="text-base text-italic">
                         Last updated {updatedAt}

--- a/frontend/src/containers/ViewDashboard.tsx
+++ b/frontend/src/containers/ViewDashboard.tsx
@@ -9,12 +9,18 @@ import Spinner from "../components/Spinner";
 import DashboardHeader from "../components/DashboardHeader";
 
 interface PathParams {
-  dashboardId: string;
+  friendlyURL: string;
 }
 
 function ViewDashboard() {
-  const { dashboardId } = useParams<PathParams>();
-  const { dashboard, loading } = usePublicDashboard(dashboardId);
+  const { friendlyURL } = useParams<PathParams>();
+  const { dashboard, loading, dashboardNotFound } = usePublicDashboard(
+    friendlyURL
+  );
+
+  if (dashboardNotFound) {
+    return <Redirect to="/404/page-not-found" />;
+  }
 
   return loading || dashboard === undefined ? (
     <Spinner
@@ -25,7 +31,7 @@ function ViewDashboard() {
       }}
       label="Loading"
     />
-  ) : dashboard.id ? (
+  ) : (
     <>
       <Link to="/">
         <FontAwesomeIcon icon={faArrowLeft} /> All Dashboards
@@ -44,8 +50,6 @@ function ViewDashboard() {
         );
       })}
     </>
-  ) : (
-    <Redirect to="/404/page-not-found" />
   );
 }
 

--- a/frontend/src/layouts/Public.tsx
+++ b/frontend/src/layouts/Public.tsx
@@ -32,12 +32,12 @@ function PublicLayout(props: LayoutProps) {
             </button>
             <ul className="usa-nav__primary usa-accordion">
               <li className="usa-nav__primary-item">
-                <Link
-                  to={`mailto:${EnvConfig.contactEmail}?subject=Performance Dashboard Assistance`}
+                <a
+                  href={`mailto:${EnvConfig.contactEmail}?subject=Performance Dashboard Assistance`}
                   className="usa-nav__link"
                 >
                   Contact
-                </Link>
+                </a>
               </li>
             </ul>
           </nav>

--- a/frontend/src/models/index.tsx
+++ b/frontend/src/models/index.tsx
@@ -31,6 +31,7 @@ export type Dashboard = {
   state: string;
   updatedAt: Date;
   createdBy: string;
+  friendlyURL?: string;
 };
 
 export type PublicDashboard = {
@@ -41,6 +42,7 @@ export type PublicDashboard = {
   description?: string;
   widgets: Array<Widget>;
   updatedAt: Date;
+  friendlyURL?: string;
 };
 
 export type DashboardVersion = {

--- a/frontend/src/services/BackendService.ts
+++ b/frontend/src/services/BackendService.ts
@@ -41,6 +41,17 @@ async function fetchDashboardById(dashboardId: string): Promise<Dashboard> {
   return await API.get(apiName, `dashboard/${dashboardId}`, { headers });
 }
 
+async function fetchPublicDashboardByURL(
+  friendlyURL: string
+): Promise<Dashboard> {
+  const headers = await authHeaders();
+  return await API.get(
+    apiName,
+    `public/dashboard/friendly-url/${friendlyURL}`,
+    { headers }
+  );
+}
+
 async function fetchTopicAreas() {
   const headers = await authHeaders();
   return await API.get(apiName, "topicarea", { headers });
@@ -362,6 +373,7 @@ export default {
   fetchPublicHomepage,
   editHomepage,
   fetchPublicDashboard,
+  fetchPublicDashboardByURL,
   fetchSettings,
   editSettings,
   updateSetting,

--- a/frontend/src/services/__tests__/BackendService.test.ts
+++ b/frontend/src/services/__tests__/BackendService.test.ts
@@ -321,3 +321,13 @@ test("updateSetting makes a PUT request to settings API", async () => {
     })
   );
 });
+
+test("fetchDashboardByFriendlyURL makes a GET request to public API", async () => {
+  const friendlyURL = "my-friendly-url";
+  await BackendService.fetchPublicDashboardByURL(friendlyURL);
+  expect(API.get).toHaveBeenCalledWith(
+    "BackendApi",
+    `public/dashboard/friendly-url/my-friendly-url`,
+    expect.anything()
+  );
+});


### PR DESCRIPTION
## Description

Frontend work to load dashboards by friendlyURL. This change is backwards compatible meaning that those dashboards that don't currently have a friendlyURL will continue to load properly. 

## Testing

You can verify in my personal environment: 

Dashboard with friendlyURL: 
https://fdingler.badger.wwps.aws.dev/san-diego-dogs-in-adoption

Dashboard without friendlyURL: 
https://fdingler.badger.wwps.aws.dev/c4002355-eafd-4116-a23b-f1ae5ce5fff9 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
