### PR TITLE
Added -optional label to the add/edit chart screens

### DIFF
--- a/frontend/src/containers/AddChart.tsx
+++ b/frontend/src/containers/AddChart.tsx
@@ -483,7 +483,7 @@ function AddChart() {
                 <TextField
                   id="summary"
                   name="summary"
-                  label="Chart summary"
+                  label="Chart summary - optional"
                   hint="Give your chart a summary to explain it in more depth.
                   It can also be read by screen readers to describe the chart
                   for those with visual impairments."

--- a/frontend/src/containers/EditChart.tsx
+++ b/frontend/src/containers/EditChart.tsx
@@ -614,7 +614,7 @@ function EditChart() {
                       <TextField
                         id="summary"
                         name="summary"
-                        label="Chart summary"
+                        label="Chart summary - optional"
                         hint="Give your chart a summary to explain it in more depth.
                     It can also be read by screen readers to describe the chart
                     for those with visual impairments."


### PR DESCRIPTION
## Description

We wanted to make it more clear to our users that the chart summary input field is optional and not required. Every other input on the edit/add page is required. So, I simply added "- optional" to the label for the input, on both the edit chart page, and the add chart page.

## Testing

I made the changes locally, and then ran the test suite (./test.sh). I also double checked the webpage it self, to ensure the -optional label was there. Both tests completed successfully.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
