### PR TITLE
GTT-914: Secure Transport S3 Bucket

### DIFF
--- a/cdk/lib/constructs/datastorage.ts
+++ b/cdk/lib/constructs/datastorage.ts
@@ -1,6 +1,7 @@
 import * as cdk from "@aws-cdk/core";
 import * as s3 from "@aws-cdk/aws-s3";
 import { BucketAccessControl } from "@aws-cdk/aws-s3";
+import { Effect, PolicyStatement, AnyPrincipal } from "@aws-cdk/aws-iam";
 
 interface Props {
   datasetsBucketName: string;
@@ -58,5 +59,19 @@ export class DatasetStorage extends cdk.Construct {
         },
       ],
     });
+
+    this.datasetsBucket.addToResourcePolicy(
+      new PolicyStatement({
+        effect: Effect.DENY,
+        actions: ["s3:*"],
+        principals: [new AnyPrincipal()],
+        resources: [this.datasetsBucket.arnForObjects("*")],
+        conditions: {
+          Bool: {
+            "aws:SecureTransport": false,
+          },
+        },
+      })
+    );
   }
 }


### PR DESCRIPTION
## Description

Added policy to require secure transport to the datasets S3 bucket. This will fulfill the appSec violation.

## Testing

I ran tests, played around with the site (uploaded images, made sure I could see them) and I went to the S3 bucket policy in the interface and saw the below policy as intended.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
