### PR TITLE
Bug fix: Public users can now see images

### DIFF
--- a/cdk/lib/auth-stack.ts
+++ b/cdk/lib/auth-stack.ts
@@ -127,7 +127,12 @@ export class AuthStack extends cdk.Stack {
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
         actions: ["s3:GetObject"],
-        resources: [bucketArn.concat("/public/*.json")],
+        resources: [
+          bucketArn.concat("/public/*.json"),
+          bucketArn.concat("/public/*.png"),
+          bucketArn.concat("/public/*.jpg"),
+          bucketArn.concat("/public/*.svg"),
+        ],
       })
     );
 


### PR DESCRIPTION
## Description

I added image file types to the public user policy, so they don't get 403 errors on the front end.

## Testing

I deployed to my AWS account, and published a dashboard, and when into an incognito window, and tried viewing it as a public user. It worked.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
