### PR TITLE
GTT-894: Modified the file input component to meet the UX wireframe

### DIFF
--- a/frontend/src/components/FileInput.css
+++ b/frontend/src/components/FileInput.css
@@ -1,0 +1,10 @@
+.fileIcon {
+  display: inline-block;
+  height: 0%;
+  vertical-align: middle;
+  padding-left: 30%;
+}
+
+#fileIconLabel {
+  margin-top: 0;
+}

--- a/frontend/src/components/FileInput.css
+++ b/frontend/src/components/FileInput.css
@@ -4,7 +4,3 @@
   vertical-align: middle;
   padding-left: 30%;
 }
-
-#fileIconLabel {
-  margin-top: 0;
-}

--- a/frontend/src/components/FileInput.tsx
+++ b/frontend/src/components/FileInput.tsx
@@ -1,5 +1,8 @@
 import React from "react";
 import Spinner from "./Spinner";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faFile } from "@fortawesome/free-solid-svg-icons";
+import "./FileInput.css";
 
 interface Props {
   id: string;
@@ -32,8 +35,23 @@ function FileInput(props: Props) {
     );
   } else if (props.fileName) {
     content = (
-      <div className="usa-file-input__instructions" aria-hidden="true">
-        {props.fileName}
+      <div>
+        <div className="usa-file-input__preview-heading">
+          Selected file{" "}
+          <span className="usa-file-input__choose">Change file</span>
+        </div>
+        <div className="usa-file-input__preview" aria-hidden="true">
+          <div className="usa-file-input__preview-image">
+            <div className="fileIcon" id="fileIconDiv">
+              <FontAwesomeIcon icon={faFile} size="lg" />
+            </div>
+          </div>
+          <div></div>
+          <label className="usa-label" htmlFor="fileIconDiv" id="fileIconLabel">
+            Test.png
+          </label>
+        </div>
+        <div className="usa-file-input__box"></div>
       </div>
     );
   }

--- a/frontend/src/components/FileInput.tsx
+++ b/frontend/src/components/FileInput.tsx
@@ -48,7 +48,7 @@ function FileInput(props: Props) {
           </div>
           <div></div>
           <label className="usa-label" htmlFor="fileIconDiv" id="fileIconLabel">
-            Test.png
+            {props.fileName}
           </label>
         </div>
         <div className="usa-file-input__box"></div>

--- a/frontend/src/components/FileInput.tsx
+++ b/frontend/src/components/FileInput.tsx
@@ -47,7 +47,7 @@ function FileInput(props: Props) {
             </div>
           </div>
           <div></div>
-          <label className="usa-label" htmlFor="fileIconDiv" id="fileIconLabel">
+          <label className="usa-label margin-top-0" htmlFor="fileIconDiv">
             {props.fileName}
           </label>
         </div>


### PR DESCRIPTION
## Description

This ticket was to meet the wireframe for what the file input component looks like when a file is selected. If you go to this [link](https://designsystem.digital.gov/components/form-controls/#file-input), you will see that by default this component matches the wireframe. However, because this component is using javascript to hide and show different classes, this does not work with react. Since with react you cannot modify the dom once its displayed. The dom will only change if you modify a state attribute.

Upon inspecting the site, you can see the classes that it is toggling in order to display the image like the wireframe. In this change, I manually show these classes as a function of the file state variable. I also added come CSS to get the label and file logo to align properly. In addition, in order to get the file icon, I used font awesome.

Only concerns are that we are adding additional dependency on external CSS. This component will already break if the CSS changes, this change would be adding additional dependency on the external CSS. We would need to be careful with updating uswds. 

Below is what the interface looks like now.

![Screen Shot 2021-02-03 at 20 49 25](https://user-images.githubusercontent.com/10676027/106833903-67d87800-6662-11eb-864c-0257a3aac228.png)


## Testing

Tests pass, initial tests to the front end look good. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
