### PR TITLE
Bug fix: Frontend should fallback to default values for missing Settings

### DIFF
--- a/frontend/src/context/SettingsProvider.tsx
+++ b/frontend/src/context/SettingsProvider.tsx
@@ -30,6 +30,27 @@ export const SettingsContext = React.createContext<SettingsContextProps>({
 });
 
 /**
+ * The settings reducer takes the settings object coming from the
+ * backend and returns a Settings object containing those values
+ * and fallbacks to default values for any missing field.
+ *
+ * This protects the frontend from crashing in the event where the
+ * backend returns a Settings object that is missing certain fields.
+ */
+const settingsReducer = (backendSettings: Settings): Settings => {
+  return {
+    ...backendSettings, // add all values to start with
+    // Check if we need to fallback to default values
+    dateTimeFormat: backendSettings.dateTimeFormat
+      ? backendSettings.dateTimeFormat
+      : defaultSettings.dateTimeFormat,
+    publishingGuidance: backendSettings.publishingGuidance
+      ? backendSettings.publishingGuidance
+      : defaultSettings.publishingGuidance,
+  };
+};
+
+/**
  * This provider wraps the root of our component's tree in <App />
  * to provide Settings to all the children components in the tree. It
  * uses React Context so that settings are kept in a global state instead
@@ -56,7 +77,7 @@ function SettingsProvider(props: { children: React.ReactNode }) {
       });
       const data = await BackendService.fetchSettings();
       setSettings({
-        settings: data,
+        settings: settingsReducer(data),
         reloadSettings: fetchSettings,
         loadingSettings: false,
       });


### PR DESCRIPTION
## Description

@jenboydclark reported a bug in which her Backend was returning an incomplete `Settings` object that was missing the `dateTimeFormat` field. Her frontend was then crashing because of this missing field. 

This PR adds a function to take the settings object from the backend and merge it with the default settings values so that any missing fields in the backend are populated with default values. 

## Testing

Tested in my localhost. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
