### PR TITLE
GTT-953 Version number on Footer and new release.sh script

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "performance-dashboard-backend",
-  "version": "1.0.0",
+  "version": "0.7.0-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "performance-dashboard-backend",
-  "version": "1.0.0",
+  "version": "0.7.0-beta",
   "description": "Performance Dashboard on AWS Backend",
   "scripts": {
     "test": "LOG_LEVEL=SILENT jest --coverage --watchAll",

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "performance-dashboard-cdk",
-  "version": "1.0.0",
+  "version": "0.7.0-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "performance-dashboard-cdk",
-  "version": "1.0.0",
+  "version": "0.7.0-beta",
   "description": "Performance Dashboard on AWS CDK",
   "bin": {
     "cdk": "bin/main.js"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "performance-dashboard-frontend",
-  "version": "1.0.0",
+  "version": "0.7.0-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "performance-dashboard-frontend",
-  "version": "1.0.0",
+  "version": "0.7.0-beta",
   "private": true,
   "description": "Performance Dashboard on AWS Frontend",
   "dependencies": {

--- a/frontend/src/containers/__tests__/__snapshots__/FourZeroFour.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/FourZeroFour.test.tsx.snap
@@ -46,6 +46,12 @@ exports[`renders a FourZeroFour component 1`] = `
       >
         Contact support
       </a>
+      <span
+        class="float-right"
+      >
+        v
+        v1.0.0
+      </span>
     </div>
   </footer>
 </div>

--- a/frontend/src/layouts/Footer.tsx
+++ b/frontend/src/layouts/Footer.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import EnvConfig from "../services/EnvConfig";
+import packagejson from "../../package.json";
 
 function Footer() {
   return (
@@ -13,6 +14,7 @@ function Footer() {
         >
           Contact support
         </a>
+        <span className="float-right">v{packagejson.version}</span>
       </div>
     </footer>
   );

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -10,6 +10,9 @@ import ReactModal from "react-modal";
 import i18n from "./i18n";
 
 jest.mock("./hooks");
+jest.mock("../package.json", () => ({
+  version: "v1.0.0",
+}));
 
 dayjs.extend(relativeTime);
 ReactModal.setAppElement(document.createElement("div"));

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+
+# Set workspace paths
+WORKSPACE=$(pwd)
+CDK_DIR=$WORKSPACE/cdk
+FRONTEND_DIR=$WORKSPACE/frontend
+BACKEND_DIR=$WORKSPACE/backend
+
+# Validate release version from input
+newVersion=$1
+if [ "$newVersion" != "" ]; then
+    echo "==================================="
+    echo "Releasing new version = $newVersion"
+    echo "==================================="
+else
+    echo "Please specify the new version in semver format like v1.0.3"
+    exit 0
+fi
+
+verify_prereqs() {
+    echo "npm version"
+    npm --version
+}
+
+update_package_jsons() {
+    cd $CDK_DIR
+    echo "Updating package.json in cdk"
+    npm version $newVersion
+    
+    cd $FRONTEND_DIR
+    echo "Updating package.json in frontend"
+    npm version $newVersion
+
+    cd $BACKEND_DIR
+    echo "Updating package.json in backend"
+    npm version $newVersion
+}
+
+verify_prereqs
+update_package_jsons


### PR DESCRIPTION
## Description

Pulling the version number from the `frontend/package.json` file and displaying it in the Footer. Added a new script `release.sh` to modify the version number in all of our package.jsons. I also updated the version in those files to reflect the current version of 0.7.0-beta. 

## Testing

Updated unit test so they don't break when version changes. Deployed to my personal environment to make sure version number is displayed properly in the footer: https://fdingler.badger.wwps.aws.dev/admin/dashboards. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
