### PR TITLE
GTT-930 - Implemented audit trail service to capture changes to dashboard items

### DIFF
--- a/backend/src/lib/factories/__tests__/auditlog-factory.test.ts
+++ b/backend/src/lib/factories/__tests__/auditlog-factory.test.ts
@@ -1,0 +1,128 @@
+import {
+  Dashboard,
+  DashboardState,
+  DASHBOARD_ITEM_TYPE,
+} from "../../models/dashboard";
+import AuditLogFactory from "../auditlog-factory";
+import { ItemEvent } from "../../models/auditlog";
+
+const timestamp = new Date();
+
+describe("buildDashboardAuditLogFromEvent", () => {
+  it("builds an audit log for a create event", () => {
+    const dashboard: Dashboard = {
+      id: "8d44e664",
+      name: "Immigrant Population Dashboard",
+      version: 1,
+      parentDashboardId: "d5f6b6e4bb22",
+      topicAreaId: "be9a",
+      topicAreaName: "Department of Homeland Security",
+      description: "",
+      createdBy: "johndoe",
+      updatedAt: new Date(),
+      state: DashboardState.Draft,
+    };
+
+    const auditLog = AuditLogFactory.buildDashboardAuditLogFromEvent(
+      ItemEvent.Create,
+      timestamp,
+      dashboard
+    );
+
+    expect(auditLog.event).toEqual(ItemEvent.Create);
+    expect(auditLog.sk).toEqual(timestamp.toISOString());
+    expect(auditLog.pk).toEqual("Dashboard#d5f6b6e4bb22");
+    expect(auditLog.type).toEqual(DASHBOARD_ITEM_TYPE);
+    expect(auditLog.userId).toEqual("johndoe");
+    expect(auditLog.version).toEqual(1);
+  });
+
+  it("builds an audit log for an update event", () => {
+    const dashboard: Dashboard = {
+      id: "8d44e664",
+      name: "Immigrant Population Dashboard",
+      version: 1,
+      parentDashboardId: "d5f6b6e4bb22",
+      topicAreaId: "be9a",
+      topicAreaName: "Department of Homeland Security",
+      description: "",
+      createdBy: "johndoe",
+      updatedAt: new Date(),
+      state: DashboardState.PublishPending,
+    };
+
+    const oldDashboard: Dashboard = {
+      id: "8d44e664",
+      name: "US Citizens Population Dashboard",
+      version: 1,
+      parentDashboardId: "d5f6b6e4bb22",
+      topicAreaId: "be9a",
+      topicAreaName: "Department of Homeland Security",
+      description: "",
+      createdBy: "johndoe",
+      updatedAt: new Date(),
+      state: DashboardState.Draft,
+    };
+
+    const auditLog = AuditLogFactory.buildDashboardAuditLogFromEvent(
+      ItemEvent.Update,
+      timestamp,
+      dashboard,
+      oldDashboard
+    );
+
+    expect(auditLog.event).toEqual(ItemEvent.Update);
+    expect(auditLog.sk).toEqual(timestamp.toISOString());
+    expect(auditLog.pk).toEqual("Dashboard#d5f6b6e4bb22");
+    expect(auditLog.type).toEqual(DASHBOARD_ITEM_TYPE);
+    expect(auditLog.userId).toEqual("Unknown");
+    expect(auditLog.version).toEqual(1);
+    expect(auditLog.modifiedProperties).toEqual(
+      expect.arrayContaining([
+        {
+          property: "name",
+          oldValue: "US Citizens Population Dashboard",
+          newValue: "Immigrant Population Dashboard",
+        },
+        {
+          property: "state",
+          oldValue: DashboardState.Draft,
+          newValue: DashboardState.PublishPending,
+        },
+        {
+          property: "updatedAt",
+          oldValue: oldDashboard.updatedAt.toISOString(),
+          newValue: dashboard.updatedAt.toISOString(),
+        },
+      ])
+    );
+  });
+
+  it("builds an audit log for a delete event", () => {
+    const dashboard: Dashboard = {
+      id: "8d44e664",
+      name: "Immigrant Population Dashboard",
+      version: 1,
+      parentDashboardId: "d5f6b6e4bb22",
+      topicAreaId: "be9a",
+      topicAreaName: "Department of Homeland Security",
+      description: "",
+      createdBy: "johndoe",
+      updatedAt: new Date(),
+      state: DashboardState.Draft,
+    };
+
+    const auditLog = AuditLogFactory.buildDashboardAuditLogFromEvent(
+      ItemEvent.Delete,
+      timestamp,
+      dashboard
+    );
+
+    expect(auditLog.event).toEqual(ItemEvent.Delete);
+    expect(auditLog.sk).toEqual(timestamp.toISOString());
+    expect(auditLog.pk).toEqual("Dashboard#d5f6b6e4bb22");
+    expect(auditLog.type).toEqual(DASHBOARD_ITEM_TYPE);
+    expect(auditLog.userId).toEqual("Unknown");
+    expect(auditLog.version).toEqual(1);
+  });
+});

--- a/backend/src/lib/factories/auditlog-factory.ts
+++ b/backend/src/lib/factories/auditlog-factory.ts
@@ -1,0 +1,70 @@
+import {
+  DashboardAuditLogItem,
+  ModifiedProperty,
+  ItemEvent,
+} from "../models/auditlog";
+import { Dashboard, DASHBOARD_ITEM_TYPE } from "../models/dashboard";
+import DashboardFactory from "./dashboard-factory";
+
+/**
+ * Builds an AuditLog dynamodb item that corresponds to the
+ * event that happend: Dashboard created, updated or deleted.
+ * If the event is Update, the list of modifiedProperties
+ * will be populated.
+ */
+function buildDashboardAuditLogFromEvent(
+  event: ItemEvent,
+  timestamp: Date,
+  dashboard: Dashboard,
+  oldDashboard?: Dashboard
+): DashboardAuditLogItem {
+  // TODO: Add `updatedBy` attribute to Dashboard model
+  const user = event === ItemEvent.Create ? dashboard.createdBy : "Unknown";
+
+  const auditLog: DashboardAuditLogItem = {
+    pk: DashboardFactory.itemId(dashboard.parentDashboardId),
+    sk: timestamp.toISOString(),
+    type: DASHBOARD_ITEM_TYPE,
+    userId: user,
+    version: dashboard.version,
+    event,
+  };
+
+  if (event === ItemEvent.Update) {
+    auditLog.modifiedProperties = getModifiedProps(oldDashboard, dashboard);
+  }
+
+  return auditLog;
+}
+
+/**
+ * Compares 2 dynamodb items and returns the properties that have changed
+ * in the newItem compared to the oldItem.
+ */
+function getModifiedProps(oldItem: any, newItem: any): ModifiedProperty[] {
+  const keys = [...Object.keys(oldItem), ...Object.keys(newItem)];
+  const props = new Set<string>(keys);
+  const modifiedProps: ModifiedProperty[] = [];
+
+  props.forEach((prop) => {
+    if (oldItem[prop] !== newItem[prop]) {
+      modifiedProps.push({
+        property: prop,
+        oldValue: getPropValue(oldItem, prop),
+        newValue: getPropValue(newItem, prop),
+      });
+    }
+  });
+
+  return modifiedProps;
+}
+
+function getPropValue(item: any, prop: string) {
+  if (!item[prop]) return "";
+  if (item[prop] instanceof Date) return item[prop].toISOString();
+  return item[prop];
+}
+
+export default {
+  buildDashboardAuditLogFromEvent,
+};

--- a/backend/src/lib/factories/dashboard-factory.ts
+++ b/backend/src/lib/factories/dashboard-factory.ts
@@ -9,9 +9,8 @@ import {
   DashboardState,
   DashboardVersion,
   PublicDashboard,
+  DASHBOARD_ITEM_TYPE,
 } from "../models/dashboard";
-
-const DASHBOARD_ITEM_TYPE: string = "Dashboard";
 
 function createNew(
   name: string,

--- a/backend/src/lib/models/auditlog.ts
+++ b/backend/src/lib/models/auditlog.ts
@@ -1,0 +1,27 @@
+// Represents a dynamodb item in the Audit Trail table
+export interface AuditLogItem {
+  pk: string;
+  sk: string;
+  type: string;
+  userId: string;
+  event: ItemEvent;
+}
+
+export enum ItemEvent {
+  Create = "Create",
+  Update = "Update",
+  Delete = "Delete",
+}
+
+export type ModifiedProperty = {
+  property: string;
+  oldValue: any;
+  newValue: any;
+};
+
+// Represents a dynamodb item in the Audit Trail table that
+// contains attributes specific to Dashboard audit logs.
+export interface DashboardAuditLogItem extends AuditLogItem {
+  version: number;
+  modifiedProperties?: ModifiedProperty[];
+}

--- a/backend/src/lib/models/dashboard.ts
+++ b/backend/src/lib/models/dashboard.ts
@@ -1,5 +1,7 @@
 import { Widget } from "./widget";
 
+export const DASHBOARD_ITEM_TYPE = "Dashboard";
+
 export enum DashboardState {
   Draft = "Draft",
   Published = "Published",

--- a/backend/src/lib/repositories/__tests__/auditlog-repo.test.ts
+++ b/backend/src/lib/repositories/__tests__/auditlog-repo.test.ts
@@ -1,0 +1,22 @@
+import { mocked } from "ts-jest/utils";
+import { AuditLogItem } from "../../models/auditlog";
+import AuditLogRepository from "../auditlog-repo";
+import DynamoDBService from "../../services/dynamodb";
+
+jest.mock("../../services/dynamodb");
+
+process.env.AUDIT_TRAIL_TABLE = "AuditTrailTable";
+
+const dynamodb = mocked(DynamoDBService.prototype);
+DynamoDBService.getInstance = jest.fn().mockReturnValue(dynamodb);
+
+describe("saveAuditLog", () => {
+  it("calls putItem on dynamodb service", async () => {
+    const auditLog = {} as AuditLogItem;
+    await AuditLogRepository.saveAuditLog(auditLog);
+    expect(dynamodb.put).toBeCalledWith({
+      TableName: "AuditTrailTable",
+      Item: auditLog,
+    });
+  });
+});

--- a/backend/src/lib/repositories/auditlog-repo.ts
+++ b/backend/src/lib/repositories/auditlog-repo.ts
@@ -1,0 +1,20 @@
+import { AuditLogItem } from "../models/auditlog";
+import DynamoDBService from "../services/dynamodb";
+import logger from "../services/logger";
+
+async function saveAuditLog(auditLog: AuditLogItem) {
+  const dynamodb = DynamoDBService.getInstance();
+  logger.info("Saving audit log record %o", auditLog);
+  return dynamodb.put({
+    TableName: getTableName(),
+    Item: auditLog,
+  });
+}
+
+function getTableName(): string {
+  return process.env.AUDIT_TRAIL_TABLE as string;
+}
+
+export default {
+  saveAuditLog,
+};

--- a/backend/src/lib/services/__tests__/audit-trail.test.ts
+++ b/backend/src/lib/services/__tests__/audit-trail.test.ts
@@ -1,25 +1,108 @@
+import { Dashboard, DASHBOARD_ITEM_TYPE } from "../../models/dashboard";
 import AuditTrailService from "../audit-trail";
+import AuditLogFactory from "../../factories/auditlog-factory";
+import DashboardFactory from "../../factories/dashboard-factory";
+import AuditLogRepository from "../../repositories/auditlog-repo";
+import { ItemEvent } from "../..//models/auditlog";
+
+jest.mock("../../factories/dashboard-factory");
+jest.mock("../../factories/auditlog-factory");
+jest.mock("../../repositories/auditlog-repo");
 
 const timestamp = new Date();
 
-describe("handleCreatedItem", () => {
-  it("does nothing", async () => {
-    const newItem = {};
-    await AuditTrailService.handleCreatedItem(newItem, timestamp);
-  });
-});
+describe("handleItemEvent", () => {
+  it("discards event if item is not a Dashboard", async () => {
+    const newItem = { foo: "bar", type: "not a dashboard" };
+    const oldItem = { foo: "notbar", type: "not a dashboard" };
 
-describe("handleModifiedItem", () => {
-  it("does nothing", async () => {
-    const newItem = {};
-    const oldItem = {};
-    await AuditTrailService.handleModifiedItem(oldItem, newItem, timestamp);
-  });
-});
+    await AuditTrailService.handleItemEvent(
+      ItemEvent.Create,
+      oldItem,
+      newItem,
+      timestamp
+    );
 
-describe("handleDeletedItem", () => {
-  it("does nothing", async () => {
-    const oldItem = {};
-    await AuditTrailService.handleDeletedItem(oldItem, timestamp);
+    expect(DashboardFactory.fromItem).not.toBeCalled();
+    expect(AuditLogRepository.saveAuditLog).not.toBeCalled();
+    expect(AuditLogFactory.buildDashboardAuditLogFromEvent).not.toBeCalled();
+  });
+
+  it("creates an audit log for a dashboard create event", async () => {
+    const newItem = { foo: "bar", type: DASHBOARD_ITEM_TYPE };
+    const oldItem = null;
+
+    const newDashboard = {} as Dashboard;
+    DashboardFactory.fromItem = jest.fn().mockReturnValue(newDashboard);
+
+    await AuditTrailService.handleItemEvent(
+      ItemEvent.Create,
+      oldItem,
+      newItem,
+      timestamp
+    );
+
+    expect(DashboardFactory.fromItem).toBeCalledWith(newItem);
+    expect(AuditLogRepository.saveAuditLog).toBeCalled();
+    expect(AuditLogFactory.buildDashboardAuditLogFromEvent).toBeCalledWith(
+      ItemEvent.Create,
+      timestamp,
+      newDashboard,
+      undefined
+    );
+  });
+
+  it("creates an audit log for a dashboard update event", async () => {
+    const newItem = { fizz: "buzz", type: DASHBOARD_ITEM_TYPE };
+    const oldItem = { fizz: "notbuzz", type: DASHBOARD_ITEM_TYPE };
+
+    const newDashboard = {} as Dashboard;
+    const oldDashboard = {} as Dashboard;
+    DashboardFactory.fromItem = jest
+      .fn()
+      .mockReturnValueOnce(newDashboard) // first call returns new dashboard
+      .mockReturnValueOnce(oldDashboard); // second call is for old dashboard
+
+    await AuditTrailService.handleItemEvent(
+      ItemEvent.Update,
+      oldItem,
+      newItem,
+      timestamp
+    );
+
+    expect(DashboardFactory.fromItem).toBeCalledWith(newItem);
+    expect(DashboardFactory.fromItem).toBeCalledWith(oldItem);
+
+    expect(AuditLogRepository.saveAuditLog).toBeCalled();
+    expect(AuditLogFactory.buildDashboardAuditLogFromEvent).toBeCalledWith(
+      ItemEvent.Update,
+      timestamp,
+      newDashboard,
+      oldDashboard
+    );
+  });
+
+  it("creates an audit log for a dashboard delete event", async () => {
+    const newItem = null;
+    const oldItem = { fizz: "buzz", type: DASHBOARD_ITEM_TYPE };
+
+    const oldDashboard = {} as Dashboard;
+    DashboardFactory.fromItem = jest.fn().mockReturnValue(oldDashboard);
+
+    await AuditTrailService.handleItemEvent(
+      ItemEvent.Delete,
+      oldItem,
+      newItem,
+      timestamp
+    );
+
+    expect(DashboardFactory.fromItem).toBeCalledWith(oldItem);
+    expect(AuditLogRepository.saveAuditLog).toBeCalled();
+    expect(AuditLogFactory.buildDashboardAuditLogFromEvent).toBeCalledWith(
+      ItemEvent.Delete,
+      timestamp,
+      oldDashboard,
+      undefined
+    );
   });
 });


### PR DESCRIPTION
## Description

Implemented Audit Trail service to create audit log entries for changes in Dashboard items. It handles the 3 types of events that can happen to a dashboard dynamodb item: Create, Update and Delete. 

## Testing

Deployed to my personal environment and verified that all changes are being captured. If the event is an `Update`, it also captures the properties that changed. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
