### PR TITLE
GTT-774 Refactored generateFriendlyURL function

### DIFF
--- a/backend/src/lib/factories/__tests__/dashboard-factory.test.ts
+++ b/backend/src/lib/factories/__tests__/dashboard-factory.test.ts
@@ -280,15 +280,19 @@ describe("generateFriendlyURL", () => {
   test("generates a sanitized URL", () => {
     expect(factory.generateFriendlyURL("COVID-19")).toEqual("covid-19");
     expect(factory.generateFriendlyURL("La Construcción")).toEqual(
-      "la-construccin"
+      "la-construcción"
     );
-    expect(factory.generateFriendlyURL("Jen'O Brien")).toEqual("jeno-brien");
+    expect(factory.generateFriendlyURL("Jen'O Brien")).toEqual("jen-o-brien");
     expect(factory.generateFriendlyURL("Performance Dashboard @ AWS")).toEqual(
       "performance-dashboard-aws"
     );
     expect(factory.generateFriendlyURL("This is - great")).toEqual(
       "this-is-great"
     );
-    expect(factory.generateFriendlyURL("A Construção")).toEqual("a-construo");
+    expect(factory.generateFriendlyURL("A Construção")).toEqual("a-construção");
+    expect(factory.generateFriendlyURL("訳サービスで、テキストや")).toEqual(
+      "訳サービスで、テキストや"
+    );
+    expect(factory.generateFriendlyURL("!	#	$	&	'	(	)	*	+	,	/	:	;	=	?	@	[	] hi")).toEqual("-hi");
   });
 });

--- a/backend/src/lib/factories/__tests__/dashboard-factory.test.ts
+++ b/backend/src/lib/factories/__tests__/dashboard-factory.test.ts
@@ -293,6 +293,6 @@ describe("generateFriendlyURL", () => {
     expect(factory.generateFriendlyURL("訳サービスで、テキストや")).toEqual(
       "訳サービスで、テキストや"
     );
-    expect(factory.generateFriendlyURL("!	#	$	&	'	(	)	*	+	,	/	:	;	=	?	@	[	] hi")).toEqual("-hi");
+    expect(factory.generateFriendlyURL("!	#	$	&	'	(	)	*	+	,	/	:	;	=	?	@	[	] hi")).toEqual("hi");
   });
 });

--- a/backend/src/lib/factories/dashboard-factory.ts
+++ b/backend/src/lib/factories/dashboard-factory.ts
@@ -141,7 +141,7 @@ function generateFriendlyURL(dashboardName: string): string {
   return dashboardName
     .trim()
     .toLocaleLowerCase()
-    .replace(/[^a-z0-9 -]+/g, "") // remove non-alphanumeric characters
+    .replace(/[!#$&'\(\)\*\+,\/:;=\?@\[\]]+/g, " ") // remove RFC-3986 reserved characters
     .replace(/\s+/g, "-") // replace spaces for dashes
     .replace(/-+/g, "-"); // convert consecutive dashes to singular dash
 }

--- a/backend/src/lib/factories/dashboard-factory.ts
+++ b/backend/src/lib/factories/dashboard-factory.ts
@@ -143,7 +143,8 @@ function generateFriendlyURL(dashboardName: string): string {
     .toLocaleLowerCase()
     .replace(/[!#$&'\(\)\*\+,\/:;=\?@\[\]]+/g, " ") // remove RFC-3986 reserved characters
     .replace(/\s+/g, "-") // replace spaces for dashes
-    .replace(/-+/g, "-"); // convert consecutive dashes to singular dash
+    .replace(/-+/g, "-") // convert consecutive dashes to singular dash
+    .replace(/^-+|-+$/g, ""); // remove dashes at the end and beginning
 }
 
 export default {


### PR DESCRIPTION
## Description

I found that we can leave non-alphanumeric characters in the URL as long as we remove reserved URI characters `!#$&'()*+,/:;=?@[]` according to the RFC-3986 definition. 

## Testing

You can test in my environment that Dashboards with non-alphanumeric characters still load. For example [this one with Japanese chars](https://fdingler.badger.wwps.aws.dev/%E3%83%8F%E3%83%B3%E3%83%89%E3%83%A1%E3%82%A4%E3%83%89%E3%83%92%E3%82%AD%E3%83%AF%E4%BD%BF%E3%81%84%E6%96%B9-). 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
