### PR TITLE
fix: Rows were always sorted backwards in Table component

### DIFF
--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -28,6 +28,19 @@ interface Props {
 
 function Table(props: Props) {
   const className = props.className ? ` ${props.className}` : "";
+
+  const { initialSortByField, initialSortAscending } = props;
+  const initialSortBy = React.useMemo(() => {
+    return initialSortByField
+      ? [
+          {
+            id: initialSortByField,
+            desc: !initialSortAscending,
+          },
+        ]
+      : [];
+  }, [initialSortByField, initialSortAscending]);
+
   const {
     getTableProps,
     getTableBodyProps,
@@ -43,15 +56,7 @@ function Table(props: Props) {
       disableSortRemove: true,
       initialState: {
         selectedRowIds: {},
-        sortBy: React.useMemo(
-          () => [
-            {
-              id: props.initialSortByField || "",
-              desc: !props.initialSortAscending,
-            },
-          ],
-          [props.initialSortByField, props.initialSortAscending]
-        ),
+        sortBy: initialSortBy,
       },
     },
     useGlobalFilter,

--- a/frontend/src/components/__tests__/Table.test.tsx
+++ b/frontend/src/components/__tests__/Table.test.tsx
@@ -47,7 +47,7 @@ test("renders a basic table", async () => {
 });
 
 test("renders a table with selection checkboxes", async () => {
-  const { container } = render(
+  render(
     <Table
       selection="multiple"
       columns={columns}
@@ -55,7 +55,23 @@ test("renders a table with selection checkboxes", async () => {
       screenReaderField="name"
     />
   );
-  expect(container).toMatchSnapshot();
+  expect(
+    screen.getByRole("checkbox", {
+      name: "Banana",
+    })
+  ).toBeInTheDocument();
+
+  expect(
+    screen.getByRole("checkbox", {
+      name: "Chocolate",
+    })
+  ).toBeInTheDocument();
+
+  expect(
+    screen.getByRole("checkbox", {
+      name: "Vanilla",
+    })
+  ).toBeInTheDocument();
 });
 
 test("calls onSelection function when user selects a row", async () => {

--- a/frontend/src/components/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/Table.test.tsx.snap
@@ -106,17 +106,17 @@ exports[`renders a basic table 1`] = `
           role="cell"
           scope="row"
         >
-          3
+          1
         </th>
         <td
           role="cell"
         >
-          Vanilla
+          Banana
         </td>
         <td
           role="cell"
         >
-          2019-11-11
+          2021-11-11
         </td>
       </tr>
       <tr
@@ -146,155 +146,8 @@ exports[`renders a basic table 1`] = `
           role="cell"
           scope="row"
         >
-          1
-        </th>
-        <td
-          role="cell"
-        >
-          Banana
-        </td>
-        <td
-          role="cell"
-        >
-          2021-11-11
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-`;
-
-exports[`renders a table with selection checkboxes 1`] = `
-<div>
-  <table
-    class="usa-table usa-table--borderless"
-    role="table"
-  >
-    <thead>
-      <tr
-        role="row"
-      >
-        <th
-          colspan="1"
-          role="columnheader"
-          scope="col"
-          style="padding: 0.5rem 1rem;"
-        >
-          <input
-            style="cursor: pointer;"
-            title="Toggle All Rows Selected"
-            type="checkbox"
-          />
-        </th>
-        <th
-          colspan="1"
-          role="columnheader"
-          scope="col"
-          style="padding: 0.5rem 1rem;"
-        >
-          ID
-          <button
-            class="margin-left-1 usa-button usa-button--unstyled"
-            style="cursor: pointer;"
-            title="Toggle SortBy ID"
-          >
-            <svg
-              aria-hidden="true"
-              class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base-light text-white"
-              data-icon="chevron-up"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
-                fill="currentColor"
-              />
-            </svg>
-          </button>
-        </th>
-        <th
-          colspan="1"
-          role="columnheader"
-          scope="col"
-          style="padding: 0.5rem 1rem;"
-        >
-          Name
-          <button
-            class="margin-left-1 usa-button usa-button--unstyled"
-            style="cursor: pointer;"
-            title="Toggle SortBy Name"
-          >
-            <svg
-              aria-hidden="true"
-              class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base-light text-white"
-              data-icon="chevron-up"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
-                fill="currentColor"
-              />
-            </svg>
-          </button>
-        </th>
-        <th
-          colspan="1"
-          role="columnheader"
-          scope="col"
-          style="padding: 0.5rem 1rem;"
-        >
-          Last Updated
-          <button
-            class="margin-left-1 usa-button usa-button--unstyled"
-            style="cursor: pointer;"
-            title="Toggle SortBy Last Updated"
-          >
-            <svg
-              aria-hidden="true"
-              class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base-light text-white"
-              data-icon="chevron-up"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
-                fill="currentColor"
-              />
-            </svg>
-          </button>
-        </th>
-      </tr>
-    </thead>
-    <tbody
-      role="rowgroup"
-    >
-      <tr
-        role="row"
-      >
-        <td
-          role="cell"
-        >
-          <input
-            style="cursor: pointer;"
-            title="Vanilla"
-            type="checkbox"
-          />
-        </td>
-        <td
-          role="cell"
-        >
           3
-        </td>
+        </th>
         <td
           role="cell"
         >
@@ -304,62 +157,6 @@ exports[`renders a table with selection checkboxes 1`] = `
           role="cell"
         >
           2019-11-11
-        </td>
-      </tr>
-      <tr
-        role="row"
-      >
-        <td
-          role="cell"
-        >
-          <input
-            style="cursor: pointer;"
-            title="Chocolate"
-            type="checkbox"
-          />
-        </td>
-        <td
-          role="cell"
-        >
-          2
-        </td>
-        <td
-          role="cell"
-        >
-          Chocolate
-        </td>
-        <td
-          role="cell"
-        >
-          2020-11-11
-        </td>
-      </tr>
-      <tr
-        role="row"
-      >
-        <td
-          role="cell"
-        >
-          <input
-            style="cursor: pointer;"
-            title="Banana"
-            type="checkbox"
-          />
-        </td>
-        <td
-          role="cell"
-        >
-          1
-        </td>
-        <td
-          role="cell"
-        >
-          Banana
-        </td>
-        <td
-          role="cell"
-        >
-          2021-11-11
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
## Description

Miguel discovered that Rows in the table were being sorted descending always by default. This was because I was passing the `initialState.sortBy` function always to `desc: true` even when no `initialSortByField` was provided. 

## Testing

You can verify by creating a table here: https://fdingler.badger.wwps.aws.dev/admin/dashboard/1dcde43a-9700-41d3-b651-ceee60f7bdf8/add-table and notice how the Row order will be the same as the order in your CSV file. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
