### PR TITLE
GTT-1015 Filter out noisy audit logs in frontend

### DIFF
--- a/frontend/src/hooks/dashboard-hooks.ts
+++ b/frontend/src/hooks/dashboard-hooks.ts
@@ -7,6 +7,7 @@ import {
   PublicDashboard,
 } from "../models";
 import BackendService from "../services/BackendService";
+import AuditTrailService from "../services/AuditTrailService";
 
 type UseDashboardHook = {
   loading: boolean;
@@ -219,7 +220,13 @@ export function useDashboardHistory(
         const data = await BackendService.fetchDashboardHistory(
           parentDashboardId
         );
-        setAuditlogs(data);
+
+        // Filter out noisy logs first
+        const logs = AuditTrailService.removeNosiyAuditLogs(
+          data as DashboardAuditLog[]
+        );
+
+        setAuditlogs(logs);
         setLoading(false);
       };
       fetchData();

--- a/frontend/src/services/AuditTrailService.ts
+++ b/frontend/src/services/AuditTrailService.ts
@@ -43,8 +43,32 @@ function getActionFromDashboardAuditLog({
   return action;
 }
 
+/**
+ * Given a list of Dashboard audit logs, it removes those for
+ * which the only modified property is `updatedAt`. These logs are
+ * noise for users because `updatedAt` is a property that changes
+ * too often and it doesn't add value to see all these records.
+ */
+function removeNosiyAuditLogs(
+  auditlogs: DashboardAuditLog[]
+): DashboardAuditLog[] {
+  if (!auditlogs) return [];
+  const noisyProperties = ["updatedAt"];
+  return auditlogs.filter(({ event, modifiedProperties }) => {
+    if (event === "Create" || event === "Delete") return true;
+    if (!modifiedProperties) return false;
+
+    const remainingProperties = modifiedProperties.filter(
+      (prop) => !noisyProperties.includes(prop.property)
+    );
+
+    return remainingProperties.length > 0;
+  });
+}
+
 const AuditLogService = {
   getActionFromDashboardAuditLog,
+  removeNosiyAuditLogs,
 };
 
 export default AuditLogService;

--- a/frontend/src/services/__tests__/AuditTrailService.test.ts
+++ b/frontend/src/services/__tests__/AuditTrailService.test.ts
@@ -118,3 +118,84 @@ describe("getActionFromDashboardAuditLog", () => {
     expect(action).toEqual("Returned to draft");
   });
 });
+
+describe("removeNoisyAuditLogs", () => {
+  test("it does not remove a Create event", () => {
+    const createAuditLog: DashboardAuditLog = {
+      itemId: "001",
+      timestamp: new Date(),
+      event: "Create",
+      userId: "johndoe",
+      version: 1,
+    };
+
+    const auditlogs = [createAuditLog];
+    const result = AuditTrailService.removeNosiyAuditLogs(auditlogs);
+    expect(result).toContain(createAuditLog);
+  });
+
+  test("it does not remove a Delete event", () => {
+    const deleteAuditLog: DashboardAuditLog = {
+      itemId: "001",
+      timestamp: new Date(),
+      event: "Delete",
+      userId: "johndoe",
+      version: 1,
+    };
+
+    const auditlogs = [deleteAuditLog];
+    const result = AuditTrailService.removeNosiyAuditLogs(auditlogs);
+    expect(result).toContain(deleteAuditLog);
+  });
+
+  test("it does not remove an Update event with other interesting properties", () => {
+    const updateAuditLog: DashboardAuditLog = {
+      itemId: "001",
+      timestamp: new Date(),
+      event: "Update",
+      userId: "johndoe",
+      version: 1,
+      modifiedProperties: [
+        {
+          property: "updatedAt",
+          oldValue: "foo",
+          newValue: "bar",
+        },
+        {
+          property: "state",
+          oldValue: "Draft",
+          newValue: "PublishPending",
+        },
+      ],
+    };
+
+    const auditlogs = [updateAuditLog];
+    const result = AuditTrailService.removeNosiyAuditLogs(auditlogs);
+
+    expect(result).toHaveLength(1);
+    expect(result).toContain(updateAuditLog);
+  });
+
+  test("it removes an Update event with `updatedAt` as only property", () => {
+    const updateAuditLog: DashboardAuditLog = {
+      itemId: "001",
+      timestamp: new Date(),
+      event: "Update",
+      userId: "johndoe",
+      version: 1,
+      modifiedProperties: [
+        {
+          property: "updatedAt",
+          oldValue: "foo",
+          newValue: "bar",
+        },
+      ],
+    };
+
+    const auditlogs = [updateAuditLog];
+    const result = AuditTrailService.removeNosiyAuditLogs(auditlogs);
+
+    expect(result).toHaveLength(0);
+    expect(result).not.toContain(updateAuditLog);
+  });
+});


### PR DESCRIPTION
## Description

The Dashboard history includes audit logs for which only modified property is the `updatedAt` field. These logs are noisy and don't add value to users because `updatedAt` is updated too often in Dashboards. This PR removes those audit logs in the frontend before displaying them in the history table. 

## Testing

Wrote unit tests and verified noisy logs don't show up in the dashboard history. For example, re-ordering the Content Items causes many updatedAt logs to be created, I verified they don't show up in the dashboard history anymore.  

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
