### PR TITLE
GTT-908: Frontend: New screens to edit Image content items

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import PublishDashboard from "./containers/PublishDashboard";
 import ArchivedDashboard from "./containers/ArchivedDashboard";
 import AddChart from "./containers/AddChart";
 import AddImage from "./containers/AddImage";
+import EditImage from "./containers/EditImage";
 import EditChart from "./containers/EditChart";
 import AddTable from "./containers/AddTable";
 import EditTable from "./containers/EditTable";
@@ -151,6 +152,10 @@ const routes: Array<AppRoute> = [
   {
     path: "/admin/dashboard/:dashboardId/add-image",
     component: AddImage,
+  },
+  {
+    path: "/admin/dashboard/:dashboardId/edit-image/:widgetId",
+    component: EditImage,
   },
   {
     path: "/admin/dashboard/:dashboardId/edit-text/:widgetId",

--- a/frontend/src/containers/EditImage.tsx
+++ b/frontend/src/containers/EditImage.tsx
@@ -1,0 +1,312 @@
+import React, { useState } from "react";
+import { useForm } from "react-hook-form";
+import { useHistory, useParams } from "react-router-dom";
+import BackendService from "../services/BackendService";
+import StorageService from "../services/StorageService";
+import Breadcrumbs from "../components/Breadcrumbs";
+import TextField from "../components/TextField";
+import FileInput from "../components/FileInput";
+import Button from "../components/Button";
+import { useDashboard, useWidget, useImage } from "../hooks";
+import Spinner from "../components/Spinner";
+import ImagePreview from "../components/ImagePreview";
+
+interface FormValues {
+  title: string;
+  summary: string;
+  showTitle: boolean;
+  summaryBelow: boolean;
+  altText: string;
+  image: File;
+}
+
+interface PathParams {
+  dashboardId: string;
+  widgetId: string;
+}
+
+function EditImage() {
+  const history = useHistory();
+
+  const { dashboardId, widgetId } = useParams<PathParams>();
+  const { dashboard, loading } = useDashboard(dashboardId);
+  const { setWidget, widget } = useWidget(dashboardId, widgetId);
+  const { register, errors, handleSubmit } = useForm<FormValues>();
+  const imageHook = useImage(widget?.content.s3Key.raw);
+
+  const [newImageFile, setNewImageFile] = useState<File | undefined>(undefined);
+  const [imageUploading, setImageUploading] = useState(false);
+
+  const supportedImageFileTypes = Object.values(StorageService.imageFileTypes);
+  const originalImageHook = imageHook;
+
+  const onSubmit = async (values: FormValues) => {
+    if (!widget) {
+      return;
+    }
+    try {
+      setImageUploading(true);
+
+      const s3Key = newImageFile
+        ? await StorageService.uploadImage(newImageFile)
+        : widget.content.s3Key.raw;
+
+      const fileName = newImageFile
+        ? newImageFile.name
+        : widget.content.fileName;
+
+      await BackendService.editWidget(
+        dashboardId,
+        widgetId,
+        values.title,
+        values.showTitle,
+        {
+          title: values.title,
+          s3Key: {
+            raw: s3Key,
+          },
+          fileName: fileName,
+          imageAltText: values.altText,
+          summary: values.summary,
+          summaryBelow: values.summaryBelow,
+        },
+        widget.updatedAt
+      );
+      setImageUploading(false);
+
+      history.push(`/admin/dashboard/edit/${dashboardId}`, {
+        alert: {
+          type: "success",
+          message: `"${values.title}" image has been successfully edited`,
+        },
+      });
+    } catch (err) {
+      console.log("Failed to edit content item", err);
+      setImageUploading(false);
+    }
+  };
+
+  const onCancel = () => {
+    history.push(`/admin/dashboard/edit/${dashboardId}`);
+  };
+
+  const handleChangeTitle = (event: React.FormEvent<HTMLInputElement>) => {
+    if (widget) {
+      setWidget({
+        ...widget,
+        content: {
+          ...widget.content,
+          title: (event.target as HTMLInputElement).value,
+        },
+      });
+    }
+  };
+
+  const handleSummaryChange = (event: React.FormEvent<HTMLTextAreaElement>) => {
+    if (widget) {
+      setWidget({
+        ...widget,
+        content: {
+          ...widget.content,
+          summary: (event.target as HTMLTextAreaElement).value,
+        },
+      });
+    }
+  };
+
+  const handleSummaryBelowChange = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    if (widget) {
+      setWidget({
+        ...widget,
+        content: {
+          ...widget.content,
+          summaryBelow: (event.target as HTMLInputElement).checked,
+        },
+      });
+    }
+  };
+
+  const handleShowTitleChange = (event: React.FormEvent<HTMLInputElement>) => {
+    if (widget) {
+      setWidget({
+        ...widget,
+        showTitle: (event.target as HTMLInputElement).checked,
+        content: {
+          ...widget.content,
+        },
+      });
+    }
+  };
+
+  const onFileProcessed = (data: File) => {
+    if (data) {
+      setNewImageFile(data);
+    }
+  };
+
+  const crumbs = [
+    {
+      label: "Dashboards",
+      url: "/admin/dashboards",
+    },
+    {
+      label: dashboard?.name,
+      url: `/admin/dashboard/edit/${dashboardId}`,
+    },
+  ];
+
+  if (!loading) {
+    crumbs.push({
+      label: "Edit image",
+      url: "",
+    });
+  }
+
+  return (
+    <>
+      <Breadcrumbs crumbs={crumbs} />
+      <h1>Edit Image</h1>
+
+      {!widget || imageHook.loading || imageUploading ? (
+        <Spinner className="text-center margin-top-6" label="Loading" />
+      ) : (
+        <>
+          <div className="grid-row width-desktop">
+            <div className="grid-col-6">
+              <form
+                className="usa-form usa-form--large"
+                onSubmit={handleSubmit(onSubmit)}
+              >
+                <fieldset className="usa-fieldset">
+                  <TextField
+                    id="title"
+                    name="title"
+                    label="Image title"
+                    hint="Give your image a descriptive title."
+                    error={errors.title && "Please specify an image title"}
+                    onChange={handleChangeTitle}
+                    defaultValue={widget.content.title}
+                    required
+                    register={register}
+                  />
+
+                  <div className="usa-checkbox">
+                    <input
+                      className="usa-checkbox__input"
+                      id="display-title"
+                      type="checkbox"
+                      name="showTitle"
+                      defaultChecked={widget.showTitle}
+                      onChange={handleShowTitleChange}
+                      ref={register()}
+                    />
+                    <label
+                      className="usa-checkbox__label"
+                      htmlFor="display-title"
+                    >
+                      Show title on dashboard
+                    </label>
+                  </div>
+
+                  <div>
+                    <FileInput
+                      id="dataset"
+                      name="image"
+                      label="File upload"
+                      accept={supportedImageFileTypes.toString()}
+                      loading={false}
+                      register={register}
+                      hint={<span>Must be a PNG, JPEG, or SVG file</span>}
+                      fileName={
+                        newImageFile?.name
+                          ? newImageFile.name
+                          : widget.content.fileName
+                      }
+                      onFileProcessed={onFileProcessed}
+                    />
+                  </div>
+
+                  <div>
+                    <div hidden={false}>
+                      <TextField
+                        id="altText"
+                        name="altText"
+                        label="Image alt text"
+                        hint="Invisible description of the image which is read aloud to users with visual impairments on a screen reader."
+                        register={register}
+                        defaultValue={widget.content.imageAltText}
+                        multiline
+                        rows={1}
+                      />
+
+                      <TextField
+                        id="summary"
+                        name="summary"
+                        label="Image description - optional"
+                        hint="Give your image a description to explain it in more depth."
+                        register={register}
+                        onChange={handleSummaryChange}
+                        multiline
+                        defaultValue={widget.content.summary}
+                        rows={5}
+                      />
+                      <div className="usa-checkbox">
+                        <input
+                          className="usa-checkbox__input"
+                          id="summary-below"
+                          type="checkbox"
+                          name="summaryBelow"
+                          defaultChecked={widget.content.summaryBelow}
+                          onChange={handleSummaryBelowChange}
+                          ref={register()}
+                        />
+                        <label
+                          className="usa-checkbox__label"
+                          htmlFor="summary-below"
+                        >
+                          Show description below image
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                </fieldset>
+                <br />
+                <hr />
+                <Button
+                  disabled={!originalImageHook.file && !newImageFile}
+                  type="submit"
+                >
+                  Save
+                </Button>
+                <Button
+                  variant="unstyled"
+                  className="text-base-dark hover:text-base-darker active:text-base-darkest"
+                  type="button"
+                  onClick={onCancel}
+                >
+                  Cancel
+                </Button>
+              </form>
+            </div>
+            <div className="grid-col-6">
+              <div hidden={false} className="margin-left-4">
+                <h4>Preview</h4>
+                <ImagePreview
+                  title={widget.showTitle ? widget.content.title : ""}
+                  summary={widget.content.summary}
+                  file={newImageFile ? newImageFile : originalImageHook.file}
+                  summaryBelow={widget.content.summaryBelow}
+                  altText={widget.content.imageAltText}
+                />
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </>
+  );
+}
+
+export default EditImage;

--- a/frontend/src/containers/__tests__/EditImage.test.tsx
+++ b/frontend/src/containers/__tests__/EditImage.test.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import BackendService from "../../services/BackendService";
+import StorageService from "../../services/StorageService";
+import EditImage from "../EditImage";
+
+jest.mock("../../services/BackendService");
+jest.mock("../../services/StorageService");
+jest.mock("../../hooks");
+
+beforeEach(() => {
+  BackendService.editWidget = jest.fn();
+  StorageService.downloadFile = jest.fn();
+  window.URL.createObjectURL = jest.fn();
+});
+
+test("renders title", async () => {
+  render(<EditImage />, { wrapper: MemoryRouter });
+  expect(
+    await screen.findByRole("heading", { name: "Edit Image" })
+  ).toBeInTheDocument();
+});
+
+test("renders Image title", async () => {
+  render(<EditImage />, { wrapper: MemoryRouter });
+  expect(await screen.findByLabelText("Image title")).toBeInTheDocument();
+});
+
+test("renders element descriptions", async () => {
+  const { getByText } = render(<EditImage />, { wrapper: MemoryRouter });
+  expect(getByText("Give your image a descriptive title.")).toBeInTheDocument();
+  expect(getByText("Must be a PNG, JPEG, or SVG file")).toBeInTheDocument();
+  expect(
+    getByText(
+      "Invisible description of the image which is read aloud to users with visual impairments on a screen reader."
+    )
+  ).toBeInTheDocument();
+  expect(
+    getByText("Give your image a description to explain it in more depth.")
+  ).toBeInTheDocument();
+});
+
+test("renders a file upload input", async () => {
+  render(<EditImage />, { wrapper: MemoryRouter });
+  expect(await screen.findByLabelText("File upload")).toBeInTheDocument();
+});
+
+test("on submit, it calls editWidget api and uploads dataset", async () => {
+  const { getByRole, getByText, getByLabelText } = render(<EditImage />, {
+    wrapper: MemoryRouter,
+  });
+
+  const submitButton = getByRole("button", { name: "Save" });
+
+  fireEvent.input(getByLabelText("Image title"), {
+    target: {
+      value: "Test Image",
+    },
+  });
+
+  fireEvent.input(getByLabelText("Image alt text"), {
+    target: {
+      value: "Test alt text",
+    },
+  });
+
+  fireEvent.change(getByLabelText("File upload"), {
+    target: {
+      files: ["image.jpg"],
+    },
+  });
+
+  await waitFor(() => expect(submitButton).toBeEnabled());
+  await waitFor(() => {
+    expect(getByText("Preview")).toBeInTheDocument();
+
+    expect(getByText("Image alt text")).toBeInTheDocument();
+    expect(
+      getByText(
+        "Invisible description of the image which is read aloud to users with visual impairments on a screen reader."
+      )
+    ).toBeInTheDocument();
+
+    expect(getByText("Image description - optional")).toBeInTheDocument();
+    expect(
+      getByText("Give your image a description to explain it in more depth.")
+    ).toBeInTheDocument();
+  });
+
+  await act(async () => {
+    fireEvent.click(submitButton);
+  });
+
+  expect(BackendService.editWidget).toHaveBeenCalled();
+  expect(StorageService.uploadImage).toHaveBeenCalled();
+});

--- a/frontend/src/hooks/__mocks__/index.tsx
+++ b/frontend/src/hooks/__mocks__/index.tsx
@@ -163,7 +163,12 @@ export function useWidget(
     widgetType: "Text",
     order: 1,
     updatedAt: "",
-    content: { text: "test" },
+    content: {
+      text: "test",
+      s3Key: {
+        raw: "abc.jpeg",
+      },
+    },
   });
 
   return {

--- a/frontend/src/hooks/image-hooks.ts
+++ b/frontend/src/hooks/image-hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import StorageService from "../services/StorageService";
 
 type UseImageHook = {
@@ -10,15 +10,18 @@ export function useImage(s3Key: string): UseImageHook {
   const [loading, setLoading] = useState<boolean>(false);
   const [file, setFile] = useState<File>();
 
-  useEffect(() => {
-    const fetchData = async () => {
+  const fetchData = useCallback(async () => {
+    if (s3Key) {
       setLoading(true);
       const data = await StorageService.downloadFile(s3Key);
       setFile(data);
       setLoading(false);
-    };
-    fetchData();
+    }
   }, [s3Key]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
 
   return {
     loading,


### PR DESCRIPTION
## Description

Added a new page that would allow the user to edit an image widget, after it has been created.

## Testing

I went through various scenarios, including editing labels but no the image, editing only the image, and editing all values and ensuring it looked correct when I went back to the widget. I also added unit tests. I ran the entire suite with the new tests and it worked.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
