### PR TITLE
GTT-930 Stream processor to handle records from dynamodb streams

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -23,6 +23,7 @@ To run the backend locally from VSCode, create a folder in the root of this repo
         "AWS_REGION": "us-west-2",
         "LOCAL_MODE": "true",
         "MAIN_TABLE": "PerformanceDash-${stageName}-Backend-MainTable",
+        "AUDIT_TRAIL_TABLE": "PerformanceDash-${stageName}-Backend-AuditTrailTable",
         "DATASETS_BUCKET": "performancedash-${stageName}-${accountNumber}-${region}-datasets",
         "USER_POOL_ID": "${your-user-pool-id}",
         "LOG_LEVEL": "debug",

--- a/backend/src/lambda/streams.ts
+++ b/backend/src/lambda/streams.ts
@@ -1,4 +1,5 @@
 import { DynamoDBStreamEvent, Context } from "aws-lambda";
+import StreamProcessor from "../lib/services/stream-processor";
 
 /**
  * Lambda entry handler for messages coming from the
@@ -6,11 +7,12 @@ import { DynamoDBStreamEvent, Context } from "aws-lambda";
  *
  * @param event
  */
-export const handler = (event: DynamoDBStreamEvent, context: Context) => {
+export const handler = async (event: DynamoDBStreamEvent, context: Context) => {
   console.log("Event=", JSON.stringify(event));
   console.log("Context=", JSON.stringify(context));
 
-  // TODO: Implement function to process messages from the stream
+  const promises = event.Records.map(StreamProcessor.processRecord);
+  await Promise.all(promises);
 
-  return true;
+  console.log("Finished processing records", promises.length);
 };

--- a/backend/src/lib/services/__tests__/audit-trail.test.ts
+++ b/backend/src/lib/services/__tests__/audit-trail.test.ts
@@ -1,0 +1,25 @@
+import AuditTrailService from "../audit-trail";
+
+const timestamp = new Date();
+
+describe("handleCreatedItem", () => {
+  it("does nothing", async () => {
+    const newItem = {};
+    await AuditTrailService.handleCreatedItem(newItem, timestamp);
+  });
+});
+
+describe("handleModifiedItem", () => {
+  it("does nothing", async () => {
+    const newItem = {};
+    const oldItem = {};
+    await AuditTrailService.handleModifiedItem(oldItem, newItem, timestamp);
+  });
+});
+
+describe("handleDeletedItem", () => {
+  it("does nothing", async () => {
+    const oldItem = {};
+    await AuditTrailService.handleDeletedItem(oldItem, timestamp);
+  });
+});

--- a/backend/src/lib/services/__tests__/dynamodb.test.ts
+++ b/backend/src/lib/services/__tests__/dynamodb.test.ts
@@ -2,15 +2,15 @@ import { DocumentClient } from "aws-sdk/clients/dynamodb";
 import { mocked } from "ts-jest/utils";
 import DynamoDBService from "../dynamodb";
 
-jest.mock("aws-sdk/clients/dynamodb");
 jest.mock("aws-xray-sdk");
 
-let documentClient = mocked(DocumentClient.prototype);
-documentClient.transactWrite = jest.fn().mockReturnValue({
-  promise: jest.fn(),
-});
-
 describe("transactWrite", () => {
+  jest.mock("aws-sdk/clients/dynamodb");
+  let documentClient = mocked(DocumentClient.prototype);
+  documentClient.transactWrite = jest.fn().mockReturnValue({
+    promise: jest.fn(),
+  });
+
   it("creates 2 batches of 25 requests", async () => {
     const numberOfItems = 50;
     const updateItems = [];
@@ -32,5 +32,23 @@ describe("transactWrite", () => {
     });
 
     expect(documentClient.transactWrite).toBeCalledTimes(2);
+  });
+});
+
+describe("unmarshall", () => {
+  it("should convert a raw dynamodb item into a javascript object", () => {
+    const dynamodb = DynamoDBService.getInstance();
+    const item = {
+      dashboardId: {
+        S: "Dashboard#001",
+      },
+      version: {
+        N: "3",
+      },
+    };
+
+    const dashboard = dynamodb.unmarshall(item);
+    expect(dashboard.dashboardId).toEqual("Dashboard#001");
+    expect(dashboard.version).toEqual(3);
   });
 });

--- a/backend/src/lib/services/__tests__/stream-processor.test.ts
+++ b/backend/src/lib/services/__tests__/stream-processor.test.ts
@@ -1,0 +1,182 @@
+import { DynamoDBRecord, StreamRecord } from "aws-lambda";
+import StreamProcessor from "../stream-processor";
+import AuditTrailService from "../audit-trail";
+
+jest.mock("../audit-trail");
+
+it("discards a record that is missing the `dynamodb` property", async () => {
+  await StreamProcessor.processRecord({
+    eventID: "007131",
+    eventName: "INSERT",
+    eventSource: "aws:dynamodb",
+  });
+  expect(AuditTrailService.handleCreatedItem).not.toBeCalled();
+});
+
+it("discards a record which source is not dynamodb", async () => {
+  await StreamProcessor.processRecord({
+    eventID: "007131",
+    eventName: "INSERT",
+    eventSource: "aws:bananas",
+  });
+  expect(AuditTrailService.handleCreatedItem).not.toBeCalled();
+});
+
+it("handles an INSERT record and delegates to AuditTrail service", async () => {
+  await StreamProcessor.processRecord({
+    eventID: "007131",
+    eventName: "INSERT",
+    eventSource: "aws:dynamodb",
+    dynamodb: {
+      ApproximateCreationDateTime: 1612375403,
+      Keys: {
+        pk: {
+          S: "Dashboard#1dcde43a-9700-41d3-b651-ceee60f7bdf8",
+        },
+        sk: {
+          S: "Dashboard#1dcde43a-9700-41d3-b651-ceee60f7bdf8",
+        },
+      },
+      NewImage: {
+        pk: {
+          S: "Dashboard#1dcde43a-9700-41d3-b651-ceee60f7bdf8",
+        },
+        sk: {
+          S: "Dashboard#1dcde43a-9700-41d3-b651-ceee60f7bdf8",
+        },
+        type: {
+          S: "Dashboard",
+        },
+        version: {
+          N: "1",
+        },
+      },
+    },
+  });
+
+  expect(AuditTrailService.handleCreatedItem).toBeCalledWith(
+    expect.objectContaining({
+      pk: "Dashboard#1dcde43a-9700-41d3-b651-ceee60f7bdf8",
+      sk: "Dashboard#1dcde43a-9700-41d3-b651-ceee60f7bdf8",
+      type: "Dashboard",
+      version: 1,
+    }),
+    new Date("2021-02-03T18:03:23.000Z")
+  );
+});
+
+it("handles a MODIFY record and delegates to AuditTrail service", async () => {
+  await StreamProcessor.processRecord({
+    eventID: "9700125",
+    eventName: "MODIFY",
+    eventSource: "aws:dynamodb",
+    dynamodb: {
+      ApproximateCreationDateTime: 1612375403,
+      Keys: {
+        pk: {
+          S: "Dashboard#1dcde43a-9700-41d3-b651-ceee60f7bdf8",
+        },
+        sk: {
+          S: "Dashboard#1dcde43a-9700-41d3-b651-ceee60f7bdf8",
+        },
+      },
+      NewImage: {
+        pk: {
+          S: "Dashboard#1dcde43a-9700-41d3-b651-ceee60f7bdf8",
+        },
+        sk: {
+          S: "Dashboard#1dcde43a-9700-41d3-b651-ceee60f7bdf8",
+        },
+        type: {
+          S: "Dashboard",
+        },
+        version: {
+          N: "1",
+        },
+        dashboardName: {
+          S: "Bananas",
+        },
+      },
+      OldImage: {
+        pk: {
+          S: "Dashboard#1dcde43a-9700-41d3-b651-ceee60f7bdf8",
+        },
+        sk: {
+          S: "Dashboard#1dcde43a-9700-41d3-b651-ceee60f7bdf8",
+        },
+        type: {
+          S: "Dashboard",
+        },
+        version: {
+          N: "1",
+        },
+        dashboardName: {
+          S: "My Dashboard",
+        },
+      },
+    },
+  });
+
+  expect(AuditTrailService.handleModifiedItem).toBeCalledWith(
+    // Old item
+    expect.objectContaining({
+      pk: "Dashboard#1dcde43a-9700-41d3-b651-ceee60f7bdf8",
+      sk: "Dashboard#1dcde43a-9700-41d3-b651-ceee60f7bdf8",
+      type: "Dashboard",
+      version: 1,
+      dashboardName: "My Dashboard",
+    }),
+    // New item
+    expect.objectContaining({
+      pk: "Dashboard#1dcde43a-9700-41d3-b651-ceee60f7bdf8",
+      sk: "Dashboard#1dcde43a-9700-41d3-b651-ceee60f7bdf8",
+      type: "Dashboard",
+      version: 1,
+      dashboardName: "Bananas",
+    }),
+    new Date("2021-02-03T18:03:23.000Z")
+  );
+});
+
+it("handles a REMOVE record and delegates to AuditTrail service", async () => {
+  await StreamProcessor.processRecord({
+    eventID: "1735129",
+    eventName: "REMOVE",
+    eventSource: "aws:dynamodb",
+    dynamodb: {
+      ApproximateCreationDateTime: 1612375403,
+      Keys: {
+        pk: {
+          S: "Dashboard#1dcde43a-9700-41d3-b651-ceee60f7bdf8",
+        },
+        sk: {
+          S: "Dashboard#1dcde43a-9700-41d3-b651-ceee60f7bdf8",
+        },
+      },
+      OldImage: {
+        pk: {
+          S: "Dashboard#1dcde43a-9700-41d3-b651-ceee60f7bdf8",
+        },
+        sk: {
+          S: "Dashboard#1dcde43a-9700-41d3-b651-ceee60f7bdf8",
+        },
+        type: {
+          S: "Dashboard",
+        },
+        version: {
+          N: "1",
+        },
+      },
+    },
+  });
+
+  expect(AuditTrailService.handleDeletedItem).toBeCalledWith(
+    expect.objectContaining({
+      pk: "Dashboard#1dcde43a-9700-41d3-b651-ceee60f7bdf8",
+      sk: "Dashboard#1dcde43a-9700-41d3-b651-ceee60f7bdf8",
+      type: "Dashboard",
+      version: 1,
+    }),
+    new Date("2021-02-03T18:03:23.000Z")
+  );
+});

--- a/backend/src/lib/services/audit-trail.ts
+++ b/backend/src/lib/services/audit-trail.ts
@@ -1,0 +1,22 @@
+import logger from "./logger";
+
+async function handleModifiedItem(oldItem: any, newItem: any, timestamp: Date) {
+  logger.info("Creating audit log entry for modified item");
+  // TODO: Implement
+}
+
+async function handleCreatedItem(newItem: any, timestamp: Date) {
+  logger.info("Creating audit log entry for new created item");
+  // TODO: Implement
+}
+
+async function handleDeletedItem(oldItem: any, timestamp: Date) {
+  logger.info("Creating audit log entry for deleted item");
+  // TODO: Implement
+}
+
+export default {
+  handleModifiedItem,
+  handleCreatedItem,
+  handleDeletedItem,
+};

--- a/backend/src/lib/services/dynamodb.ts
+++ b/backend/src/lib/services/dynamodb.ts
@@ -1,4 +1,5 @@
 import AWSXRay from "aws-xray-sdk";
+import { DynamoDB } from "aws-sdk";
 import { DocumentClient } from "aws-sdk/clients/dynamodb";
 import logger from "./logger";
 
@@ -56,6 +57,15 @@ class DynamoDBService {
   async delete(input: DocumentClient.DeleteItemInput) {
     logger.debug("DynamoDB DeleteItem %o", input);
     return this.client.delete(input).promise();
+  }
+
+  /**
+   * This function is useful to convert records from DynamoDB Streams
+   * into Javascript objects. It maps the "S", "N", attributes into
+   * corresponding primitives (string, number, boolean, etc).
+   */
+  unmarshall(data: DynamoDB.AttributeMap) {
+    return DynamoDB.Converter.unmarshall(data);
   }
 
   async transactWrite(input: DocumentClient.TransactWriteItemsInput) {

--- a/backend/src/lib/services/stream-processor.ts
+++ b/backend/src/lib/services/stream-processor.ts
@@ -1,0 +1,102 @@
+import { DynamoDBRecord, StreamRecord } from "aws-lambda";
+import DynamoDBService from "./dynamodb";
+import AuditTrailService from "./audit-trail";
+import logger from "./logger";
+
+/**
+ * This function is the entry point for processing a single
+ * message coming from the DynamoDB Stream of the main table.
+ *
+ * Relevant documentation:
+ * https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.Lambda.Tutorial.html
+ */
+async function processRecord(record: DynamoDBRecord) {
+  if (!record.dynamodb || record.eventSource != "aws:dynamodb") {
+    logger.error("Discarding invalid stream record");
+    return;
+  }
+
+  switch (record.eventName) {
+    case "MODIFY":
+      logger.info("Handling MODIFY stream record");
+      return handleModifyRecord(record.dynamodb);
+
+    case "INSERT":
+      logger.info("Handling INSERT stream record");
+      return handleInsertRecord(record.dynamodb);
+
+    case "REMOVE":
+      logger.info("Handling REMOVE stream record");
+      return handleRemoveRecord(record.dynamodb);
+
+    default:
+      logger.error("Discarding stream record, unknown eventName");
+      return;
+  }
+}
+
+/**
+ * Handles a MODIFY record, which occurs when an item is updated on the
+ * main table. The record contains the old item (OldImage) and the new
+ * item (NewImage).
+ */
+async function handleModifyRecord(record: StreamRecord) {
+  if (!record.OldImage || !record.NewImage) {
+    logger.error("Discarding stream record. Missing `OldImage` or `NewImage`");
+    return;
+  }
+
+  const dynamodb = DynamoDBService.getInstance();
+  const oldItem = dynamodb.unmarshall(record.OldImage);
+  const newItem = dynamodb.unmarshall(record.NewImage);
+
+  const timestamp = getTimestampFromRecord(record);
+  return AuditTrailService.handleModifiedItem(oldItem, newItem, timestamp);
+}
+
+/**
+ * Handles an INSERT record, which occurs when a new item is created on the
+ * main table. The record contains the new item (NewImage).
+ */
+async function handleInsertRecord(record: StreamRecord) {
+  if (!record.NewImage) {
+    logger.error("Discarding stream record. Missing `NewImage`");
+    return;
+  }
+
+  const dynamodb = DynamoDBService.getInstance();
+  const newItem = dynamodb.unmarshall(record.NewImage);
+
+  const timestamp = getTimestampFromRecord(record);
+  return AuditTrailService.handleCreatedItem(newItem, timestamp);
+}
+
+/**
+ * Handles a REMOVE record, which occurs when an item is deleted from the
+ * main table. The record contains the deleted item (OldImage).
+ */
+async function handleRemoveRecord(record: StreamRecord) {
+  if (!record.OldImage) {
+    logger.error("Discarding stream record. Missing `OldImage`");
+    return;
+  }
+
+  const dynamodb = DynamoDBService.getInstance();
+  const oldItem = dynamodb.unmarshall(record.OldImage);
+
+  const timestamp = getTimestampFromRecord(record);
+  return AuditTrailService.handleDeletedItem(oldItem, timestamp);
+}
+
+function getTimestampFromRecord(record: StreamRecord): Date {
+  if (!record.ApproximateCreationDateTime) {
+    return new Date();
+  }
+
+  const epochTime = record.ApproximateCreationDateTime as number;
+  return new Date(epochTime * 1000);
+}
+
+export default {
+  processRecord,
+};


### PR DESCRIPTION
## Description

Implemented a Stream Processor that takes a message from the stream and handles INSERT, MODIFY and REMOVE records. It sends the old item and new item to the Audit Trail service to save a log entry in dynamodb. **Note** The implementation of the Audit Trail service will be in the next PR. 

## Testing

Wrote unit tests. Deployed and tested in my personal environment. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
