### PR TITLE
GTT-947 CloudWatch alarms and Ops dashboard to add Audit Trail resources

### DIFF
--- a/cdk/bin/main.ts
+++ b/cdk/bin/main.ts
@@ -47,8 +47,10 @@ const operations = new OpsStack(app, "Ops", {
   stackName: stackPrefix.concat("-Ops"),
   privateApiFunction: backend.privateApiFunction,
   publicApiFunction: backend.publicApiFunction,
+  dynamodbStreamsFunction: backend.dynamodbStreamsFunction,
   restApi: backend.restApi,
   mainTable: backend.mainTable,
+  auditTrailTable: backend.auditTrailTable,
 });
 
 Tags.of(auth).add("app-id", APP_ID);

--- a/cdk/lib/backend-stack.ts
+++ b/cdk/lib/backend-stack.ts
@@ -18,6 +18,7 @@ interface BackendStackProps extends cdk.StackProps {
 export class BackendStack extends cdk.Stack {
   public readonly privateApiFunction: lambda.Function;
   public readonly publicApiFunction: lambda.Function;
+  public readonly dynamodbStreamsFunction: lambda.Function;
   public readonly mainTable: dynamodb.Table;
   public readonly auditTrailTable: dynamodb.Table;
   public readonly restApi: apigateway.RestApi;
@@ -48,6 +49,7 @@ export class BackendStack extends cdk.Stack {
      */
     this.privateApiFunction = lambdas.apiHandler;
     this.publicApiFunction = lambdas.publicApiHandler;
+    this.dynamodbStreamsFunction = lambdas.ddbStreamProcessor;
     this.mainTable = database.mainTable;
     this.restApi = backendApi.api;
 


### PR DESCRIPTION
## Description

Updated the OpsStack to include 2 new CloudWatch alarms: ErrorRate and Throttles for the new lambda function that processes messages from DynamoDB Streams. Also added the Lambda and DynamoDB metrics to the Cloudwatch Dashboard. 

## Testing

Tested in my AWS account to make sure alarms and metrics show up properly. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
