### PR TITLE
GTT-821 Hardcode createdBy to `ingestapi` in CreateDataset endpoint

### DIFF
--- a/backend/src/lib/controllers/__tests__/ingestapi-ctrl.test.ts
+++ b/backend/src/lib/controllers/__tests__/ingestapi-ctrl.test.ts
@@ -44,13 +44,6 @@ describe("createDataset", () => {
     expect(res.send).toBeCalledWith("Missing required field `name`");
   });
 
-  it("returns a 400 error when metadata.createdBy is missing", async () => {
-    delete req.body.metadata.createdBy;
-    await IngestApiCtrl.createDataset(req, res);
-    expect(res.status).toBeCalledWith(400);
-    expect(res.send).toBeCalledWith("Missing required field `createdBy`");
-  });
-
   it("returns a 400 error when data is missing", async () => {
     delete req.body.data;
     await IngestApiCtrl.createDataset(req, res);
@@ -60,7 +53,12 @@ describe("createDataset", () => {
 
   it("saves the dataset", async () => {
     await IngestApiCtrl.createDataset(req, res);
-    expect(repository.createDataset).toBeCalled();
+    expect(repository.createDataset).toBeCalledWith(
+      expect.objectContaining({
+        createdBy: "ingestapi",
+      }),
+      [{ data: "data" }]
+    );
   });
 });
 

--- a/backend/src/lib/controllers/ingestapi-ctrl.ts
+++ b/backend/src/lib/controllers/ingestapi-ctrl.ts
@@ -21,10 +21,6 @@ async function createDataset(req: Request, res: Response) {
     return res.status(400).send("Missing required field `name`");
   }
 
-  if (!metadata.createdBy) {
-    return res.status(400).send("Missing required field `createdBy`");
-  }
-
   if (!data) {
     return res.status(400).send("Missing required field `data`");
   }
@@ -37,6 +33,9 @@ async function createDataset(req: Request, res: Response) {
     logger.warn("Unable to parse dataset %s", data);
     return res.status(400).send("Data is not a valid JSON array");
   }
+
+  // Make all datasets created with this endpoint createdBy=ingestapi
+  metadata.createdBy = "ingestapi";
 
   try {
     const repo = DatasetRepository.getInstance();


### PR DESCRIPTION
## Description

Hardcoding `createdBy` field to `ingestapi` instead of letting the caller specify an arbitrary username. 

## Testing

I updated the unit tests to verify that `createdBy` is always `ingestapi` and not the value provided in the endpoint. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
