### PR TITLE
[AppSec] Dataset Ingestion API - Set cache control in header

### DIFF
--- a/backend/src/lib/api/middleware/__tests__/csp.test.ts
+++ b/backend/src/lib/api/middleware/__tests__/csp.test.ts
@@ -3,7 +3,7 @@ import csp from "../csp";
 
 const req = {} as Request;
 const res = {
-  setHeader: jest.fn() as any,
+  set: jest.fn() as any,
 } as Response;
 const next = jest.fn();
 
@@ -11,22 +11,20 @@ describe("csp", () => {
   it("injects csp headers", () => {
     csp(req, res, next);
 
-    expect(res.setHeader).toHaveBeenCalledWith(
+    expect(res.set).toHaveBeenCalledWith(
       "Content-Security-Policy",
       "default-src 'self'; block-all-mixed-content;"
     );
-    expect(res.setHeader).toHaveBeenCalledWith(
+    expect(res.set).toHaveBeenCalledWith(
       "Strict-Transport-Security",
       "max-age=31540000; includeSubdomains"
     );
-    expect(res.setHeader).toHaveBeenCalledWith(
-      "X-XSS-Protection",
-      "1; mode=block"
-    );
-    expect(res.setHeader).toHaveBeenCalledWith("X-Frame-Options", "DENY");
-    expect(res.setHeader).toHaveBeenCalledWith(
-      "X-Content-Type-Options",
-      "nosniff"
+    expect(res.set).toHaveBeenCalledWith("X-XSS-Protection", "1; mode=block");
+    expect(res.set).toHaveBeenCalledWith("X-Frame-Options", "DENY");
+    expect(res.set).toHaveBeenCalledWith("X-Content-Type-Options", "nosniff");
+    expect(res.set).toHaveBeenCalledWith(
+      "Cache-control",
+      "public, max-age=600"
     );
 
     expect(next).toHaveBeenCalled();

--- a/backend/src/lib/api/middleware/csp.ts
+++ b/backend/src/lib/api/middleware/csp.ts
@@ -4,17 +4,15 @@ import { Request, Response, NextFunction } from "express";
  * Inject security related HTTP headers into the responses
  */
 const csp = function (req: Request, res: Response, next: NextFunction) {
-  res.setHeader(
+  res.set(
     "Content-Security-Policy",
     "default-src 'self'; block-all-mixed-content;"
   );
-  res.setHeader(
-    "Strict-Transport-Security",
-    "max-age=31540000; includeSubdomains"
-  );
-  res.setHeader("X-XSS-Protection", "1; mode=block");
-  res.setHeader("X-Frame-Options", "DENY");
-  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.set("Strict-Transport-Security", "max-age=31540000; includeSubdomains");
+  res.set("X-XSS-Protection", "1; mode=block");
+  res.set("X-Frame-Options", "DENY");
+  res.set("X-Content-Type-Options", "nosniff");
+  res.set("Cache-control", "public, max-age=600");
   next();
 };
 

--- a/backend/src/lib/controllers/__tests__/ingestapi-ctrl.test.ts
+++ b/backend/src/lib/controllers/__tests__/ingestapi-ctrl.test.ts
@@ -12,6 +12,7 @@ jest.mock("../../factories/dataset-factory");
 const repository = mocked(DatasetRepository.prototype);
 const res = ({
   send: jest.fn().mockReturnThis(),
+  set: jest.fn().mockReturnThis(),
   status: jest.fn().mockReturnThis(),
   json: jest.fn().mockReturnThis(),
 } as any) as Response;

--- a/backend/src/lib/controllers/ingestapi-ctrl.ts
+++ b/backend/src/lib/controllers/ingestapi-ctrl.ts
@@ -53,7 +53,7 @@ async function createDataset(req: Request, res: Response) {
     });
 
     await repo.saveDataset(dataset);
-    res.setHeader("Cache-Control", "public, max-age=600");
+    res.set("Cache-control", "public, max-age=600");
     res.json(dataset);
   } catch (err) {
     logger.error("Failed to create dataset %o, %o", metadata, parsedData);
@@ -88,7 +88,7 @@ async function updateDataset(req: Request, res: Response) {
 
   try {
     await DatasetService.updateDataset(id, metadata, parsedData);
-    res.setHeader("Cache-Control", "public, max-age=600");
+    res.set("Cache-control", "public, max-age=600");
     res.json();
   } catch (err) {
     logger.error("Failed to update dataset %o, %o", err, metadata, parsedData);
@@ -109,7 +109,7 @@ async function deleteDataset(req: Request, res: Response) {
   await repo.deleteDataset(id);
   logger.info("Dataset deleted %s", id);
 
-  res.setHeader("Cache-Control", "public, max-age=600");
+  res.set("Cache-control", "public, max-age=600");
   return res.send();
 }
 

--- a/backend/src/lib/controllers/ingestapi-ctrl.ts
+++ b/backend/src/lib/controllers/ingestapi-ctrl.ts
@@ -53,7 +53,6 @@ async function createDataset(req: Request, res: Response) {
     });
 
     await repo.saveDataset(dataset);
-    res.set("Cache-control", "public, max-age=600");
     res.json(dataset);
   } catch (err) {
     logger.error("Failed to create dataset %o, %o", metadata, parsedData);
@@ -88,7 +87,6 @@ async function updateDataset(req: Request, res: Response) {
 
   try {
     await DatasetService.updateDataset(id, metadata, parsedData);
-    res.set("Cache-control", "public, max-age=600");
     res.json();
   } catch (err) {
     logger.error("Failed to update dataset %o, %o", err, metadata, parsedData);
@@ -109,7 +107,6 @@ async function deleteDataset(req: Request, res: Response) {
   await repo.deleteDataset(id);
   logger.info("Dataset deleted %s", id);
 
-  res.set("Cache-control", "public, max-age=600");
   return res.send();
 }
 

--- a/backend/src/lib/controllers/ingestapi-ctrl.ts
+++ b/backend/src/lib/controllers/ingestapi-ctrl.ts
@@ -53,11 +53,7 @@ async function createDataset(req: Request, res: Response) {
     });
 
     await repo.saveDataset(dataset);
-<<<<<<< HEAD
     res.set("Cache-control", "public, max-age=600");
-=======
-    res.setHeader("Cache-Control", "public, max-age=600");
->>>>>>> 243c076502353333715f765f2b43fd93dc65a40e
     res.json(dataset);
   } catch (err) {
     logger.error("Failed to create dataset %o, %o", metadata, parsedData);
@@ -92,11 +88,7 @@ async function updateDataset(req: Request, res: Response) {
 
   try {
     await DatasetService.updateDataset(id, metadata, parsedData);
-<<<<<<< HEAD
     res.set("Cache-control", "public, max-age=600");
-=======
-    res.setHeader("Cache-Control", "public, max-age=600");
->>>>>>> 243c076502353333715f765f2b43fd93dc65a40e
     res.json();
   } catch (err) {
     logger.error("Failed to update dataset %o, %o", err, metadata, parsedData);
@@ -117,11 +109,7 @@ async function deleteDataset(req: Request, res: Response) {
   await repo.deleteDataset(id);
   logger.info("Dataset deleted %s", id);
 
-<<<<<<< HEAD
   res.set("Cache-control", "public, max-age=600");
-=======
-  res.setHeader("Cache-Control", "public, max-age=600");
->>>>>>> 243c076502353333715f765f2b43fd93dc65a40e
   return res.send();
 }
 

--- a/backend/src/lib/controllers/ingestapi-ctrl.ts
+++ b/backend/src/lib/controllers/ingestapi-ctrl.ts
@@ -53,6 +53,7 @@ async function createDataset(req: Request, res: Response) {
     });
 
     await repo.saveDataset(dataset);
+    res.setHeader("Cache-Control", "public, max-age=600");
     res.json(dataset);
   } catch (err) {
     logger.error("Failed to create dataset %o, %o", metadata, parsedData);
@@ -87,6 +88,7 @@ async function updateDataset(req: Request, res: Response) {
 
   try {
     await DatasetService.updateDataset(id, metadata, parsedData);
+    res.setHeader("Cache-Control", "public, max-age=600");
     res.json();
   } catch (err) {
     logger.error("Failed to update dataset %o, %o", err, metadata, parsedData);
@@ -107,6 +109,7 @@ async function deleteDataset(req: Request, res: Response) {
   await repo.deleteDataset(id);
   logger.info("Dataset deleted %s", id);
 
+  res.setHeader("Cache-Control", "public, max-age=600");
   return res.send();
 }
 


### PR DESCRIPTION
## Description

[AppSec] Dataset Ingestion API - Set cache control in header

## Testing

Tested it in my local environment.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
