### PR TITLE
Added -optional label to the add/edit table screens

### DIFF
--- a/frontend/src/containers/AddTable.tsx
+++ b/frontend/src/containers/AddTable.tsx
@@ -451,7 +451,7 @@ function AddTable() {
                 <TextField
                   id="summary"
                   name="summary"
-                  label="Table summary"
+                  label="Table summary - optional"
                   hint="Give your table a summary to explain it in more depth.
                   It can also be read by screen readers to describe the table
                   for those with visual impairments."

--- a/frontend/src/containers/EditTable.tsx
+++ b/frontend/src/containers/EditTable.tsx
@@ -576,7 +576,7 @@ function EditTable() {
                     <TextField
                       id="summary"
                       name="summary"
-                      label="Table summary"
+                      label="Table summary - optional"
                       hint="Give your table a summary to explain it in more depth.
                   It can also be read by screen readers to describe the table
                   for those with visual impairments."


### PR DESCRIPTION
## Description

We wanted to make it more clear to our users that the table summary input field is optional and not required. Every other input on the edit/add page is required. So, I simply added "- optional" to the label for the input, on both the edit table page, and the add table page.

## Testing

I made the changes locally, and then ran the test suite (./test.sh). I also double checked the webpage it self, to ensure the -optional label was there. Both tests completed successfully.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
