### PR TITLE
GTT-946 Added updatedBy field to dashboard model

### DIFF
--- a/backend/integtests/IntegrationTestSuite.postman_collection.json
+++ b/backend/integtests/IntegrationTestSuite.postman_collection.json
@@ -1739,6 +1739,80 @@
 			"response": []
 		},
 		{
+			"name": "Verify audit logs",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"const testId = pm.variables.get(\"testId\");",
+							"pm.collectionVariables.set(\"dashboard.name\", testId);"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"returns 200 OK\", () => {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"returns a list of logs\", () => {",
+							"    const auditlogs = pm.response.json();",
+							"    pm.expect(auditlogs).to.be.an(\"array\");",
+							"    pm.expect(auditlogs.length).to.be.greaterThan(5);",
+							"});",
+							"",
+							"pm.test(\"each log has appropriate attributes\", () => {",
+							"    const auditlogs = pm.response.json();",
+							"    auditlogs.forEach(auditlog => {",
+							"        pm.expect(auditlog.timestamp).to.be.a(\"string\");",
+							"        pm.expect(auditlog.version).to.be.a(\"number\");",
+							"        pm.expect(auditlog.event).to.be.oneOf([\"Create\", \"Update\", \"Delete\"]);",
+							"    });",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{baseUrl}}/dashboard/:id/auditlogs",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"dashboard",
+						":id",
+						"auditlogs"
+					],
+					"variable": [
+						{
+							"key": "id",
+							"value": "{{dashboard.id}}"
+						}
+					]
+				},
+				"description": "Creates a dashboard in the newly created topic area"
+			},
+			"response": []
+		},
+		{
 			"name": "List users",
 			"event": [
 				{

--- a/backend/postman/Performance Dashboard API.postman_collection.json
+++ b/backend/postman/Performance Dashboard API.postman_collection.json
@@ -37,6 +37,41 @@
 					"response": []
 				},
 				{
+					"name": "List Audit Logs",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/dashboard/:id/auditlogs",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"dashboard",
+								":id",
+								"auditlogs"
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "1dcde43a-9700-41d3-b651-ceee60f7bdf8"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "Create Dashboard",
 					"request": {
 						"method": "POST",
@@ -679,6 +714,50 @@
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"name\": \"{{$randomAdjective}} {{$randomProductName}}\",\n    \"widgetType\": \"Metrics\",\n    \"content\": {\n        \"title\": \"{{$randomProductName}}\",\n        \"datasetId\": \"7f24b2ad-fc7d-443a-8b23-b62c6212aee2\",\n        \"s3Key\": {\n            \"json\": \"123.json\",\n            \"raw\": \"123.json\"\n        }\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/dashboard/:id/widget",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"dashboard",
+								":id",
+								"widget"
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "235cd5a3-dd65-4706-88b5-35fe3c785584"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create Image Widget",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"{{$randomProductName}}\",\n    \"widgetType\": \"Image\",\n    \"content\": {\n        \"title\": \"{{$randomProductName}}\",\n        \"summary\": \"{{$randomLoremParagraph}}\",\n        \"summaryBelow\": false,\n        \"imageAltText\": \"{{$randomWord}}\",\n        \"fileName\": \"123.png\",\n        \"s3Key\": {\n            \"raw\": \"123.png\"\n        }\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1444,13 +1523,15 @@
 	"variable": [
 		{
 			"key": "baseUrl",
-			"value": "http://localhost:8080",
-			"type": "string"
+			"value": "http://localhost:8080"
 		},
 		{
 			"key": "token",
-			"value": "",
-			"type": "string"
+			"value": ""
+		},
+		{
+			"key": "apiKey",
+			"value": ""
 		}
 	]
 }

--- a/backend/src/lib/controllers/__tests__/topicarea-ctrl.test.ts
+++ b/backend/src/lib/controllers/__tests__/topicarea-ctrl.test.ts
@@ -44,7 +44,8 @@ describe("updateTopicArea", () => {
     await TopicAreaCtrl.updateTopicArea(req, res);
     expect(repository.renameTopicArea).toBeCalledWith(
       "3ffdb1ef-081d-4534-97e9-b69cdbb687d0",
-      "New Name"
+      "New Name",
+      user
     );
   });
 });

--- a/backend/src/lib/controllers/topicarea-ctrl.ts
+++ b/backend/src/lib/controllers/topicarea-ctrl.ts
@@ -38,6 +38,7 @@ async function getTopicAreaById(req: Request, res: Response) {
 }
 
 async function updateTopicArea(req: Request, res: Response) {
+  const user = req.user;
   const { id } = req.params;
   const { name } = req.body;
 
@@ -47,7 +48,7 @@ async function updateTopicArea(req: Request, res: Response) {
   }
 
   const repo = TopicAreaRepository.getInstance();
-  await repo.renameTopicArea(id, name);
+  await repo.renameTopicArea(id, name, user);
   res.send();
 }
 

--- a/backend/src/lib/factories/__tests__/auditlog-factory.test.ts
+++ b/backend/src/lib/factories/__tests__/auditlog-factory.test.ts
@@ -19,6 +19,7 @@ describe("buildDashboardAuditLogFromEvent", () => {
       topicAreaName: "Department of Homeland Security",
       description: "",
       createdBy: "johndoe",
+      updatedBy: "johndoe",
       updatedAt: new Date(),
       state: DashboardState.Draft,
     };
@@ -47,6 +48,7 @@ describe("buildDashboardAuditLogFromEvent", () => {
       topicAreaName: "Department of Homeland Security",
       description: "",
       createdBy: "johndoe",
+      updatedBy: "alice",
       updatedAt: new Date(),
       state: DashboardState.PublishPending,
     };
@@ -60,6 +62,7 @@ describe("buildDashboardAuditLogFromEvent", () => {
       topicAreaName: "Department of Homeland Security",
       description: "",
       createdBy: "johndoe",
+      updatedBy: "johndoe",
       updatedAt: new Date(),
       state: DashboardState.Draft,
     };
@@ -75,7 +78,7 @@ describe("buildDashboardAuditLogFromEvent", () => {
     expect(auditLog.sk).toEqual(timestamp.toISOString());
     expect(auditLog.pk).toEqual("Dashboard#d5f6b6e4bb22");
     expect(auditLog.type).toEqual(DASHBOARD_ITEM_TYPE);
-    expect(auditLog.userId).toEqual("Unknown");
+    expect(auditLog.userId).toEqual("alice");
     expect(auditLog.version).toEqual(1);
     expect(auditLog.modifiedProperties).toEqual(
       expect.arrayContaining([
@@ -108,6 +111,7 @@ describe("buildDashboardAuditLogFromEvent", () => {
       topicAreaName: "Department of Homeland Security",
       description: "",
       createdBy: "johndoe",
+      updatedBy: "johndoe",
       updatedAt: new Date(),
       state: DashboardState.Draft,
     };
@@ -122,7 +126,7 @@ describe("buildDashboardAuditLogFromEvent", () => {
     expect(auditLog.sk).toEqual(timestamp.toISOString());
     expect(auditLog.pk).toEqual("Dashboard#d5f6b6e4bb22");
     expect(auditLog.type).toEqual(DASHBOARD_ITEM_TYPE);
-    expect(auditLog.userId).toEqual("Unknown");
+    expect(auditLog.userId).toEqual("unknown");
     expect(auditLog.version).toEqual(1);
   });
 });

--- a/backend/src/lib/factories/__tests__/dashboard-factory.test.ts
+++ b/backend/src/lib/factories/__tests__/dashboard-factory.test.ts
@@ -45,7 +45,7 @@ describe("createNew", () => {
     expect(dashboard1.parentDashboardId).toEqual(dashboard1.id);
   });
 
-  it("should create a new dashboard with createdBy", () => {
+  it("should create a new dashboard with createdBy and updatedBy", () => {
     const dashboard1 = factory.createNew(
       "Dashboard1",
       "123",
@@ -54,6 +54,7 @@ describe("createNew", () => {
       user
     );
     expect(dashboard1.createdBy).toEqual(user.userId);
+    expect(dashboard1.updatedBy).toEqual(user.userId);
   });
 });
 
@@ -68,6 +69,7 @@ describe("toItem", () => {
     description: "Description test",
     parentDashboardId: "123",
     createdBy: user.userId,
+    updatedBy: user.userId,
     updatedAt: now,
     state: DashboardState.Draft,
     releaseNotes: "release note test",
@@ -95,7 +97,8 @@ describe("toItem", () => {
     expect(item.description).toEqual("Description test");
     expect(item.topicAreaId).toEqual("TopicArea#456");
     expect(item.topicAreaName).toEqual("Topic 1");
-    expect(item.createdBy).toEqual(user.userId);
+    expect(item.createdBy).toEqual(dashboard.createdBy);
+    expect(item.updatedBy).toEqual(dashboard.updatedBy);
     expect(item.updatedAt).toEqual(now.toISOString());
     expect(item.state).toEqual("Draft");
     expect(item.version).toEqual(1);
@@ -117,6 +120,7 @@ describe("fromItem", () => {
     topicAreaName: "Topic 1",
     description: "Description test",
     createdBy: user.userId,
+    updatedBy: user.userId,
     parentDashboardId: "123",
     updatedAt: now,
     state: "Draft",
@@ -131,7 +135,8 @@ describe("fromItem", () => {
     expect(dashboard.name).toEqual("Dashboard 1");
     expect(dashboard.description).toEqual("Description test");
     expect(dashboard.topicAreaName).toEqual("Topic 1");
-    expect(dashboard.createdBy).toEqual(user.userId);
+    expect(dashboard.createdBy).toEqual(item.createdBy);
+    expect(dashboard.updatedBy).toEqual(item.updatedBy);
     expect(dashboard.updatedAt).toEqual(new Date(now));
     expect(dashboard.state).toEqual(DashboardState.Draft);
     expect(dashboard.version).toEqual(1);
@@ -258,6 +263,8 @@ describe("createDraftFromDashboard", () => {
         topicAreaId: "456",
         topicAreaName: "Topic 1",
         description: "Description test",
+        createdBy: user.userId,
+        updatedBy: user.userId,
       })
     );
   });

--- a/backend/src/lib/factories/auditlog-factory.ts
+++ b/backend/src/lib/factories/auditlog-factory.ts
@@ -21,14 +21,21 @@ function buildDashboardAuditLogFromEvent(
   dashboard: Dashboard,
   oldDashboard?: Dashboard
 ): DashboardAuditLogItem {
-  // TODO: Add `updatedBy` attribute to Dashboard model
-  const user = event === ItemEvent.Create ? dashboard.createdBy : "Unknown";
+  let userId = "unknown";
+  switch (event) {
+    case ItemEvent.Create:
+      userId = dashboard.createdBy;
+      break;
+    case ItemEvent.Update:
+      userId = dashboard.updatedBy ?? "unknown";
+      break;
+  }
 
   const auditLog: DashboardAuditLogItem = {
     pk: DashboardFactory.itemId(dashboard.parentDashboardId),
     sk: timestamp.toISOString(),
     type: DASHBOARD_ITEM_TYPE,
-    userId: user,
+    userId: userId,
     version: dashboard.version,
     event,
   };

--- a/backend/src/lib/factories/dashboard-factory.ts
+++ b/backend/src/lib/factories/dashboard-factory.ts
@@ -31,6 +31,7 @@ function createNew(
     state: DashboardState.Draft,
     createdBy: user.userId,
     updatedAt: new Date(),
+    updatedBy: user.userId,
   };
 }
 
@@ -60,6 +61,7 @@ function createDraftFromDashboard(
     state: DashboardState.Draft,
     createdBy: user.userId,
     updatedAt: new Date(),
+    updatedBy: user.userId,
     widgets,
     friendlyURL: undefined, // new draft should not have friendlyURL
   };
@@ -82,6 +84,7 @@ function toItem(dashboard: Dashboard): DashboardItem {
     state: dashboard.state,
     createdBy: dashboard.createdBy,
     updatedAt: dashboard.updatedAt.toISOString(),
+    updatedBy: dashboard.updatedBy,
     releaseNotes: dashboard.releaseNotes,
     friendlyURL: dashboard.friendlyURL,
   };
@@ -100,6 +103,7 @@ function fromItem(item: DashboardItem): Dashboard {
     createdBy: item.createdBy,
     parentDashboardId: item.parentDashboardId,
     updatedAt: item.updatedAt ? new Date(item.updatedAt) : new Date(),
+    updatedBy: item.updatedBy,
     state: (item.state as DashboardState) || DashboardState.Draft,
     releaseNotes: item.releaseNotes,
     friendlyURL: item.friendlyURL,

--- a/backend/src/lib/models/dashboard.ts
+++ b/backend/src/lib/models/dashboard.ts
@@ -26,6 +26,7 @@ export interface Dashboard {
   description: string;
   createdBy: string;
   updatedAt: Date;
+  updatedBy?: string;
   state: DashboardState;
   releaseNotes?: string;
   widgets?: Array<Widget>;
@@ -46,6 +47,7 @@ export interface DashboardItem {
   description: string;
   createdBy: string;
   updatedAt: string;
+  updatedBy?: string;
   state: string;
   releaseNotes?: string;
   friendlyURL?: string;

--- a/backend/src/lib/repositories/__tests__/dashboard-repo.test.ts
+++ b/backend/src/lib/repositories/__tests__/dashboard-repo.test.ts
@@ -987,7 +987,7 @@ describe("getNextVersionNumber", () => {
 });
 
 describe("updateTopicAreaName", () => {
-  it("handles incorrect versions gracefully", async () => {
+  it("updates all dashboards with new topic area name", async () => {
     const dashboards = [
       {
         id: "abc",
@@ -1003,8 +1003,29 @@ describe("updateTopicAreaName", () => {
       },
     ];
 
-    await repo.updateTopicAreaName(dashboards, "New Topic Area Name");
-    expect(dynamodb.transactWrite).toBeCalled();
+    await repo.updateTopicAreaName(dashboards, "New Topic Area Name", user);
+    expect(dynamodb.transactWrite).toBeCalledWith({
+      TransactItems: expect.arrayContaining([
+        expect.objectContaining({
+          Update: {
+            TableName: tableName,
+            Key: {
+              pk: "Dashboard#abc",
+              sk: "Dashboard#abc",
+            },
+            UpdateExpression:
+              "set topicAreaName = :topicAreaName, #updatedBy = :updatedBy",
+            ExpressionAttributeNames: {
+              "#updatedBy": "updatedBy",
+            },
+            ExpressionAttributeValues: {
+              ":topicAreaName": "New Topic Area Name",
+              ":updatedBy": user.userId,
+            },
+          },
+        }),
+      ]),
+    });
   });
 });
 

--- a/backend/src/lib/repositories/dashboard-repo.ts
+++ b/backend/src/lib/repositories/dashboard-repo.ts
@@ -158,7 +158,9 @@ class DashboardRepository extends BaseRepository {
           sk: DashboardFactory.itemId(dashboardId),
         },
         UpdateExpression:
-          "set #dashboardName = :dashboardName, #topicAreaId = :topicAreaId, #topicAreaName = :topicAreaName, #description = :description, #updatedAt = :updatedAt, #updatedBy = :userId",
+          "set #dashboardName = :dashboardName, #topicAreaId = :topicAreaId, " +
+          "#topicAreaName = :topicAreaName, #description = :description, " +
+          "#updatedAt = :updatedAt, #updatedBy = :userId",
         ConditionExpression: "#updatedAt <= :lastUpdatedAt",
         ExpressionAttributeValues: {
           ":dashboardName": name,
@@ -600,7 +602,8 @@ class DashboardRepository extends BaseRepository {
    */
   public async updateTopicAreaName(
     dashboards: Array<Dashboard>,
-    topicAreaName: string
+    topicAreaName: string,
+    user: User
   ) {
     const updates: DocumentClient.TransactWriteItem[] = dashboards.map(
       (dashboard) => ({
@@ -610,9 +613,14 @@ class DashboardRepository extends BaseRepository {
             pk: DashboardFactory.itemId(dashboard.id),
             sk: DashboardFactory.itemId(dashboard.id),
           },
-          UpdateExpression: "set topicAreaName = :topicAreaName",
+          UpdateExpression:
+            "set topicAreaName = :topicAreaName, #updatedBy = :updatedBy",
+          ExpressionAttributeNames: {
+            "#updatedBy": "updatedBy",
+          },
           ExpressionAttributeValues: {
             ":topicAreaName": topicAreaName,
+            ":updatedBy": user.userId,
           },
         },
       })

--- a/backend/src/lib/repositories/topicarea-repo.ts
+++ b/backend/src/lib/repositories/topicarea-repo.ts
@@ -121,7 +121,7 @@ class TopicAreaRepository extends BaseRepository {
     return uniqueParents.size;
   }
 
-  public async renameTopicArea(topicAreaId: string, name: string) {
+  public async renameTopicArea(topicAreaId: string, name: string, user: User) {
     // 1. Update the TopicArea item
     await this.dynamodb.update({
       TableName: this.tableName,
@@ -145,7 +145,7 @@ class TopicAreaRepository extends BaseRepository {
     );
 
     // 3. Update topicAreaName in every dashboard in the query result
-    await dashboardRepo.updateTopicAreaName(dashboards, name);
+    await dashboardRepo.updateTopicAreaName(dashboards, name, user);
   }
 }
 

--- a/backend/src/lib/services/__tests__/auth.test.ts
+++ b/backend/src/lib/services/__tests__/auth.test.ts
@@ -1,4 +1,5 @@
 import AuthService from "../auth";
+import { Role } from "../../models/user";
 
 let req: any = {};
 
@@ -57,4 +58,13 @@ test("handles the case of roles not being present in claims", () => {
 
   const user = AuthService.getCurrentUser(req);
   expect(user?.roles).toEqual([]);
+});
+
+test("returns a dummy user when running on local mode", () => {
+  process.env.LOCAL_MODE = "true";
+  const user = AuthService.getCurrentUser(req);
+  expect(user).toEqual({
+    roles: [Role.Admin],
+    userId: "johndoe",
+  });
 });

--- a/backend/src/lib/services/auth.ts
+++ b/backend/src/lib/services/auth.ts
@@ -1,7 +1,9 @@
 import { Request } from "express";
 import { User, Role } from "../models/user";
 
-const local = !!process.env.LOCAL_MODE || false;
+function isLocalMode() {
+  return !!process.env.LOCAL_MODE || false;
+}
 
 /**
  * Gets the logged-in user from the http request headers.
@@ -9,7 +11,7 @@ const local = !!process.env.LOCAL_MODE || false;
  * Returns dummy user if running in local mode.
  */
 function getCurrentUser(req: Request): User | null {
-  if (local) {
+  if (isLocalMode()) {
     return userFromClaims(dummyUser());
   }
 
@@ -65,10 +67,10 @@ function dummyUser(): any {
     token_use: "id",
     auth_time: "1595027153",
     iss: "https://cognito-idp.us-west-2.amazonaws.com/us-west-2_JRVEBvlNZ",
-    "cognito:username": "fdingler",
+    "cognito:username": "johndoe",
     exp: "Sat Jul 18 00:05:53 UTC 2020",
     iat: "Fri Jul 17 23:05:54 UTC 2020",
-    email: "fdingler@amazon.com",
+    email: "johndoe@example.com",
     "custom:roles": '["Admin"]',
   };
 }


### PR DESCRIPTION
## Description

- Added `updatedBy` field to dashboard model.
- Updated function `renameTopicArea` to set `updatedBy` field appropriately. 
- Added integration test for the audit logs endpoint.
- Updated postman collection with the new endpoint to fetch audit logs. 

## Testing

Deployed to my personal environment, ran integration tests against it. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
