### PR TITLE
Part to whole chart improvements

### DIFF
--- a/frontend/src/components/LineChartPreview.tsx
+++ b/frontend/src/components/LineChartPreview.tsx
@@ -83,7 +83,7 @@ const LineChartPreview = (props: Props) => {
                   type="monotone"
                   stroke={colors[index]}
                   key={index}
-                  strokeWidth="2"
+                  strokeWidth={3}
                   strokeOpacity={getOpacity(line)}
                   hide={hiddenLines.includes(line)}
                 />


### PR DESCRIPTION
## Description

This PR includes the following improvements for PartToWholeChart:

GTT-855: Hovering on legend entry highlights and fades chart data
GTT-856: Hide/show data by interacting with chart legend
PartToWhole 2px in between parts

## Testing

You can test it here: https://migdizn.badger.wwps.aws.dev/admin/dashboard/ab13ccfa-17e5-4f5f-826d-0c628a621edc/edit-chart/c6bd9e03-11f9-4263-8c2e-eb2bd4d71325

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
