### PR TITLE
GTT-931 Endpoint to list dashboard audit logs

### DIFF
--- a/backend/src/lib/api/dashboard-api.ts
+++ b/backend/src/lib/api/dashboard-api.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { Role } from "../models/user";
 import DashboardCtrl from "../controllers/dashboard-ctrl";
+import AuditLogCtrl from "../controllers/auditlog-ctrl";
 import WidgetCtrl from "../controllers/widget-ctrl";
 import errorHandler from "./middleware/error-handler";
 import auth from "./middleware/auth";
@@ -25,6 +26,12 @@ router.get(
   "/:id/versions",
   rbac(Role.Admin, Role.Editor),
   errorHandler(DashboardCtrl.getVersions)
+);
+
+router.get(
+  "/:id/auditlogs",
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(AuditLogCtrl.listDashboardAuditLogs)
 );
 
 router.post(

--- a/backend/src/lib/controllers/__tests__/auditlog-ctrl.test.ts
+++ b/backend/src/lib/controllers/__tests__/auditlog-ctrl.test.ts
@@ -1,0 +1,34 @@
+import { Request, Response } from "express";
+import { AuditLog } from "../..//models/auditlog";
+import AuditLogCtrl from "../auditlog-ctrl";
+import AuditLogRepository from "../../repositories/auditlog-repo";
+
+jest.mock("../../repositories/auditlog-repo");
+
+let req: Request;
+let res: Response;
+
+beforeEach(() => {
+  res = ({
+    send: jest.fn().mockReturnThis(),
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  } as any) as Response;
+});
+
+describe("listDashboardAuditLogs", () => {
+  it("calls the audit log repository with parentDashboardId and returns logs", async () => {
+    req = ({
+      params: {
+        id: "001",
+      },
+    } as any) as Request;
+
+    const auditLogs = [] as AuditLog[];
+    AuditLogRepository.listAuditLogs = jest.fn().mockReturnValue(auditLogs);
+    await AuditLogCtrl.listDashboardAuditLogs(req, res);
+
+    expect(AuditLogRepository.listAuditLogs).toBeCalledWith("Dashboard#001");
+    expect(res.json).toBeCalledWith(auditLogs);
+  });
+});

--- a/backend/src/lib/controllers/auditlog-ctrl.ts
+++ b/backend/src/lib/controllers/auditlog-ctrl.ts
@@ -1,0 +1,19 @@
+import { Request, Response } from "express";
+import DashboardFactory from "../factories/dashboard-factory";
+import AuditLogRepository from "../repositories/auditlog-repo";
+import logger from "../services/logger";
+
+async function listDashboardAuditLogs(req: Request, res: Response) {
+  const parentDashboardId = req.params.id;
+
+  logger.info("Listing audit logs for dashboard family %s", parentDashboardId);
+  const primaryKey = DashboardFactory.itemId(parentDashboardId);
+  const auditLogs = await AuditLogRepository.listAuditLogs(primaryKey);
+
+  logger.debug("Fetched audit logs %o", auditLogs);
+  return res.json(auditLogs);
+}
+
+export default {
+  listDashboardAuditLogs,
+};

--- a/backend/src/lib/factories/__tests__/auditlog-factory.test.ts
+++ b/backend/src/lib/factories/__tests__/auditlog-factory.test.ts
@@ -4,7 +4,7 @@ import {
   DASHBOARD_ITEM_TYPE,
 } from "../../models/dashboard";
 import AuditLogFactory from "../auditlog-factory";
-import { ItemEvent } from "../../models/auditlog";
+import { DashboardAuditLogItem, ItemEvent } from "../../models/auditlog";
 
 const timestamp = new Date();
 
@@ -124,5 +124,42 @@ describe("buildDashboardAuditLogFromEvent", () => {
     expect(auditLog.type).toEqual(DASHBOARD_ITEM_TYPE);
     expect(auditLog.userId).toEqual("Unknown");
     expect(auditLog.version).toEqual(1);
+  });
+});
+
+describe("fromItem", () => {
+  it("returns a dashboard audit log", () => {
+    const auditLogItem: DashboardAuditLogItem = {
+      pk: "Dashboard#001",
+      sk: "2021-02-06T02:53:33.935Z",
+      type: DASHBOARD_ITEM_TYPE,
+      userId: "johndoe",
+      version: 1,
+      event: ItemEvent.Update,
+      modifiedProperties: [
+        {
+          property: "name",
+          oldValue: "Foo",
+          newValue: "Bar",
+        },
+      ],
+    };
+
+    const auditLog = AuditLogFactory.fromItem(auditLogItem);
+    expect(auditLog).not.toBe(null);
+    expect(auditLog).toEqual({
+      itemId: "001",
+      timestamp: new Date("2021-02-06T02:53:33.935Z"),
+      userId: "johndoe",
+      version: 1,
+      event: ItemEvent.Update,
+      modifiedProperties: [
+        {
+          property: "name",
+          oldValue: "Foo",
+          newValue: "Bar",
+        },
+      ],
+    });
   });
 });

--- a/backend/src/lib/factories/auditlog-factory.ts
+++ b/backend/src/lib/factories/auditlog-factory.ts
@@ -1,4 +1,7 @@
 import {
+  AuditLog,
+  AuditLogItem,
+  DashboardAuditLog,
   DashboardAuditLogItem,
   ModifiedProperty,
   ItemEvent,
@@ -38,6 +41,28 @@ function buildDashboardAuditLogFromEvent(
 }
 
 /**
+ * Builds an AuditLog object from a AuditLog dynamodb item. Just like
+ * the WidgetFactory.fromItem, this function returns the concrete AuditLog
+ * type depending on the item type, i.e. DashboardAuditLogItem for a Dashboard item.
+ */
+function fromItem(auditLogItem: AuditLogItem): AuditLog | null {
+  if (auditLogItem.type === DASHBOARD_ITEM_TYPE) {
+    const dashboardAuditLogItem = auditLogItem as DashboardAuditLogItem;
+    return {
+      itemId: DashboardFactory.dashboardIdFromPk(dashboardAuditLogItem.pk),
+      timestamp: new Date(dashboardAuditLogItem.sk),
+      event: dashboardAuditLogItem.event,
+      userId: dashboardAuditLogItem.userId,
+      modifiedProperties: dashboardAuditLogItem.modifiedProperties,
+      version: dashboardAuditLogItem.version,
+    } as DashboardAuditLog;
+  }
+
+  // Item type not recognized, should not happen.
+  return null;
+}
+
+/**
  * Compares 2 dynamodb items and returns the properties that have changed
  * in the newItem compared to the oldItem.
  */
@@ -66,5 +91,6 @@ function getPropValue(item: any, prop: string) {
 }
 
 export default {
+  fromItem,
   buildDashboardAuditLogFromEvent,
 };

--- a/backend/src/lib/factories/dashboard-factory.ts
+++ b/backend/src/lib/factories/dashboard-factory.ts
@@ -155,4 +155,5 @@ export default {
   toPublic,
   toVersion,
   generateFriendlyURL,
+  dashboardIdFromPk,
 };

--- a/backend/src/lib/models/auditlog.ts
+++ b/backend/src/lib/models/auditlog.ts
@@ -1,12 +1,3 @@
-// Represents a dynamodb item in the Audit Trail table
-export interface AuditLogItem {
-  pk: string;
-  sk: string;
-  type: string;
-  userId: string;
-  event: ItemEvent;
-}
-
 export enum ItemEvent {
   Create = "Create",
   Update = "Update",
@@ -19,9 +10,30 @@ export type ModifiedProperty = {
   newValue: any;
 };
 
+export interface AuditLog {
+  itemId: string;
+  timestamp: Date;
+  userId: string;
+  event: ItemEvent;
+  modifiedProperties?: ModifiedProperty[];
+}
+
+// Represents a dynamodb item in the Audit Trail table
+export interface AuditLogItem {
+  pk: string;
+  sk: string;
+  type: string;
+  userId: string;
+  event: ItemEvent;
+  modifiedProperties?: ModifiedProperty[];
+}
+
+export interface DashboardAuditLog extends AuditLog {
+  version: number;
+}
+
 // Represents a dynamodb item in the Audit Trail table that
 // contains attributes specific to Dashboard audit logs.
 export interface DashboardAuditLogItem extends AuditLogItem {
   version: number;
-  modifiedProperties?: ModifiedProperty[];
 }

--- a/backend/src/lib/repositories/__tests__/auditlog-repo.test.ts
+++ b/backend/src/lib/repositories/__tests__/auditlog-repo.test.ts
@@ -1,9 +1,11 @@
 import { mocked } from "ts-jest/utils";
 import { AuditLogItem } from "../../models/auditlog";
 import AuditLogRepository from "../auditlog-repo";
+import AuditLogFactory from "../../factories/auditlog-factory";
 import DynamoDBService from "../../services/dynamodb";
 
 jest.mock("../../services/dynamodb");
+jest.mock("../../factories/auditlog-factory");
 
 process.env.AUDIT_TRAIL_TABLE = "AuditTrailTable";
 
@@ -18,5 +20,34 @@ describe("saveAuditLog", () => {
       TableName: "AuditTrailTable",
       Item: auditLog,
     });
+  });
+});
+
+describe("listAuditLogs", () => {
+  it("queries dynamodb", async () => {
+    await AuditLogRepository.listAuditLogs("Dashboard#001");
+    expect(dynamodb.query).toBeCalledWith({
+      TableName: "AuditTrailTable",
+      KeyConditionExpression: "#pk = :pk",
+      ScanIndexForward: false,
+      ExpressionAttributeNames: {
+        "#pk": "pk",
+      },
+      ExpressionAttributeValues: {
+        ":pk": "Dashboard#001",
+      },
+    });
+  });
+
+  it("converts audit log items into audit log objects", async () => {
+    const item = { foo: "bar" };
+    dynamodb.query = jest.fn().mockReturnValue({ Items: [item] });
+
+    const auditLog = { fizz: "buzz" };
+    AuditLogFactory.fromItem = jest.fn().mockReturnValueOnce(auditLog);
+
+    const result = await AuditLogRepository.listAuditLogs("Dashboard#001");
+    expect(result).toContain(auditLog);
+    expect(AuditLogFactory.fromItem).toBeCalledWith(item);
   });
 });

--- a/backend/src/lib/repositories/auditlog-repo.ts
+++ b/backend/src/lib/repositories/auditlog-repo.ts
@@ -1,5 +1,6 @@
-import { AuditLogItem } from "../models/auditlog";
+import { AuditLog, AuditLogItem } from "../models/auditlog";
 import DynamoDBService from "../services/dynamodb";
+import AuditLogFactory from "../factories/auditlog-factory";
 import logger from "../services/logger";
 
 async function saveAuditLog(auditLog: AuditLogItem) {
@@ -11,10 +12,43 @@ async function saveAuditLog(auditLog: AuditLogItem) {
   });
 }
 
+async function listAuditLogs(pk: string): Promise<AuditLog[]> {
+  const dynamodb = DynamoDBService.getInstance();
+  logger.info("Listing audit logs for pk = %s", pk);
+
+  const queryResult = await dynamodb.query({
+    TableName: getTableName(),
+    KeyConditionExpression: "#pk = :pk",
+    ScanIndexForward: false, // get items in descending order of timestamp (sk)
+    ExpressionAttributeNames: {
+      "#pk": "pk",
+    },
+    ExpressionAttributeValues: {
+      ":pk": pk,
+    },
+  });
+
+  if (!queryResult || !queryResult.Items) {
+    logger.info("Query did not return any results");
+    return [];
+  }
+
+  const auditLogs: AuditLog[] = [];
+  queryResult.Items.forEach((item) => {
+    const auditLog = AuditLogFactory.fromItem(item as AuditLogItem);
+    if (auditLog) {
+      auditLogs.push(auditLog);
+    }
+  });
+
+  return auditLogs;
+}
+
 function getTableName(): string {
   return process.env.AUDIT_TRAIL_TABLE as string;
 }
 
 export default {
   saveAuditLog,
+  listAuditLogs,
 };

--- a/cdk/lib/constructs/api.ts
+++ b/cdk/lib/constructs/api.ts
@@ -119,6 +119,9 @@ export class BackendApi extends cdk.Construct {
     dashboard.addMethod("POST", apiIntegration, methodProps);
     dashboard.addMethod("DELETE", apiIntegration, methodProps);
 
+    const auditLogs = dashboard.addResource("auditlogs");
+    auditLogs.addMethod("GET", apiIntegration, methodProps);
+
     const versions = dashboard.addResource("versions");
     versions.addMethod("GET", apiIntegration, methodProps);
 

--- a/cdk/lib/constructs/lambdas.ts
+++ b/cdk/lib/constructs/lambdas.ts
@@ -36,6 +36,7 @@ export class LambdaFunctions extends cdk.Construct {
       logRetention: logs.RetentionDays.TEN_YEARS,
       environment: {
         MAIN_TABLE: props.mainTable.tableName,
+        AUDIT_TRAIL_TABLE: props.auditTrailTable.tableName,
         DATASETS_BUCKET: props.datasetsBucket.bucketName,
         USER_POOL_ID: props.userPool.id,
         LOG_LEVEL: "info",


### PR DESCRIPTION
## Description

Added new endpoint to list audit logs for a dashboard family. 

## Testing

Verified in my personal environment by invoking the endpoint with Postman: 

```
GET {baseUrl}/dashboard/:id/auditlogs
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
