### PR TITLE
Chart improvements for LineChart, BarChart, and ColumnChart

### DIFF
--- a/frontend/src/components/BarChartPreview.tsx
+++ b/frontend/src/components/BarChartPreview.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import {
   XAxis,
   YAxis,
@@ -15,12 +15,19 @@ type Props = {
   title: string;
   summary: string;
   bars: Array<string>;
-  data?: Array<object>;
+  data?: Array<any>;
   summaryBelow: boolean;
 };
 
 const BarChartPreview = (props: Props) => {
   const colors = useColors(props.bars.length);
+  const yAxisType = useCallback(() => {
+    return props.data &&
+      props.data.every((row) => typeof row[props.bars[0]] === "number")
+      ? "number"
+      : "category";
+  }, [props]);
+
   return (
     <div>
       <h2 className="margin-left-1 margin-bottom-1">{props.title}</h2>
@@ -42,7 +49,7 @@ const BarChartPreview = (props: Props) => {
           <XAxis type="number" />
           <YAxis
             dataKey={props.bars.length ? props.bars[0] : ""}
-            type="category"
+            type={yAxisType()}
             width={
               (props.data
                 ?.map((d) => (d as any)[props.bars.length ? props.bars[0] : ""])

--- a/frontend/src/components/BarChartPreview.tsx
+++ b/frontend/src/components/BarChartPreview.tsx
@@ -21,12 +21,12 @@ type Props = {
 
 const BarChartPreview = (props: Props) => {
   const colors = useColors(props.bars.length);
+  const { data, bars } = props;
   const yAxisType = useCallback(() => {
-    return props.data &&
-      props.data.every((row) => typeof row[props.bars[0]] === "number")
+    return data && data.every((row) => typeof row[bars[0]] === "number")
       ? "number"
       : "category";
-  }, [props]);
+  }, [data, bars]);
 
   return (
     <div>

--- a/frontend/src/components/ColumnChartPreview.tsx
+++ b/frontend/src/components/ColumnChartPreview.tsx
@@ -20,12 +20,12 @@ type Props = {
 
 const ColumnChartPreview = (props: Props) => {
   const colors = useColors(props.columns.length);
+  const { data, columns } = props;
   const xAxisType = useCallback(() => {
-    return props.data &&
-      props.data.every((row) => typeof row[props.columns[0]] === "number")
+    return data && data.every((row) => typeof row[columns[0]] === "number")
       ? "number"
       : "category";
-  }, [props]);
+  }, [data, columns]);
 
   return (
     <div>

--- a/frontend/src/components/ColumnChartPreview.tsx
+++ b/frontend/src/components/ColumnChartPreview.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 import {
   XAxis,
   YAxis,
@@ -7,6 +7,7 @@ import {
   Legend,
   ResponsiveContainer,
   CartesianGrid,
+  Tooltip,
 } from "recharts";
 import { useColors } from "../hooks";
 
@@ -19,7 +20,20 @@ type Props = {
 };
 
 const ColumnChartPreview = (props: Props) => {
+  const [columnsHover, setColumnsHover] = useState(null);
+  const [hiddenColumns, setHiddenColumns] = useState<Array<string>>([]);
   const colors = useColors(props.columns.length);
+
+  const getOpacity = useCallback(
+    (dataKey) => {
+      if (!columnsHover) {
+        return 1;
+      }
+      return columnsHover === dataKey ? 1 : 0.2;
+    },
+    [columnsHover]
+  );
+
   const { data, columns } = props;
   const xAxisType = useCallback(() => {
     return data && data.every((row) => typeof row[columns[0]] === "number")
@@ -27,11 +41,20 @@ const ColumnChartPreview = (props: Props) => {
       : "category";
   }, [data, columns]);
 
+  const toggleColumns = (e: any) => {
+    if (hiddenColumns.includes(e.dataKey)) {
+      const hidden = hiddenColumns.filter((column) => column !== e.dataKey);
+      setHiddenColumns(hidden);
+    } else {
+      setHiddenColumns([...hiddenColumns, e.dataKey]);
+    }
+  };
+
   return (
     <div>
       <h2 className="margin-left-1 margin-bottom-1">{props.title}</h2>
       {!props.summaryBelow && (
-        <p className="margin-left-1 margin-top-0 margin-bottom-3">
+        <p className="margin-left-1 margin-top-0 margin-bottom-2">
           {props.summary}
         </p>
       )}
@@ -42,12 +65,27 @@ const ColumnChartPreview = (props: Props) => {
             dataKey={props.columns.length ? props.columns[0] : ""}
             type={xAxisType()}
             padding={{ left: 20, right: 20 }}
+            domain={[0, "dataMax"]}
           />
-          <YAxis type="number" />
-          <Legend />
+          <YAxis type="number" domain={[0, "dataMax"]} />
+          <Tooltip cursor={{ fill: "#F0F0F0" }} />
+          <Legend
+            verticalAlign="top"
+            onClick={toggleColumns}
+            onMouseLeave={(e) => setColumnsHover(null)}
+            onMouseEnter={(e) => setColumnsHover(e.dataKey)}
+          />
           {props.columns.length &&
             props.columns.slice(1).map((column, index) => {
-              return <Bar dataKey={column} fill={colors[index]} key={index} />;
+              return (
+                <Bar
+                  dataKey={column}
+                  fill={colors[index]}
+                  key={index}
+                  fillOpacity={getOpacity(column)}
+                  hide={hiddenColumns.includes(column)}
+                />
+              );
             })}
         </BarChart>
       </ResponsiveContainer>

--- a/frontend/src/components/ColumnChartPreview.tsx
+++ b/frontend/src/components/ColumnChartPreview.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import {
   XAxis,
   YAxis,
@@ -14,12 +14,19 @@ type Props = {
   title: string;
   summary: string;
   columns: Array<string>;
-  data?: Array<object>;
+  data?: Array<any>;
   summaryBelow: boolean;
 };
 
 const ColumnChartPreview = (props: Props) => {
   const colors = useColors(props.columns.length);
+  const xAxisType = useCallback(() => {
+    return props.data &&
+      props.data.every((row) => typeof row[props.columns[0]] === "number")
+      ? "number"
+      : "category";
+  }, [props]);
+
   return (
     <div>
       <h2 className="margin-left-1 margin-bottom-1">{props.title}</h2>
@@ -33,7 +40,7 @@ const ColumnChartPreview = (props: Props) => {
           <CartesianGrid vertical={false} />
           <XAxis
             dataKey={props.columns.length ? props.columns[0] : ""}
-            type="category"
+            type={xAxisType()}
             padding={{ left: 20, right: 20 }}
           />
           <YAxis type="number" />

--- a/frontend/src/components/LineChartPreview.tsx
+++ b/frontend/src/components/LineChartPreview.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import {
   XAxis,
   YAxis,
@@ -14,12 +14,19 @@ type Props = {
   title: string;
   summary: string;
   lines: Array<string>;
-  data?: Array<object>;
+  data?: Array<any>;
   summaryBelow: boolean;
 };
 
 const LineChartPreview = (props: Props) => {
   const colors = useColors(props.lines.length);
+  const xAxisType = useCallback(() => {
+    return props.data &&
+      props.data.every((row) => typeof row[props.lines[0]] === "number")
+      ? "number"
+      : "category";
+  }, [props]);
+
   return (
     <div>
       <h2 className="margin-left-1 margin-bottom-1">{props.title}</h2>
@@ -33,7 +40,7 @@ const LineChartPreview = (props: Props) => {
           <CartesianGrid vertical={false} />
           <XAxis
             dataKey={props.lines.length ? props.lines[0] : ""}
-            type="category"
+            type={xAxisType()}
             padding={{ left: 20, right: 20 }}
           />
           <YAxis type="number" />

--- a/frontend/src/components/LineChartPreview.tsx
+++ b/frontend/src/components/LineChartPreview.tsx
@@ -20,12 +20,12 @@ type Props = {
 
 const LineChartPreview = (props: Props) => {
   const colors = useColors(props.lines.length);
+  const { data, lines } = props;
   const xAxisType = useCallback(() => {
-    return props.data &&
-      props.data.every((row) => typeof row[props.lines[0]] === "number")
+    return data && data.every((row) => typeof row[lines[0]] === "number")
       ? "number"
       : "category";
-  }, [props]);
+  }, [data, lines]);
 
   return (
     <div>

--- a/frontend/src/components/LineChartPreview.tsx
+++ b/frontend/src/components/LineChartPreview.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 import {
   XAxis,
   YAxis,
@@ -7,6 +7,7 @@ import {
   Legend,
   ResponsiveContainer,
   CartesianGrid,
+  Tooltip,
 } from "recharts";
 import { useColors } from "../hooks";
 
@@ -19,7 +20,20 @@ type Props = {
 };
 
 const LineChartPreview = (props: Props) => {
+  const [linesHover, setLinesHover] = useState(null);
+  const [hiddenLines, setHiddenLines] = useState<Array<string>>([]);
   const colors = useColors(props.lines.length);
+
+  const getOpacity = useCallback(
+    (dataKey) => {
+      if (!linesHover) {
+        return 1;
+      }
+      return linesHover === dataKey ? 1 : 0.2;
+    },
+    [linesHover]
+  );
+
   const { data, lines } = props;
   const xAxisType = useCallback(() => {
     return data && data.every((row) => typeof row[lines[0]] === "number")
@@ -27,11 +41,20 @@ const LineChartPreview = (props: Props) => {
       : "category";
   }, [data, lines]);
 
+  const toggleLines = (e: any) => {
+    if (hiddenLines.includes(e.dataKey)) {
+      const hidden = hiddenLines.filter((line) => line !== e.dataKey);
+      setHiddenLines(hidden);
+    } else {
+      setHiddenLines([...hiddenLines, e.dataKey]);
+    }
+  };
+
   return (
     <div>
       <h2 className="margin-left-1 margin-bottom-1">{props.title}</h2>
       {!props.summaryBelow && (
-        <p className="margin-left-1 margin-top-0 margin-bottom-3">
+        <p className="margin-left-1 margin-top-0 margin-bottom-2">
           {props.summary}
         </p>
       )}
@@ -42,18 +65,27 @@ const LineChartPreview = (props: Props) => {
             dataKey={props.lines.length ? props.lines[0] : ""}
             type={xAxisType()}
             padding={{ left: 20, right: 20 }}
+            domain={[0, "dataMax"]}
           />
           <YAxis type="number" />
-          <Legend />
+          <Tooltip cursor={{ fill: "#F0F0F0" }} />
+          <Legend
+            verticalAlign="top"
+            onClick={toggleLines}
+            onMouseLeave={(e) => setLinesHover(null)}
+            onMouseEnter={(e) => setLinesHover(e.dataKey)}
+          />
           {props.lines.length &&
             props.lines.slice(1).map((line, index) => {
               return (
                 <Line
                   dataKey={line}
+                  type="monotone"
                   stroke={colors[index]}
                   key={index}
-                  dot={false}
                   strokeWidth="2"
+                  strokeOpacity={getOpacity(line)}
+                  hide={hiddenLines.includes(line)}
                 />
               );
             })}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -42,3 +42,7 @@ p {
 .preview-container {
   overflow: auto;
 }
+
+div > .recharts-surface {
+  margin-top: 24px;
+}


### PR DESCRIPTION
## Description

This PR includes the following improvements for LineChart, BarChart, and ColumnChart:

GTT-855: Hovering on legend entry highlights and fades chart data
GTT-856: Hide/show data by interacting with chart legend
GTT-857: Hover on chart elements for more details
GTT-858: Line charts have indicators for each data point
GTT-865: Chart legend is above the data visualization

The PartToWhole improvements will be added in a separate PR.

## Testing

You can test it here: https://migdizn.badger.wwps.aws.dev/admin/dashboard/ab13ccfa-17e5-4f5f-826d-0c628a621edc/edit-chart/c6bd9e03-11f9-4263-8c2e-eb2bd4d71325

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
