### PR TITLE
GTT-841 Middleware for user authentication

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,39 @@
+# Performance Dashboard on AWS - Backend Service
+
+This package contains the code for the Backend service of PDoA. It is a NodeJS + Express application that serves an HTTP API.
+
+## How to run locally
+
+To run the backend locally from VSCode, create a folder in the root of this repository named `.vscode`. Then create a file inside named `launch.json`. Add the following contents to the file:
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Backend",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": ["-r", "ts-node/register"],
+      "outputCapture": "std",
+      "env": {
+        "AWS_ACCESS_KEY_ID": "",
+        "AWS_SECRET_ACCESS_KEY": "",
+        "AWS_SESSION_TOKEN": "",
+        "AWS_REGION": "us-west-2",
+        "LOCAL_MODE": "true",
+        "MAIN_TABLE": "PerformanceDash-${stageName}-Backend-MainTable",
+        "DATASETS_BUCKET": "performancedash-${stageName}-${accountNumber}-${region}-datasets",
+        "USER_POOL_ID": "${your-user-pool-id}",
+        "LOG_LEVEL": "debug",
+        "TS_NODE_FILES": "true"
+      },
+      "args": ["${workspaceRoot}/backend/src/local/server.ts"],
+      "cwd": "${workspaceRoot}/backend",
+      "skipFiles": ["<node_internals>/**", "node_modules/**"]
+    }
+  ]
+}
+```
+
+**Note** Make sure to fill in the correct environment variable values. The AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN may not be required if you already have credentials in you `~/.aws/credentials` file. For the other values, like MAIN_TABLE, DATASETS_BUCKET and USER_POOL_ID, you'll need to get them from the file `cdk/outputs-backend.json` after you have deployed Performance Dashboard in your AWS account.

--- a/backend/src/lib/api/dashboard-api.ts
+++ b/backend/src/lib/api/dashboard-api.ts
@@ -2,8 +2,10 @@ import { Router } from "express";
 import DashboardCtrl from "../controllers/dashboard-ctrl";
 import WidgetCtrl from "../controllers/widget-ctrl";
 import withErrorHandler from "./middleware/error-handler";
+import auth from "./middleware/auth";
 
 const router = Router();
+router.use(auth);
 
 router.get("/", withErrorHandler(DashboardCtrl.listDashboards));
 router.get("/:id", withErrorHandler(DashboardCtrl.getDashboardById));

--- a/backend/src/lib/api/dataset-api.ts
+++ b/backend/src/lib/api/dataset-api.ts
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import DatasetCtrl from "../controllers/dataset-ctrl";
 import withErrorHandler from "./middleware/error-handler";
+import auth from "./middleware/auth";
 
 const router = Router();
+router.use(auth);
 
 router.get("/", withErrorHandler(DatasetCtrl.listDatasets));
 router.get("/:id", withErrorHandler(DatasetCtrl.getDatasetById));

--- a/backend/src/lib/api/middleware/__tests__/auth.test.ts
+++ b/backend/src/lib/api/middleware/__tests__/auth.test.ts
@@ -1,0 +1,39 @@
+import auth from "../auth";
+import { User } from "../../../models/user";
+import AuthService from "../../../services/auth";
+
+jest.mock("../../../services/auth");
+
+let req: any;
+let res: any;
+let next = jest.fn();
+const user: User = { userId: "johndoe" };
+
+beforeEach(() => {
+  req = {};
+  res = {
+    status: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+  };
+  next = jest.fn();
+});
+
+test("adds a user to the request object", () => {
+  AuthService.getCurrentUser = jest.fn().mockReturnValue(user);
+  auth(req, res, next);
+  expect(req.user).toEqual(user);
+});
+
+test("invokes the next function", () => {
+  AuthService.getCurrentUser = jest.fn().mockReturnValue(user);
+  auth(req, res, next);
+  expect(next).toBeCalled();
+});
+
+test("returns a 401 Unauthorized when no user found", () => {
+  AuthService.getCurrentUser = jest.fn().mockReturnValue(undefined);
+  auth(req, res, next);
+  expect(res.status).toBeCalledWith(401);
+  expect(res.send).toBeCalledWith("Unauthorized");
+  expect(next).not.toBeCalled();
+});

--- a/backend/src/lib/api/middleware/auth.ts
+++ b/backend/src/lib/api/middleware/auth.ts
@@ -1,0 +1,25 @@
+import { Request, Response, NextFunction } from "express";
+import AuthService from "../../services/auth";
+
+/**
+ * This middleware should only be used in the APIs that require
+ * Cognito-based authentication. The Public API and the Data
+ * Ingestion API should not use it.
+ *
+ * Extracts the user from the JWT token included in the request headers
+ * and makes it available in the Request object so it can be used in
+ * the Controllers. If no user is found, this middleware will reject
+ * the request with a 401 Forbidden status code.
+ */
+const auth = function (req: Request, res: Response, next: NextFunction) {
+  const user = AuthService.getCurrentUser(req);
+  if (!user) {
+    res.status(401);
+    return res.send("Unauthorized");
+  }
+
+  req.user = user;
+  next();
+};
+
+export default auth;

--- a/backend/src/lib/api/settings-api.ts
+++ b/backend/src/lib/api/settings-api.ts
@@ -2,8 +2,10 @@ import { Router } from "express";
 import SettingsCtrl from "../controllers/settings-ctrl";
 import withErrorHandler from "./middleware/error-handler";
 import HomepageCtrl from "../controllers/homepage-ctrl";
+import auth from "./middleware/auth";
 
 const router = Router();
+router.use(auth);
 
 router.get("/", withErrorHandler(SettingsCtrl.getSettings));
 router.put("/", withErrorHandler(SettingsCtrl.updateSettings));

--- a/backend/src/lib/api/topicarea-api.ts
+++ b/backend/src/lib/api/topicarea-api.ts
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import TopicAreaCtrl from "../controllers/topicarea-ctrl";
 import withErrorHandler from "./middleware/error-handler";
+import auth from "./middleware/auth";
 
 const router = Router();
+router.use(auth);
 
 router.get("/", withErrorHandler(TopicAreaCtrl.listTopicAreas));
 router.get("/:id", withErrorHandler(TopicAreaCtrl.getTopicAreaById));

--- a/backend/src/lib/api/user-api.ts
+++ b/backend/src/lib/api/user-api.ts
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import UserCtrl from "../controllers/user-ctrl";
 import withErrorHandler from "./middleware/error-handler";
+import auth from "./middleware/auth";
 
 const router = Router();
+router.use(auth);
 
 router.get("/", withErrorHandler(UserCtrl.getUsers));
 router.post("/", withErrorHandler(UserCtrl.addUsers));

--- a/backend/src/lib/controllers/__tests__/dashboard-ctrl.test.ts
+++ b/backend/src/lib/controllers/__tests__/dashboard-ctrl.test.ts
@@ -11,10 +11,8 @@ import DashboardCtrl from "../dashboard-ctrl";
 import DashboardFactory from "../../factories/dashboard-factory";
 import DashboardRepository from "../../repositories/dashboard-repo";
 import TopicAreaRepository from "../../repositories/topicarea-repo";
-import AuthService from "../../services/auth";
 import dashboardCtrl from "../dashboard-ctrl";
 
-jest.mock("../../services/auth");
 jest.mock("../../repositories/dashboard-repo");
 jest.mock("../../repositories/topicarea-repo");
 
@@ -24,7 +22,6 @@ const topicareaRepo = mocked(TopicAreaRepository.prototype);
 let res: Response;
 
 beforeEach(() => {
-  AuthService.getCurrentUser = jest.fn().mockReturnValue(user);
   DashboardRepository.getInstance = jest.fn().mockReturnValue(repository);
   TopicAreaRepository.getInstance = jest.fn().mockReturnValue(topicareaRepo);
 
@@ -39,19 +36,13 @@ describe("createDashboard", () => {
   let req: Request;
   beforeEach(() => {
     req = ({
+      user,
       body: {
         topicAreaId: "abc",
         name: "test",
         description: "description test",
       },
     } as any) as Request;
-  });
-
-  it("returns a 401 error when user is not authenticated", async () => {
-    AuthService.getCurrentUser = jest.fn().mockReturnValue(null);
-    await DashboardCtrl.createDashboard(req, res);
-    expect(res.status).toBeCalledWith(401);
-    expect(res.send).toBeCalledWith("Unauthorized");
   });
 
   it("returns a 400 error when topicAreaId is missing", async () => {
@@ -90,6 +81,7 @@ describe("updateDashboard", () => {
   jest.setSystemTime(now);
   beforeEach(() => {
     req = ({
+      user,
       params: {
         id: "123",
       },
@@ -100,13 +92,6 @@ describe("updateDashboard", () => {
         updatedAt: now.toISOString(),
       },
     } as any) as Request;
-  });
-
-  it("returns a 401 error when user is not authenticated", async () => {
-    AuthService.getCurrentUser = jest.fn().mockReturnValue(null);
-    await DashboardCtrl.updateDashboard(req, res);
-    expect(res.status).toBeCalledWith(401);
-    expect(res.send).toBeCalledWith("Unauthorized");
   });
 
   it("returns a 400 error when topicAreaId is invalid", async () => {
@@ -163,6 +148,7 @@ describe("publishDashboard", () => {
   jest.setSystemTime(now);
   beforeEach(() => {
     req = ({
+      user,
       params: {
         id: "123",
       },
@@ -171,13 +157,6 @@ describe("publishDashboard", () => {
         releaseNotes: "release note test",
       },
     } as any) as Request;
-  });
-
-  it("returns a 401 error when user is not authenticated", async () => {
-    AuthService.getCurrentUser = jest.fn().mockReturnValue(null);
-    await DashboardCtrl.publishDashboard(req, res);
-    expect(res.status).toBeCalledWith(401);
-    expect(res.send).toBeCalledWith("Unauthorized");
   });
 
   it("returns a 400 error when updatedAt is missing", async () => {
@@ -292,6 +271,7 @@ describe("publishPendingDashboard", () => {
   jest.setSystemTime(now);
   beforeEach(() => {
     req = ({
+      user,
       params: {
         id: "123",
       },
@@ -299,13 +279,6 @@ describe("publishPendingDashboard", () => {
         updatedAt: now.toISOString(),
       },
     } as any) as Request;
-  });
-
-  it("returns a 401 error when user is not authenticated", async () => {
-    AuthService.getCurrentUser = jest.fn().mockReturnValue(null);
-    await DashboardCtrl.publishPendingDashboard(req, res);
-    expect(res.status).toBeCalledWith(401);
-    expect(res.send).toBeCalledWith("Unauthorized");
   });
 
   it("returns a 400 error when updatedAt is missing", async () => {
@@ -368,6 +341,7 @@ describe("archiveDashboard", () => {
   jest.setSystemTime(now);
   beforeEach(() => {
     req = ({
+      user,
       params: {
         id: "123",
       },
@@ -375,13 +349,6 @@ describe("archiveDashboard", () => {
         updatedAt: now.toISOString(),
       },
     } as any) as Request;
-  });
-
-  it("returns a 401 error when user is not authenticated", async () => {
-    AuthService.getCurrentUser = jest.fn().mockReturnValue(null);
-    await DashboardCtrl.archiveDashboard(req, res);
-    expect(res.status).toBeCalledWith(401);
-    expect(res.send).toBeCalledWith("Unauthorized");
   });
 
   it("returns a 400 error when updatedAt is missing", async () => {
@@ -444,6 +411,7 @@ describe("moveToDraftDashboard", () => {
   jest.setSystemTime(now);
   beforeEach(() => {
     req = ({
+      user,
       params: {
         id: "123",
       },
@@ -451,13 +419,6 @@ describe("moveToDraftDashboard", () => {
         updatedAt: now.toISOString(),
       },
     } as any) as Request;
-  });
-
-  it("returns a 401 error when user is not authenticated", async () => {
-    AuthService.getCurrentUser = jest.fn().mockReturnValue(null);
-    await DashboardCtrl.moveToDraftDashboard(req, res);
-    expect(res.status).toBeCalledWith(401);
-    expect(res.send).toBeCalledWith("Unauthorized");
   });
 
   it("returns a 400 error when updatedAt is missing", async () => {
@@ -519,17 +480,11 @@ describe("deleteDashboard", () => {
   let req: Request;
   beforeEach(() => {
     req = ({
+      user,
       params: {
         id: "090b0410",
       },
     } as any) as Request;
-  });
-
-  it("returns a 401 error when user is not authenticated", async () => {
-    AuthService.getCurrentUser = jest.fn().mockReturnValue(null);
-    await DashboardCtrl.deleteDashboard(req, res);
-    expect(res.status).toBeCalledWith(401);
-    expect(res.send).toBeCalledWith("Unauthorized");
   });
 
   it("deletes the dashboard", async () => {
@@ -542,17 +497,11 @@ describe("deleteDashboards", () => {
   let req: Request;
   beforeEach(() => {
     req = ({
+      user,
       query: {
         ids: "090b0410,76546546",
       },
     } as any) as Request;
-  });
-
-  it("returns a 401 error when user is not authenticated", async () => {
-    AuthService.getCurrentUser = jest.fn().mockReturnValue(null);
-    await DashboardCtrl.deleteDashboards(req, res);
-    expect(res.status).toBeCalledWith(401);
-    expect(res.send).toBeCalledWith("Unauthorized");
   });
 
   it("returns a 400 error when ids is missing", async () => {
@@ -575,6 +524,7 @@ describe("getPublicDashboardById", () => {
   let req: Request;
   beforeEach(() => {
     req = ({
+      user,
       params: {
         id: "090b0410",
       },
@@ -646,6 +596,7 @@ describe("createNewDraft", () => {
   let dashboard: Dashboard;
   beforeEach(() => {
     req = ({
+      user,
       params: {
         id: "090b0410",
       },
@@ -709,6 +660,7 @@ describe("getVersions", () => {
   let dashboard: Dashboard;
   beforeEach(() => {
     req = ({
+      user,
       params: {
         id: "090b0410",
       },

--- a/backend/src/lib/controllers/__tests__/dataset-ctrl.test.ts
+++ b/backend/src/lib/controllers/__tests__/dataset-ctrl.test.ts
@@ -4,7 +4,6 @@ import { User } from "../../models/user";
 import DatasetCtrl from "../dataset-ctrl";
 import DatasetRepository from "../../repositories/dataset-repo";
 
-jest.mock("../../services/auth");
 jest.mock("../../repositories/dataset-repo");
 
 const user: User = { userId: "johndoe" };

--- a/backend/src/lib/controllers/__tests__/dataset-ctrl.test.ts
+++ b/backend/src/lib/controllers/__tests__/dataset-ctrl.test.ts
@@ -3,7 +3,6 @@ import { mocked } from "ts-jest/utils";
 import { User } from "../../models/user";
 import DatasetCtrl from "../dataset-ctrl";
 import DatasetRepository from "../../repositories/dataset-repo";
-import AuthService from "../../services/auth";
 
 jest.mock("../../services/auth");
 jest.mock("../../repositories/dataset-repo");
@@ -17,7 +16,6 @@ const res = ({
 } as any) as Response;
 
 beforeEach(() => {
-  AuthService.getCurrentUser = jest.fn().mockReturnValue(user);
   DatasetRepository.getInstance = jest.fn().mockReturnValue(repository);
 });
 
@@ -25,6 +23,7 @@ describe("createDataset", () => {
   let req: Request;
   beforeEach(() => {
     req = ({
+      user,
       body: {
         fileName: "covid-dataset.csv",
         s3Key: {
@@ -33,13 +32,6 @@ describe("createDataset", () => {
         },
       },
     } as any) as Request;
-  });
-
-  it("returns a 401 error when user is not authenticated", async () => {
-    AuthService.getCurrentUser = jest.fn().mockReturnValue(null);
-    await DatasetCtrl.createDataset(req, res);
-    expect(res.status).toBeCalledWith(401);
-    expect(res.send).toBeCalledWith("Unauthorized");
   });
 
   it("returns a 400 error when fileName is missing", async () => {

--- a/backend/src/lib/controllers/__tests__/homepage-ctrl.test.ts
+++ b/backend/src/lib/controllers/__tests__/homepage-ctrl.test.ts
@@ -11,7 +11,6 @@ import HomepageRepository from "../../repositories/homepage-repo";
 import DashboardRepository from "../../repositories/dashboard-repo";
 import DashboardFactory from "../../factories/dashboard-factory";
 import HomepageCtrl from "../homepage-ctrl";
-import AuthService from "../../services/auth";
 
 jest.mock("../../repositories/homepage-repo");
 jest.mock("../../repositories/dashboard-repo");
@@ -29,7 +28,6 @@ const res = ({
 } as any) as Response;
 
 beforeEach(() => {
-  AuthService.getCurrentUser = jest.fn().mockReturnValue(user);
   HomepageRepository.getInstance = jest.fn().mockReturnValue(repository);
   DashboardRepository.getInstance = jest.fn().mockReturnValue(dashboardRepo);
   dashboardRepo.listPublishedDashboards = jest.fn().mockReturnValue([]);
@@ -164,19 +162,13 @@ describe("updateHomepage", () => {
   jest.setSystemTime(now);
   beforeEach(() => {
     req = ({
+      user,
       body: {
         title: "abc",
         description: "description test",
         updatedAt: now.toISOString(),
       },
     } as any) as Request;
-  });
-
-  it("returns a 401 error when user is not authenticated", async () => {
-    AuthService.getCurrentUser = jest.fn().mockReturnValue(null);
-    await HomepageCtrl.updateHomepage(req, res);
-    expect(res.status).toBeCalledWith(401);
-    expect(res.send).toBeCalledWith("Unauthorized");
   });
 
   it("returns a 400 error when title is missing", async () => {

--- a/backend/src/lib/controllers/__tests__/settings-ctrl.test.ts
+++ b/backend/src/lib/controllers/__tests__/settings-ctrl.test.ts
@@ -4,9 +4,7 @@ import { User } from "../../models/user";
 import SettingsFactory from "../../factories/settings-factory";
 import SettingsRepository from "../../repositories/settings-repo";
 import SettingsCtrl from "../settings-ctrl";
-import AuthService from "../../services/auth";
 
-jest.mock("../../services/auth");
 jest.mock("../../repositories/settings-repo");
 jest.mock("../../factories/settings-factory");
 
@@ -16,7 +14,6 @@ const req = ({} as any) as Request;
 let res: Response;
 
 beforeEach(() => {
-  AuthService.getCurrentUser = jest.fn().mockReturnValue(user);
   SettingsRepository.getInstance = jest.fn().mockReturnValue(repository);
   res = ({
     send: jest.fn().mockReturnThis(),
@@ -26,13 +23,6 @@ beforeEach(() => {
 });
 
 describe("getSettings", () => {
-  it("returns a 401 error when user is not authenticated", async () => {
-    AuthService.getCurrentUser = jest.fn().mockReturnValue(null);
-    await SettingsCtrl.getSettings(req, res);
-    expect(res.status).toBeCalledWith(401);
-    expect(res.send).toBeCalledWith("Unauthorized");
-  });
-
   it("returns settings when available in the database", async () => {
     SettingsFactory.getDefaultSettings = jest.fn();
     repository.getSettings = jest.fn().mockReturnValueOnce({
@@ -58,17 +48,11 @@ describe("updateSettings", () => {
   jest.setSystemTime(now);
   beforeEach(() => {
     req = ({
+      user,
       body: {
         updatedAt: now.toISOString(),
       },
     } as any) as Request;
-  });
-
-  it("returns a 401 error when user is not authenticated", async () => {
-    AuthService.getCurrentUser = jest.fn().mockReturnValue(null);
-    await SettingsCtrl.updateSettings(req, res);
-    expect(res.status).toBeCalledWith(401);
-    expect(res.send).toBeCalledWith("Unauthorized");
   });
 
   it("returns a 400 error when updatedAt is not specified", async () => {

--- a/backend/src/lib/controllers/__tests__/topicarea-ctrl.test.ts
+++ b/backend/src/lib/controllers/__tests__/topicarea-ctrl.test.ts
@@ -2,11 +2,8 @@ import { Request, Response } from "express";
 import { mocked } from "ts-jest/utils";
 import { User } from "../../models/user";
 import TopicAreaCtrl from "../topicarea-ctrl";
-import TopicAreaFactory from "../../factories/topicarea-factory";
 import TopicAreaRepository from "../../repositories/topicarea-repo";
-import AuthService from "../../services/auth";
 
-jest.mock("../../services/auth");
 jest.mock("../../repositories/topicarea-repo");
 
 const user: User = { userId: "johndoe" };
@@ -18,7 +15,6 @@ const res = ({
 } as any) as Response;
 
 beforeEach(() => {
-  AuthService.getCurrentUser = jest.fn().mockReturnValue(user);
   TopicAreaRepository.getInstance = jest.fn().mockReturnValue(repository);
 });
 
@@ -26,6 +22,7 @@ describe("updateTopicArea", () => {
   let req: Request;
   beforeEach(() => {
     req = ({
+      user,
       params: {
         id: "3ffdb1ef-081d-4534-97e9-b69cdbb687d0",
       },
@@ -33,13 +30,6 @@ describe("updateTopicArea", () => {
         name: "New Name",
       },
     } as any) as Request;
-  });
-
-  it("returns a 401 error when user is not authenticated", async () => {
-    AuthService.getCurrentUser = jest.fn().mockReturnValue(null);
-    await TopicAreaCtrl.updateTopicArea(req, res);
-    expect(res.status).toBeCalledWith(401);
-    expect(res.send).toBeCalledWith("Unauthorized");
   });
 
   it("returns a 400 error when name is missing", async () => {
@@ -63,17 +53,11 @@ describe("deleteTopicArea", () => {
   let req: Request;
   beforeEach(() => {
     req = ({
+      user,
       params: {
         id: "3ffdb1ef-081d-4534-97e9-b69cdbb687d0",
       },
     } as any) as Request;
-  });
-
-  it("returns a 401 error when user is not authenticated", async () => {
-    AuthService.getCurrentUser = jest.fn().mockReturnValue(null);
-    await TopicAreaCtrl.deleteTopicArea(req, res);
-    expect(res.status).toBeCalledWith(401);
-    expect(res.send).toBeCalledWith("Unauthorized");
   });
 
   it("returns a 400 error when topicAreaId is missing", async () => {

--- a/backend/src/lib/controllers/__tests__/user-ctrl.test.ts
+++ b/backend/src/lib/controllers/__tests__/user-ctrl.test.ts
@@ -3,10 +3,8 @@ import { mocked } from "ts-jest/utils";
 import { Role, User } from "../../models/user";
 import UserRepository from "../../repositories/user-repo";
 import UserCtrl from "../user-ctrl";
-import AuthService from "../../services/auth";
 import UserFactory from "../../factories/user-factory";
 
-jest.mock("../../services/auth");
 jest.mock("../../repositories/user-repo");
 jest.mock("../../factories/user-factory");
 
@@ -16,7 +14,6 @@ const req = ({} as any) as Request;
 let res: Response;
 
 beforeEach(() => {
-  AuthService.getCurrentUser = jest.fn().mockReturnValue(user);
   UserRepository.getInstance = jest.fn().mockReturnValue(repository);
   res = ({
     send: jest.fn().mockReturnThis(),
@@ -29,18 +26,12 @@ describe("addUser", () => {
   let req: Request;
   beforeEach(() => {
     req = ({
+      user,
       body: {
         role: "Admin",
         emails: "test1@test.com,test2@test.com",
       },
     } as any) as Request;
-  });
-
-  it("returns a 401 error when user is not authenticated", async () => {
-    AuthService.getCurrentUser = jest.fn().mockReturnValue(null);
-    await UserCtrl.addUsers(req, res);
-    expect(res.status).toBeCalledWith(401);
-    expect(res.send).toBeCalledWith("Unauthorized");
   });
 
   it("returns a 400 error when role is missing", async () => {
@@ -87,17 +78,11 @@ describe("resendInvite", () => {
   let req: Request;
   beforeEach(() => {
     req = ({
+      user,
       body: {
         emails: "test1@test.com,test2@test.com",
       },
     } as any) as Request;
-  });
-
-  it("returns a 401 error when user is not authenticated", async () => {
-    AuthService.getCurrentUser = jest.fn().mockReturnValue(null);
-    await UserCtrl.resendInvite(req, res);
-    expect(res.status).toBeCalledWith(401);
-    expect(res.send).toBeCalledWith("Unauthorized");
   });
 
   it("returns a 400 error when emails is missing", async () => {
@@ -124,18 +109,12 @@ describe("changeRole", () => {
   let req: Request;
   beforeEach(() => {
     req = ({
+      user,
       body: {
         role: "Editor",
         emails: "test1@test.com,test2@test.com",
       },
     } as any) as Request;
-  });
-
-  it("returns a 401 error when user is not authenticated", async () => {
-    AuthService.getCurrentUser = jest.fn().mockReturnValue(null);
-    await UserCtrl.changeRole(req, res);
-    expect(res.status).toBeCalledWith(401);
-    expect(res.send).toBeCalledWith("Unauthorized");
   });
 
   it("returns a 400 error when role is missing", async () => {
@@ -176,13 +155,6 @@ describe("changeRole", () => {
 });
 
 describe("getUsers", () => {
-  it("returns a 401 error when user is not authenticated", async () => {
-    AuthService.getCurrentUser = jest.fn().mockReturnValue(null);
-    await UserCtrl.getUsers(req, res);
-    expect(res.status).toBeCalledWith(401);
-    expect(res.send).toBeCalledWith("Unauthorized");
-  });
-
   it("returns users when available in cognito", async () => {
     const now = new Date();
     jest.useFakeTimers("modern");

--- a/backend/src/lib/controllers/__tests__/widget-ctrl.test.ts
+++ b/backend/src/lib/controllers/__tests__/widget-ctrl.test.ts
@@ -5,11 +5,8 @@ import WidgetCtrl from "../widget-ctrl";
 import WidgetFactory from "../../factories/widget-factory";
 import WidgetRepository from "../../repositories/widget-repo";
 import { WidgetType } from "../../models/widget";
-import AuthService from "../../services/auth";
 import DashboardRepository from "../../repositories/dashboard-repo";
-import widgetFactory from "../../factories/widget-factory";
 
-jest.mock("../../services/auth");
 jest.mock("../../repositories/widget-repo");
 jest.mock("../../repositories/dashboard-repo");
 
@@ -23,7 +20,6 @@ const res = ({
 } as any) as Response;
 
 beforeEach(() => {
-  AuthService.getCurrentUser = jest.fn().mockReturnValue(user);
   WidgetRepository.getInstance = jest.fn().mockReturnValue(repository);
   DashboardRepository.getInstance = jest.fn().mockReturnValue(dashboardRepo);
 });
@@ -32,6 +28,7 @@ describe("createWidget", () => {
   let req: Request;
   beforeEach(() => {
     req = ({
+      user,
       params: {
         id: "090b0410",
       },
@@ -43,13 +40,6 @@ describe("createWidget", () => {
         },
       },
     } as any) as Request;
-  });
-
-  it("returns a 401 error when user is not authenticated", async () => {
-    AuthService.getCurrentUser = jest.fn().mockReturnValue(null);
-    await WidgetCtrl.createWidget(req, res);
-    expect(res.status).toBeCalledWith(401);
-    expect(res.send).toBeCalledWith("Unauthorized");
   });
 
   it("returns a 400 error when dashboardId is missing", async () => {
@@ -104,6 +94,7 @@ describe("updateWidget", () => {
   jest.setSystemTime(now);
   beforeEach(() => {
     req = ({
+      user,
       params: {
         id: "090b0410",
         widgetId: "14507073",
@@ -117,13 +108,6 @@ describe("updateWidget", () => {
         },
       },
     } as any) as Request;
-  });
-
-  it("returns a 401 error when user is not authenticated", async () => {
-    AuthService.getCurrentUser = jest.fn().mockReturnValue(null);
-    await WidgetCtrl.updateWidget(req, res);
-    expect(res.status).toBeCalledWith(401);
-    expect(res.send).toBeCalledWith("Unauthorized");
   });
 
   it("returns a 400 error when dashboardId is missing", async () => {
@@ -180,18 +164,12 @@ describe("deleteWidget", () => {
   let req: Request;
   beforeEach(() => {
     req = ({
+      user,
       params: {
         id: "090b0410",
         widgetId: "14507073",
       },
     } as any) as Request;
-  });
-
-  it("returns a 401 error when user is not authenticated", async () => {
-    AuthService.getCurrentUser = jest.fn().mockReturnValue(null);
-    await WidgetCtrl.deleteWidget(req, res);
-    expect(res.status).toBeCalledWith(401);
-    expect(res.send).toBeCalledWith("Unauthorized");
   });
 
   it("returns a 400 error when dashboardId is missing", async () => {
@@ -218,6 +196,7 @@ describe("setWidgetOrder", () => {
   let req: Request;
   beforeEach(() => {
     req = ({
+      user,
       params: { id: "090b0410" },
       body: {
         widgets: [
@@ -234,13 +213,6 @@ describe("setWidgetOrder", () => {
         ],
       },
     } as any) as Request;
-  });
-
-  it("returns a 401 error when user is not authenticated", async () => {
-    AuthService.getCurrentUser = jest.fn().mockReturnValue(null);
-    await WidgetCtrl.setWidgetOrder(req, res);
-    expect(res.status).toBeCalledWith(401);
-    expect(res.send).toBeCalledWith("Unauthorized");
   });
 
   it("returns a 400 error when dashboardId is missing", async () => {

--- a/backend/src/lib/controllers/dashboard-ctrl.ts
+++ b/backend/src/lib/controllers/dashboard-ctrl.ts
@@ -2,31 +2,17 @@ import { Request, Response } from "express";
 import { ItemNotFound } from "../errors";
 import { Dashboard, DashboardState } from "../models/dashboard";
 import DashboardFactory from "../factories/dashboard-factory";
-import AuthService from "../services/auth";
 import DashboardRepository from "../repositories/dashboard-repo";
 import TopicAreaRepository from "../repositories/topicarea-repo";
 
 async function listDashboards(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-
-  if (!user) {
-    res.status(401).send("Unauthorized");
-    return;
-  }
-
   const repo = DashboardRepository.getInstance();
   const dashboards = await repo.listDashboards();
   res.json(dashboards);
 }
 
 async function createDashboard(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-
-  if (!user) {
-    res.status(401).send("Unauthorized");
-    return;
-  }
-
+  const user = req.user;
   const { topicAreaId, name, description } = req.body;
 
   if (!topicAreaId) {
@@ -56,12 +42,6 @@ async function createDashboard(req: Request, res: Response) {
 }
 
 async function getDashboardById(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-  if (!user) {
-    res.status(401);
-    return res.send("Unauthorized");
-  }
-
   const { id } = req.params;
   const repo = DashboardRepository.getInstance();
 
@@ -131,12 +111,6 @@ async function getPublicDashboardById(req: Request, res: Response) {
 }
 
 async function getVersions(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-  if (!user) {
-    res.status(401);
-    return res.send("Unauthorized");
-  }
-
   const { id } = req.params;
   const repo = DashboardRepository.getInstance();
 
@@ -154,13 +128,7 @@ async function getVersions(req: Request, res: Response) {
 }
 
 async function updateDashboard(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-
-  if (!user) {
-    res.status(401).send("Unauthorized");
-    return;
-  }
-
+  const user = req.user;
   const { id } = req.params;
   const { name, topicAreaId, description, updatedAt } = req.body;
 
@@ -206,13 +174,7 @@ async function updateDashboard(req: Request, res: Response) {
 }
 
 async function publishDashboard(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-
-  if (!user) {
-    res.status(401).send("Unauthorized");
-    return;
-  }
-
+  const user = req.user;
   const { id } = req.params;
   const { updatedAt, releaseNotes } = req.body;
 
@@ -260,13 +222,7 @@ async function publishDashboard(req: Request, res: Response) {
 }
 
 async function publishPendingDashboard(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-
-  if (!user) {
-    res.status(401).send("Unauthorized");
-    return;
-  }
-
+  const user = req.user;
   const { id } = req.params;
   const { updatedAt } = req.body;
 
@@ -288,13 +244,7 @@ async function publishPendingDashboard(req: Request, res: Response) {
 }
 
 async function archiveDashboard(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-
-  if (!user) {
-    res.status(401).send("Unauthorized");
-    return;
-  }
-
+  const user = req.user;
   const { id } = req.params;
   const { updatedAt } = req.body;
 
@@ -316,13 +266,7 @@ async function archiveDashboard(req: Request, res: Response) {
 }
 
 async function moveToDraftDashboard(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-
-  if (!user) {
-    res.status(401).send("Unauthorized");
-    return;
-  }
-
+  const user = req.user;
   const { id } = req.params;
   const { updatedAt } = req.body;
 
@@ -344,13 +288,6 @@ async function moveToDraftDashboard(req: Request, res: Response) {
 }
 
 async function deleteDashboard(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-
-  if (!user) {
-    res.status(401).send("Unauthorized");
-    return;
-  }
-
   const { id } = req.params;
 
   const repo = DashboardRepository.getInstance();
@@ -359,13 +296,6 @@ async function deleteDashboard(req: Request, res: Response) {
 }
 
 async function deleteDashboards(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-
-  if (!user) {
-    res.status(401).send("Unauthorized");
-    return;
-  }
-
   const { ids } = req.query;
 
   if (!ids) {
@@ -381,13 +311,7 @@ async function deleteDashboards(req: Request, res: Response) {
 }
 
 async function createNewDraft(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-
-  if (!user) {
-    res.status(401).send("Unauthorized");
-    return;
-  }
-
+  const user = req.user;
   const { id } = req.params;
   const repo = DashboardRepository.getInstance();
 

--- a/backend/src/lib/controllers/dataset-ctrl.ts
+++ b/backend/src/lib/controllers/dataset-ctrl.ts
@@ -1,30 +1,16 @@
 import { Request, Response } from "express";
-import AuthService from "../services/auth";
 import DatasetRepository from "../repositories/dataset-repo";
 import DatasetFactory from "../factories/dataset-factory";
 import { SourceType } from "../models/dataset";
 import { ItemNotFound } from "../errors";
 
 async function listDatasets(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-
-  if (!user) {
-    res.status(401).send("Unauthorized");
-    return;
-  }
-
   const repo = DatasetRepository.getInstance();
   const datasets = await repo.listDatasets();
   res.json(datasets);
 }
 
 async function getDatasetById(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-  if (!user) {
-    res.status(401);
-    return res.send("Unauthorized");
-  }
-
   const { id } = req.params;
   const repo = DatasetRepository.getInstance();
 
@@ -41,11 +27,7 @@ async function getDatasetById(req: Request, res: Response) {
 }
 
 async function createDataset(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-  if (!user) {
-    return res.status(401).send("Unauthorized");
-  }
-
+  const user = req.user;
   const { fileName, s3Key } = req.body;
   if (!fileName) {
     return res.status(400).send("Missing required field `fileName`");

--- a/backend/src/lib/controllers/homepage-ctrl.ts
+++ b/backend/src/lib/controllers/homepage-ctrl.ts
@@ -37,13 +37,7 @@ async function getHomepage(req: Request, res: Response) {
 }
 
 async function updateHomepage(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-
-  if (!user) {
-    res.status(401).send("Unauthorized");
-    return;
-  }
-
+  const user = req.user;
   const { title, description, updatedAt } = req.body;
 
   if (!title) {

--- a/backend/src/lib/controllers/settings-ctrl.ts
+++ b/backend/src/lib/controllers/settings-ctrl.ts
@@ -4,13 +4,6 @@ import SettingsRepository from "../repositories/settings-repo";
 import AuthService from "../services/auth";
 
 async function getSettings(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-
-  if (!user) {
-    res.status(401);
-    return res.send("Unauthorized");
-  }
-
   const repo = SettingsRepository.getInstance();
   const settings = await repo.getSettings();
 
@@ -18,14 +11,9 @@ async function getSettings(req: Request, res: Response) {
 }
 
 async function updateSettings(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-
-  if (!user) {
-    res.status(401).send("Unauthorized");
-    return;
-  }
-
+  const user = req.user;
   let { updatedAt } = req.body;
+
   const {
     publishingGuidance,
     dateTimeFormat,

--- a/backend/src/lib/controllers/topicarea-ctrl.ts
+++ b/backend/src/lib/controllers/topicarea-ctrl.ts
@@ -1,29 +1,16 @@
 import { Request, Response } from "express";
 import TopicAreaFactory from "../factories/topicarea-factory";
-import AuthService from "../services/auth";
 import TopicAreaRepository from "../repositories/topicarea-repo";
 
 async function listTopicAreas(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-
-  if (!user) {
-    res.status(401).send("Unauthorized");
-    return;
-  }
-
   const repo = TopicAreaRepository.getInstance();
   const topicareas = await repo.list();
   res.json(topicareas);
 }
 
 async function createTopicArea(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
+  const user = req.user;
   const { name } = req.body;
-
-  if (!user) {
-    res.status(401).send("Unauthorized");
-    return;
-  }
 
   if (!name) {
     res.status(400).send("Missing required field `name`");
@@ -38,13 +25,6 @@ async function createTopicArea(req: Request, res: Response) {
 }
 
 async function getTopicAreaById(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-
-  if (!user) {
-    res.status(401).send("Unauthorized");
-    return;
-  }
-
   const { id } = req.params;
 
   if (!id) {
@@ -58,14 +38,8 @@ async function getTopicAreaById(req: Request, res: Response) {
 }
 
 async function updateTopicArea(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
   const { id } = req.params;
   const { name } = req.body;
-
-  if (!user) {
-    res.status(401).send("Unauthorized");
-    return;
-  }
 
   if (!name) {
     res.status(400).send("Missing required field `name`");
@@ -78,13 +52,7 @@ async function updateTopicArea(req: Request, res: Response) {
 }
 
 async function deleteTopicArea(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
   const { id } = req.params;
-
-  if (!user) {
-    res.status(401).send("Unauthorized");
-    return;
-  }
 
   if (!id) {
     res.status(400).send("Missing required param `id`");

--- a/backend/src/lib/controllers/user-ctrl.ts
+++ b/backend/src/lib/controllers/user-ctrl.ts
@@ -1,17 +1,9 @@
 import { Request, Response } from "express";
 import UserRepository from "../repositories/user-repo";
 import UserFactory from "../factories/user-factory";
-import AuthService from "../services/auth";
 import { Role } from "../models/user";
 
 async function getUsers(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-
-  if (!user) {
-    res.status(401);
-    return res.send("Unauthorized");
-  }
-
   const repo = UserRepository.getInstance();
   try {
     const users = await repo.listUsers();
@@ -22,13 +14,6 @@ async function getUsers(req: Request, res: Response) {
 }
 
 async function addUsers(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-
-  if (!user) {
-    res.status(401);
-    return res.send("Unauthorized");
-  }
-
   const { role, emails } = req.body;
 
   if (!role) {
@@ -67,13 +52,6 @@ async function addUsers(req: Request, res: Response) {
 }
 
 async function resendInvite(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-
-  if (!user) {
-    res.status(401);
-    return res.send("Unauthorized");
-  }
-
   const { emails } = req.body;
 
   if (!emails) {
@@ -100,13 +78,6 @@ async function resendInvite(req: Request, res: Response) {
 }
 
 async function changeRole(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-
-  if (!user) {
-    res.status(401);
-    return res.send("Unauthorized");
-  }
-
   const { role, emails } = req.body;
 
   if (!role) {

--- a/backend/src/lib/controllers/widget-ctrl.ts
+++ b/backend/src/lib/controllers/widget-ctrl.ts
@@ -1,17 +1,9 @@
 import { Request, Response } from "express";
-import AuthService from "../services/auth";
 import WidgetFactory from "../factories/widget-factory";
 import WidgetRepository from "../repositories/widget-repo";
 import DashboardRepository from "../repositories/dashboard-repo";
 
 async function getWidgetById(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-
-  if (!user) {
-    res.status(401).send("Unauthorized");
-    return;
-  }
-
   const { id, widgetId } = req.params;
 
   if (!id) {
@@ -30,12 +22,7 @@ async function getWidgetById(req: Request, res: Response) {
 }
 
 async function createWidget(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-  if (!user) {
-    res.status(401).send("Unauthorized");
-    return;
-  }
-
+  const user = req.user;
   const dashboardId = req.params.id;
   if (!dashboardId) {
     res.status(400).send("Missing required field `id`");
@@ -83,12 +70,7 @@ async function createWidget(req: Request, res: Response) {
 }
 
 async function updateWidget(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-  if (!user) {
-    res.status(401).send("Unauthorized");
-    return;
-  }
-
+  const user = req.user;
   const dashboardId = req.params.id;
   if (!dashboardId) {
     res.status(400).send("Missing required field `id`");
@@ -133,12 +115,6 @@ async function updateWidget(req: Request, res: Response) {
 }
 
 async function deleteWidget(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-  if (!user) {
-    res.status(401).send("Unauthorized");
-    return;
-  }
-
   const dashboardId = req.params.id;
   const widgetId = req.params.widgetId;
 
@@ -158,12 +134,7 @@ async function deleteWidget(req: Request, res: Response) {
 }
 
 async function setWidgetOrder(req: Request, res: Response) {
-  const user = AuthService.getCurrentUser(req);
-  if (!user) {
-    res.status(401).send("Unauthorized");
-    return;
-  }
-
+  const user = req.user;
   const dashboardId = req.params.id;
   const { widgets } = req.body;
 

--- a/backend/src/lib/types/express/index.d.ts
+++ b/backend/src/lib/types/express/index.d.ts
@@ -1,0 +1,9 @@
+import { User } from "../../models/user";
+
+declare global {
+  namespace Express {
+    interface Request {
+      user: User;
+    }
+  }
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,23 +1,16 @@
 {
-    "compilerOptions": {
-      "module": "commonjs",
-      "target": "es6",
-      "strict": true,
-      "baseUrl": "./",
-      "outDir": "build",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "inlineSourceMap": true,
-      "resolveJsonModule": true,
-      "types": [
-        "node",
-        "jest",
-      ],
-      "typeRoots": [
-        "node_modules/@types"
-      ]
-    },
-    "include": [
-      "./src/**/*.ts"
-    ]
-  }
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "strict": true,
+    "baseUrl": "./",
+    "outDir": "build",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "inlineSourceMap": true,
+    "resolveJsonModule": true,
+    "types": ["node", "jest"],
+    "typeRoots": ["./src/lib/types", "node_modules/@types"]
+  },
+  "include": ["./src/**/*.ts"]
+}


### PR DESCRIPTION
## Description

In preparation for enforcing User roles in the Backend. I created a middleware that extracts the user from the JWT token and adds it to the `Request` object from expressjs so that Controllers can use it. This will make it easier for my next PR to implement a middleware for Role-Based Access Control. 

**Note:** We no longer need to validate if the user is present in our controllers. We can assume that if a Controller function is invoked, is because it already passed the authentication validation.  

## Testing

Deployed to my personal environment and ran the integration test suite to verify nothing broke. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
