### PR TITLE
GTT-820

### DIFF
--- a/frontend/src/containers/PublishDashboard.tsx
+++ b/frontend/src/containers/PublishDashboard.tsx
@@ -32,6 +32,7 @@ function PublishDashboard() {
   const { dashboard, reloadDashboard, loading } = useDashboard(dashboardId);
   const { settings } = useSettings();
   const { register, errors, handleSubmit, trigger } = useForm<FormValues>();
+  const [releaseNotes, setReleaseNotes] = useState("");
 
   const { versions } = useDashboardVersions(dashboard?.parentDashboardId);
 
@@ -91,6 +92,10 @@ function PublishDashboard() {
         },
       });
     }
+  };
+
+  const handleReleaseNotesInput = (event: React.FormEvent<HTMLInputElement>) => {
+    setReleaseNotes((event.target as HTMLInputElement).value);
   };
 
   return (
@@ -185,6 +190,7 @@ function PublishDashboard() {
                   label="Internal release notes"
                   error={errors.releaseNotes && "Please enter release notes"}
                   hint="Describe what changes you are publishing to the dashboard."
+                  onChange={handleReleaseNotesInput}
                   register={register}
                   required
                   multiline
@@ -253,7 +259,7 @@ function PublishDashboard() {
                 </Button>
               </span>
               <span hidden={step === 1}>
-                <Button variant="default" type="button" onClick={onContinue}>
+                <Button variant="default" type="button" onClick={onContinue} disabled={releaseNotes===""}>
                   Continue
                 </Button>
               </span>

--- a/frontend/src/containers/PublishDashboard.tsx
+++ b/frontend/src/containers/PublishDashboard.tsx
@@ -94,7 +94,9 @@ function PublishDashboard() {
     }
   };
 
-  const handleReleaseNotesInput = (event: React.FormEvent<HTMLInputElement>) => {
+  const handleReleaseNotesInput = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
     setReleaseNotes((event.target as HTMLInputElement).value);
   };
 
@@ -259,7 +261,12 @@ function PublishDashboard() {
                 </Button>
               </span>
               <span hidden={step === 1}>
-                <Button variant="default" type="button" onClick={onContinue} disabled={releaseNotes===""}>
+                <Button
+                  variant="default"
+                  type="button"
+                  onClick={onContinue}
+                  disabled={releaseNotes === ""}
+                >
                   Continue
                 </Button>
               </span>


### PR DESCRIPTION
## Description

On the publish dashboard page, it was requested that the continue button be disabled unless there is notes in the "Internal Release Notes" input box. This will imply to the user that this is a required field.

## Testing

I ran the test script ./test.sh (which completed successfully) and I visually verified it.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
