### PR TITLE
GTT-889 New model for MetricsWidget

### DIFF
--- a/backend/src/lib/factories/__tests__/widget-factory.test.ts
+++ b/backend/src/lib/factories/__tests__/widget-factory.test.ts
@@ -7,6 +7,7 @@ import {
   ChartWidget,
   TableWidget,
   ChartType,
+  MetricsWidget,
 } from "../../models/widget";
 
 const dummyWidgetName = "Some widget";
@@ -564,5 +565,69 @@ describe("createFromWidget", () => {
         },
       })
     );
+  });
+});
+
+describe("createMetricsWidget", () => {
+  const content = {
+    title: "Population trends",
+    datasetId: "090b0410",
+    s3Key: {
+      json: "abc.json",
+    },
+  };
+
+  it("builds a metrics widget", () => {
+    const widget = WidgetFactory.createWidget({
+      name: dummyWidgetName,
+      dashboardId,
+      widgetType: WidgetType.Metrics,
+      showTitle: true,
+      content,
+    }) as MetricsWidget;
+
+    expect(widget.id).toBeDefined();
+    expect(widget.name).toEqual(dummyWidgetName);
+    expect(widget.dashboardId).toEqual(dashboardId);
+    expect(widget.widgetType).toEqual(WidgetType.Metrics);
+    expect(widget.showTitle).toBe(true);
+    expect(widget.content.title).toEqual("Population trends");
+    expect(widget.content.datasetId).toEqual("090b0410");
+    expect(widget.content.s3Key).toEqual({
+      json: "abc.json",
+    });
+  });
+
+  it("throws an error if datasetId is undefined", () => {
+    expect(() => {
+      WidgetFactory.createWidget({
+        name: dummyWidgetName,
+        dashboardId,
+        widgetType: WidgetType.Metrics,
+        showTitle: true,
+        content: {
+          ...content,
+          datasetId: undefined,
+        },
+      });
+    }).toThrowError("Metrics widget must have `content.datasetId` field");
+  });
+
+  it("throws an error if s3Key.json is undefined", () => {
+    expect(() => {
+      WidgetFactory.createWidget({
+        name: dummyWidgetName,
+        dashboardId,
+        widgetType: WidgetType.Metrics,
+        showTitle: true,
+        content: {
+          ...content,
+          s3Key: {
+            ...content.s3Key,
+            json: undefined,
+          },
+        },
+      });
+    }).toThrowError("Metrics widget must have `content.s3Key.json` field");
   });
 });

--- a/backend/src/lib/factories/widget-factory.ts
+++ b/backend/src/lib/factories/widget-factory.ts
@@ -7,6 +7,7 @@ import {
   ChartWidget,
   TableWidget,
   ChartType,
+  MetricsWidget,
 } from "../models/widget";
 
 export const WIDGET_ITEM_TYPE = "Widget";
@@ -40,6 +41,8 @@ function createWidget(widgetInfo: CreateWidgetInfo): Widget {
       return createChartWidget(widget);
     case WidgetType.Table:
       return createTableWidget(widget);
+    case WidgetType.Metrics:
+      return createMetricsWidget(widget);
     default:
       throw new Error("Invalid widget type");
   }
@@ -187,6 +190,25 @@ function createTableWidget(widget: Widget): TableWidget {
       s3Key: widget.content.s3Key,
       fileName: widget.content.fileName,
       datasetType: widget.content.datasetType,
+    },
+  };
+}
+
+function createMetricsWidget(widget: Widget): MetricsWidget {
+  if (!widget.content.datasetId) {
+    throw new Error("Metrics widget must have `content.datasetId` field");
+  }
+
+  if (!widget.content.s3Key || !widget.content.s3Key.json) {
+    throw new Error("Metrics widget must have `content.s3Key.json` field");
+  }
+
+  return {
+    ...widget,
+    content: {
+      title: widget.content.title,
+      datasetId: widget.content.datasetId,
+      s3Key: widget.content.s3Key,
     },
   };
 }

--- a/backend/src/lib/factories/widget-factory.ts
+++ b/backend/src/lib/factories/widget-factory.ts
@@ -87,6 +87,8 @@ function fromItem(item: WidgetItem): Widget {
       return widget as ChartWidget;
     case WidgetType.Table:
       return widget as TableWidget;
+    case WidgetType.Metrics:
+      return widget as MetricsWidget;
     default:
       return widget;
   }

--- a/backend/src/lib/models/widget.ts
+++ b/backend/src/lib/models/widget.ts
@@ -2,6 +2,7 @@ export enum WidgetType {
   Text = "Text",
   Chart = "Chart",
   Table = "Table",
+  Metrics = "Metrics",
 }
 
 export enum ChartType {
@@ -68,5 +69,15 @@ export interface TableWidget extends Widget {
       json: string;
     };
     fileName: string;
+  };
+}
+
+export interface MetricsWidget extends Widget {
+  content: {
+    title: string;
+    datasetId: string;
+    s3Key: {
+      json: string;
+    };
   };
 }


### PR DESCRIPTION
## Description

Added new model to represent the new Metrics widget. Added factory function to create one  

## Testing

- Wrote unit tests. 
- Tested with postman creating a Metrics widget with the following payload: 

```json
{
    "name": "My Widget Name",
    "widgetType": "Metrics",
    "content": {
        "title": "My Widget Title",
        "datasetId": "7f24b2ad-fc7d-443a-8b23-b62c6212aee2",
        "s3Key": {
            "json": "123.json"
        }
    }
}
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
