### PR TITLE
Bugfix in fetch dashboard by URL

### DIFF
--- a/frontend/src/services/BackendService.ts
+++ b/frontend/src/services/BackendService.ts
@@ -44,11 +44,10 @@ async function fetchDashboardById(dashboardId: string): Promise<Dashboard> {
 async function fetchPublicDashboardByURL(
   friendlyURL: string
 ): Promise<Dashboard> {
-  const headers = await authHeaders();
   return await API.get(
     apiName,
     `public/dashboard/friendly-url/${friendlyURL}`,
-    { headers }
+    {}
   );
 }
 


### PR DESCRIPTION
## Description

The function fetchDashboardByURL was incorrectly sending credentials to the public api. This caused the request to fail because there were no credentials for a public unauthenticated user. 

## Testing

Tested in my personal environment in an Incognito browser window. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
