### PR TITLE
GTT-841 Role-based access control in Backend

### DIFF
--- a/backend/src/lib/api/dashboard-api.ts
+++ b/backend/src/lib/api/dashboard-api.ts
@@ -1,34 +1,114 @@
 import { Router } from "express";
+import { Role } from "../models/user";
 import DashboardCtrl from "../controllers/dashboard-ctrl";
 import WidgetCtrl from "../controllers/widget-ctrl";
-import withErrorHandler from "./middleware/error-handler";
+import errorHandler from "./middleware/error-handler";
 import auth from "./middleware/auth";
+import rbac from "./middleware/rbac";
 
 const router = Router();
 router.use(auth);
 
-router.get("/", withErrorHandler(DashboardCtrl.listDashboards));
-router.get("/:id", withErrorHandler(DashboardCtrl.getDashboardById));
-router.get("/:id/versions", withErrorHandler(DashboardCtrl.getVersions));
-router.post("/:id", withErrorHandler(DashboardCtrl.createNewDraft));
-router.post("/", withErrorHandler(DashboardCtrl.createDashboard));
-router.put("/:id/publish", withErrorHandler(DashboardCtrl.publishDashboard));
+router.get(
+  "/",
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(DashboardCtrl.listDashboards)
+);
+
+router.get(
+  "/:id",
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(DashboardCtrl.getDashboardById)
+);
+
+router.get(
+  "/:id/versions",
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(DashboardCtrl.getVersions)
+);
+
+router.post(
+  "/:id",
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(DashboardCtrl.createNewDraft)
+);
+
+router.post(
+  "/",
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(DashboardCtrl.createDashboard)
+);
+
+router.put(
+  "/:id/publish",
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(DashboardCtrl.publishDashboard)
+);
+
 router.put(
   "/:id/publishpending",
-  withErrorHandler(DashboardCtrl.publishPendingDashboard)
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(DashboardCtrl.publishPendingDashboard)
 );
-router.put("/:id/archive", withErrorHandler(DashboardCtrl.archiveDashboard));
-router.put("/:id/draft", withErrorHandler(DashboardCtrl.moveToDraftDashboard));
-router.put("/:id/widgetorder", withErrorHandler(WidgetCtrl.setWidgetOrder));
-router.put("/:id", withErrorHandler(DashboardCtrl.updateDashboard));
-router.delete("/", withErrorHandler(DashboardCtrl.deleteDashboards));
-router.delete("/:id", withErrorHandler(DashboardCtrl.deleteDashboard));
-router.post("/:id/widget", withErrorHandler(WidgetCtrl.createWidget));
-router.get("/:id/widget/:widgetId", withErrorHandler(WidgetCtrl.getWidgetById));
-router.put("/:id/widget/:widgetId", withErrorHandler(WidgetCtrl.updateWidget));
+
+router.put(
+  "/:id/archive",
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(DashboardCtrl.archiveDashboard)
+);
+
+router.put(
+  "/:id/draft",
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(DashboardCtrl.moveToDraftDashboard)
+);
+
+router.put(
+  "/:id/widgetorder",
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(WidgetCtrl.setWidgetOrder)
+);
+
+router.put(
+  "/:id",
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(DashboardCtrl.updateDashboard)
+);
+
+router.delete(
+  "/",
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(DashboardCtrl.deleteDashboards)
+);
+
+router.delete(
+  "/:id",
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(DashboardCtrl.deleteDashboard)
+);
+
+router.post(
+  "/:id/widget",
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(WidgetCtrl.createWidget)
+);
+
+router.get(
+  "/:id/widget/:widgetId",
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(WidgetCtrl.getWidgetById)
+);
+
+router.put(
+  "/:id/widget/:widgetId",
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(WidgetCtrl.updateWidget)
+);
+
 router.delete(
   "/:id/widget/:widgetId",
-  withErrorHandler(WidgetCtrl.deleteWidget)
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(WidgetCtrl.deleteWidget)
 );
 
 export default router;

--- a/backend/src/lib/api/dataset-api.ts
+++ b/backend/src/lib/api/dataset-api.ts
@@ -1,13 +1,29 @@
 import { Router } from "express";
+import { Role } from "../models/user";
 import DatasetCtrl from "../controllers/dataset-ctrl";
-import withErrorHandler from "./middleware/error-handler";
+import errorHandler from "./middleware/error-handler";
 import auth from "./middleware/auth";
+import rbac from "./middleware/rbac";
 
 const router = Router();
 router.use(auth);
 
-router.get("/", withErrorHandler(DatasetCtrl.listDatasets));
-router.get("/:id", withErrorHandler(DatasetCtrl.getDatasetById));
-router.post("/", withErrorHandler(DatasetCtrl.createDataset));
+router.get(
+  "/",
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(DatasetCtrl.listDatasets)
+);
+
+router.get(
+  "/:id",
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(DatasetCtrl.getDatasetById)
+);
+
+router.post(
+  "/",
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(DatasetCtrl.createDataset)
+);
 
 export default router;

--- a/backend/src/lib/api/ingest-api.ts
+++ b/backend/src/lib/api/ingest-api.ts
@@ -1,11 +1,11 @@
 import { Router } from "express";
 import IngestApiCtrl from "../controllers/ingestapi-ctrl";
-import withErrorHandler from "./middleware/error-handler";
+import errorHandler from "./middleware/error-handler";
 
 const router = Router();
 
-router.post("/dataset", withErrorHandler(IngestApiCtrl.createDataset));
-router.put("/dataset/:id", withErrorHandler(IngestApiCtrl.updateDataset));
-router.delete("/dataset/:id", withErrorHandler(IngestApiCtrl.deleteDataset));
+router.post("/dataset", errorHandler(IngestApiCtrl.createDataset));
+router.put("/dataset/:id", errorHandler(IngestApiCtrl.updateDataset));
+router.delete("/dataset/:id", errorHandler(IngestApiCtrl.deleteDataset));
 
 export default router;

--- a/backend/src/lib/api/middleware/__tests__/error-handler.test.ts
+++ b/backend/src/lib/api/middleware/__tests__/error-handler.test.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import withErrorHandler from "../error-handler";
+import errorHandler from "../error-handler";
 
 const successfulRouteHandler = jest.fn(() => Promise.resolve());
 const failedRouteHandler = jest.fn(() => Promise.reject("error"));
@@ -12,13 +12,13 @@ const res = {
 
 describe("withErrorHandler", () => {
   it("calls the route handler", async () => {
-    await withErrorHandler(successfulRouteHandler)(req, res);
+    await errorHandler(successfulRouteHandler)(req, res);
     expect(successfulRouteHandler).toBeCalled();
   });
 
   it("handles error and returns a 500 error", async () => {
     console.error = jest.fn();
-    await withErrorHandler(failedRouteHandler)(req, res);
+    await errorHandler(failedRouteHandler)(req, res);
     expect(res.status).toBeCalledWith(500);
     expect(console.error).toBeCalledWith("error");
     expect(res.send).toBeCalledWith("Internal server error");

--- a/backend/src/lib/api/middleware/__tests__/rbac.test.ts
+++ b/backend/src/lib/api/middleware/__tests__/rbac.test.ts
@@ -1,0 +1,81 @@
+import { User, Role } from "../../../models/user";
+import rbac from "../rbac";
+
+let req: any;
+let res: any;
+let next = jest.fn();
+let user: User;
+
+beforeEach(() => {
+  req = {
+    path: "/dashboard",
+  };
+  res = {
+    status: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+  };
+  next = jest.fn();
+  user = {
+    userId: "johndoe",
+    roles: [],
+  };
+});
+
+test("should return a 401 when user is not available", () => {
+  rbac()(req, res, next);
+  expect(res.status).toBeCalledWith(401);
+  expect(res.send).toBeCalledWith("Unauthorized");
+  expect(next).not.toBeCalled();
+});
+
+test("should return a 403 when user does not have role assigned", () => {
+  user.roles = undefined;
+  req.user = user;
+
+  rbac()(req, res, next);
+
+  expect(res.status).toBeCalledWith(403);
+  expect(res.send).toBeCalledWith("User johndoe does not have a role assigned");
+  expect(next).not.toBeCalled();
+});
+
+test("should return a 403 when user's roles are not allowed", () => {
+  user.roles = [Role.Editor];
+  req.user = user;
+
+  const allowedRoles = [Role.Publisher];
+  rbac(...allowedRoles)(req, res, next);
+
+  expect(res.status).toBeCalledWith(403);
+  expect(next).not.toBeCalled();
+  expect(res.send).toBeCalledWith(
+    "User johndoe is not authorized to access /dashboard"
+  );
+});
+
+test("should return a 403 when no allowedRoles provided", () => {
+  // Regardless if the user is an admin. If the rbac() middleware
+  // specifies no allowed roles. The request should be denied.
+  user.roles = [Role.Admin, Role.Editor, Role.Publisher];
+  req.user = user;
+
+  // No allowed roles
+  rbac()(req, res, next);
+
+  expect(res.status).toBeCalledWith(403);
+  expect(next).not.toBeCalled();
+  expect(res.send).toBeCalledWith(
+    "User johndoe is not authorized to access /dashboard"
+  );
+});
+
+test("should allow the user to proceed if it has the appropriate role", () => {
+  user.roles = [Role.Admin, Role.Editor];
+  req.user = user;
+
+  const allowedRoles = [Role.Editor];
+  rbac(...allowedRoles)(req, res, next);
+
+  expect(next).toBeCalled();
+  expect(res.send).not.toBeCalled();
+});

--- a/backend/src/lib/api/middleware/error-handler.ts
+++ b/backend/src/lib/api/middleware/error-handler.ts
@@ -14,10 +14,7 @@ import { ItemNotFound } from "../../errors/index";
  * validation or access denied errors should be handled gracefully by
  * the controllers and return appropriate HTTP status codes.
  */
-const withErrorHandler = (fn: Function) => async (
-  req: Request,
-  res: Response
-) => {
+const errorHandler = (fn: Function) => async (req: Request, res: Response) => {
   Promise.resolve(fn(req, res)).catch((err) => {
     console.error(err);
 
@@ -31,4 +28,4 @@ const withErrorHandler = (fn: Function) => async (
   });
 };
 
-export default withErrorHandler;
+export default errorHandler;

--- a/backend/src/lib/api/middleware/rbac.ts
+++ b/backend/src/lib/api/middleware/rbac.ts
@@ -1,0 +1,41 @@
+import { Request, Response, NextFunction } from "express";
+import { Role } from "../../models/user";
+
+/**
+ * Role-based access control (RBAC) middleware.
+ * Assumes that the `auth` middleware has already placed
+ * the user in the Request object.
+ */
+const rbac = (...allowedRoles: Role[]) =>
+  function (req: Request, res: Response, next: NextFunction) {
+    const user = req.user;
+    if (!user) {
+      // This technically should not happen. If the request got
+      // all the way to this middleware, the user should already
+      // be in the request object. But just in case ...
+      return res.status(401).send("Unauthorized");
+    }
+
+    if (!user.roles) {
+      return res
+        .status(403)
+        .send(`User ${user.userId} does not have a role assigned`);
+    }
+
+    // Get the intersection of the Allowed Roles and the user's roles.
+    // i.e. User has roles [A,B] and AllowedRoles are [B].
+    // Intersection should return B, hence the request should be allowed.
+    const intersection = user.roles.filter((role) =>
+      allowedRoles.includes(role)
+    );
+
+    if (intersection.length === 0) {
+      return res
+        .status(403)
+        .send(`User ${user.userId} is not authorized to access ${req.path}`);
+    }
+
+    next();
+  };
+
+export default rbac;

--- a/backend/src/lib/api/public-api.ts
+++ b/backend/src/lib/api/public-api.ts
@@ -2,21 +2,21 @@ import { Router } from "express";
 import DashboardCtrl from "../controllers/dashboard-ctrl";
 import HomepageCtrl from "../controllers/homepage-ctrl";
 import SettingsCtrl from "../controllers/settings-ctrl";
-import withErrorHandler from "./middleware/error-handler";
+import errorHandler from "./middleware/error-handler";
 
 const router = Router();
 
 router.get(
   "/dashboard/:id",
-  withErrorHandler(DashboardCtrl.getPublicDashboardById)
+  errorHandler(DashboardCtrl.getPublicDashboardById)
 );
 
 router.get(
   "/dashboard/friendly-url/:friendlyURL",
-  withErrorHandler(DashboardCtrl.getPublicDashboardByFriendlyURL)
+  errorHandler(DashboardCtrl.getPublicDashboardByFriendlyURL)
 );
 
-router.get("/homepage", withErrorHandler(HomepageCtrl.getPublicHomepage));
-router.get("/settings", withErrorHandler(SettingsCtrl.getPublicSettings));
+router.get("/homepage", errorHandler(HomepageCtrl.getPublicHomepage));
+router.get("/settings", errorHandler(SettingsCtrl.getPublicSettings));
 
 export default router;

--- a/backend/src/lib/api/settings-api.ts
+++ b/backend/src/lib/api/settings-api.ts
@@ -1,15 +1,32 @@
 import { Router } from "express";
+import { Role } from "../models/user";
 import SettingsCtrl from "../controllers/settings-ctrl";
-import withErrorHandler from "./middleware/error-handler";
+import errorHandler from "./middleware/error-handler";
 import HomepageCtrl from "../controllers/homepage-ctrl";
 import auth from "./middleware/auth";
+import rbac from "./middleware/rbac";
 
 const router = Router();
 router.use(auth);
 
-router.get("/", withErrorHandler(SettingsCtrl.getSettings));
-router.put("/", withErrorHandler(SettingsCtrl.updateSettings));
-router.get("/homepage", withErrorHandler(HomepageCtrl.getHomepage));
-router.put("/homepage", withErrorHandler(HomepageCtrl.updateHomepage));
+router.get(
+  "/",
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(SettingsCtrl.getSettings)
+);
+
+router.put("/", rbac(Role.Admin), errorHandler(SettingsCtrl.updateSettings));
+
+router.get(
+  "/homepage",
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(HomepageCtrl.getHomepage)
+);
+
+router.put(
+  "/homepage",
+  rbac(Role.Admin),
+  errorHandler(HomepageCtrl.updateHomepage)
+);
 
 export default router;

--- a/backend/src/lib/api/topicarea-api.ts
+++ b/backend/src/lib/api/topicarea-api.ts
@@ -1,15 +1,37 @@
 import { Router } from "express";
+import { Role } from "../models/user";
 import TopicAreaCtrl from "../controllers/topicarea-ctrl";
-import withErrorHandler from "./middleware/error-handler";
+import errorHandler from "./middleware/error-handler";
 import auth from "./middleware/auth";
+import rbac from "./middleware/rbac";
 
 const router = Router();
 router.use(auth);
 
-router.get("/", withErrorHandler(TopicAreaCtrl.listTopicAreas));
-router.get("/:id", withErrorHandler(TopicAreaCtrl.getTopicAreaById));
-router.post("/", withErrorHandler(TopicAreaCtrl.createTopicArea));
-router.put("/:id", withErrorHandler(TopicAreaCtrl.updateTopicArea));
-router.delete("/:id", withErrorHandler(TopicAreaCtrl.deleteTopicArea));
+router.get(
+  "/",
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(TopicAreaCtrl.listTopicAreas)
+);
+
+router.get(
+  "/:id",
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(TopicAreaCtrl.getTopicAreaById)
+);
+
+router.post("/", rbac(Role.Admin), errorHandler(TopicAreaCtrl.createTopicArea));
+
+router.put(
+  "/:id",
+  rbac(Role.Admin),
+  errorHandler(TopicAreaCtrl.updateTopicArea)
+);
+
+router.delete(
+  "/:id",
+  rbac(Role.Admin),
+  errorHandler(TopicAreaCtrl.deleteTopicArea)
+);
 
 export default router;

--- a/backend/src/lib/api/user-api.ts
+++ b/backend/src/lib/api/user-api.ts
@@ -1,14 +1,16 @@
 import { Router } from "express";
+import { Role } from "../models/user";
 import UserCtrl from "../controllers/user-ctrl";
-import withErrorHandler from "./middleware/error-handler";
+import errorHandler from "./middleware/error-handler";
 import auth from "./middleware/auth";
+import rbac from "./middleware/rbac";
 
 const router = Router();
 router.use(auth);
 
-router.get("/", withErrorHandler(UserCtrl.getUsers));
-router.post("/", withErrorHandler(UserCtrl.addUsers));
-router.post("/invite", withErrorHandler(UserCtrl.resendInvite));
-router.put("/role", withErrorHandler(UserCtrl.changeRole));
+router.get("/", rbac(Role.Admin), errorHandler(UserCtrl.getUsers));
+router.post("/", rbac(Role.Admin), errorHandler(UserCtrl.addUsers));
+router.post("/invite", rbac(Role.Admin), errorHandler(UserCtrl.resendInvite));
+router.put("/role", rbac(Role.Admin), errorHandler(UserCtrl.changeRole));
 
 export default router;

--- a/backend/src/lib/services/__tests__/auth.test.ts
+++ b/backend/src/lib/services/__tests__/auth.test.ts
@@ -1,0 +1,60 @@
+import AuthService from "../auth";
+
+let req: any = {};
+
+test("extracts the user roles from the JWT token", () => {
+  req.headers = {
+    "x-apigateway-event": JSON.stringify({
+      requestContext: {
+        authorizer: {
+          claims: {
+            sub: "18df9386",
+            aud: "5suh28b1",
+            "custom:roles": '["Admin"]',
+            email_verified: "true",
+            event_id: "bf084059",
+            token_use: "id",
+            auth_time: "1610562801",
+            iss: "https://cognito-idp.us-west-2.amazonaws.com/us-west-2_123",
+            "cognito:username": "johndoe",
+            exp: "Wed Jan 13 19:33:21 UTC 2021",
+            iat: "Wed Jan 13 18:33:21 UTC 2021",
+            email: "johndoe@amazon.com",
+          },
+        },
+      },
+    }),
+  };
+
+  const user = AuthService.getCurrentUser(req);
+  expect(user?.userId).toEqual("johndoe");
+  expect(user?.roles).toEqual(["Admin"]);
+});
+
+test("handles the case of roles not being present in claims", () => {
+  req.headers = {
+    "x-apigateway-event": JSON.stringify({
+      requestContext: {
+        authorizer: {
+          claims: {
+            sub: "18df9386",
+            aud: "5suh28b1",
+            // "custom:roles": '["Admin"]', // Roles not available
+            email_verified: "true",
+            event_id: "bf084059",
+            token_use: "id",
+            auth_time: "1610562801",
+            iss: "https://cognito-idp.us-west-2.amazonaws.com/us-west-2_123",
+            "cognito:username": "johndoe",
+            exp: "Wed Jan 13 19:33:21 UTC 2021",
+            iat: "Wed Jan 13 18:33:21 UTC 2021",
+            email: "johndoe@amazon.com",
+          },
+        },
+      },
+    }),
+  };
+
+  const user = AuthService.getCurrentUser(req);
+  expect(user?.roles).toEqual([]);
+});

--- a/backend/src/lib/services/auth.ts
+++ b/backend/src/lib/services/auth.ts
@@ -1,5 +1,5 @@
 import { Request } from "express";
-import { User } from "../models/user";
+import { User, Role } from "../models/user";
 
 const local = !!process.env.LOCAL_MODE || false;
 
@@ -41,8 +41,18 @@ function userFromClaims(claims: any): User {
    *
    * https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
    */
+  let roles: Array<Role> = [];
+  if (claims["custom:roles"]) {
+    try {
+      roles = JSON.parse(claims["custom:roles"]);
+    } catch (err) {
+      console.error("Invalid value for custom:roles in JWT token claims", err);
+    }
+  }
+
   return {
     userId: claims["cognito:username"],
+    roles,
   };
 }
 
@@ -59,6 +69,7 @@ function dummyUser(): any {
     exp: "Sat Jul 18 00:05:53 UTC 2020",
     iat: "Fri Jul 17 23:05:54 UTC 2020",
     email: "fdingler@amazon.com",
+    "custom:roles": '["Admin"]',
   };
 }
 


### PR DESCRIPTION
## Description

- Wrote a new middleware for RBAC (Role-based Access Control).
- Implemented this middleware in every API that requires user authentication.
- Updated the `AuthService` to extract the roles from the JWT token claims. 
- Gave Admin users access to everything. 
- Editors have access to everything except updating Settings and updating Topic Areas. 
- Also renamed the `error-handler` middleware from `withErrorHandler` to `errorHandler` to shorten it a little bit.

## Testing

- Wrote unit tests for the rbac middleware
- Ran integration test suite against my environment to verify nothing broke. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
