### PR TITLE
fix: Table crashes when column header is an empty string

### DIFF
--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -18,8 +18,10 @@ interface Props {
   rows: Array<object>;
   width?: string;
   columns: Array<{
-    accessor: string;
+    accessor?: string;
     Header: string;
+    Cell?: Function;
+    id?: string;
   }>;
 }
 

--- a/frontend/src/components/TablePreview.tsx
+++ b/frontend/src/components/TablePreview.tsx
@@ -24,10 +24,15 @@ const TablePreview = (props: Props) => {
         className="margin-left-2px"
         columns={useMemo(
           () =>
-            headers.map((header) => {
+            headers.map((header, i) => {
               return {
                 Header: header,
+                id: String(i),
                 accessor: header,
+                Cell: (props: any) => {
+                  const row = props.row.original;
+                  return row[header] || null;
+                },
               };
             }),
           [headers]

--- a/frontend/src/components/__tests__/TablePreview.test.tsx
+++ b/frontend/src/components/__tests__/TablePreview.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import TablePreview from "../TablePreview";
 
@@ -31,4 +31,21 @@ test("table preview should match snapshot", async () => {
     { wrapper: MemoryRouter }
   );
   expect(wrapper.container).toMatchSnapshot();
+});
+
+test("table should not crash when a column header is an empty string", async () => {
+  const wrapper = render(
+    <TablePreview
+      title="test title"
+      summary="test summary"
+      headers={["", "something"]}
+      data={[{ "": "foo", something: "bar" }]}
+    />,
+    { wrapper: MemoryRouter }
+  );
+
+  expect(screen.getByRole("table")).toBeInTheDocument();
+  expect(screen.getByText("foo")).toBeInTheDocument();
+  expect(screen.getByText("bar")).toBeInTheDocument();
+  expect(screen.getByText("something")).toBeInTheDocument();
 });

--- a/frontend/src/containers/EditTable.tsx
+++ b/frontend/src/containers/EditTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from "react";
+import React, { useState, useCallback, useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { useHistory, useParams } from "react-router-dom";
 import { Dataset, DatasetType } from "../models";
@@ -313,6 +313,12 @@ function EditTable() {
     });
   }
 
+  const tableHeaders = useMemo(() => {
+    return currentJson.length > 0
+      ? (Object.keys(currentJson[0]) as Array<string>)
+      : [];
+  }, [currentJson]);
+
   return (
     <>
       <Breadcrumbs crumbs={crumbs} />
@@ -623,11 +629,7 @@ function EditTable() {
                   <TablePreview
                     title={widget.showTitle ? widget.content.title : ""}
                     summary={widget.content.summary}
-                    headers={
-                      currentJson.length > 0
-                        ? (Object.keys(currentJson[0]) as Array<string>)
-                        : []
-                    }
+                    headers={tableHeaders}
                     data={currentJson}
                   />
                 )}


### PR DESCRIPTION
## Description

The Table component was crashing when a column header was en empty string. This was because the `react-table` library takes an empty string as an invalid `accessor` and doesn't know how to pull the data for that column. The solution was to specify a custom `Cell` function to have control over how to render the Cell. 

## Testing

I added a unit test to verify that the table doesn't crash when there is an empty column. I also tested in my personal environment with the Dataset that @jenboydclark provided. You can verify this dashboard has Jennifer's table at the end: https://fdingler.badger.wwps.aws.dev/71d2aaeb-1cd6-4d22-afbe-97b0eed8e250

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
