### PR TITLE
GTT-956 Markdown support in content item summaries

### DIFF
--- a/frontend/src/components/BarChartPreview.tsx
+++ b/frontend/src/components/BarChartPreview.tsx
@@ -12,6 +12,7 @@ import {
 } from "recharts";
 import { useColors } from "../hooks";
 import UtilsService from "../services/UtilsService";
+import MarkdownRender from "./MarkdownRender";
 
 type Props = {
   title: string;
@@ -79,9 +80,10 @@ const BarChartPreview = (props: Props) => {
         {props.title}
       </h2>
       {!props.summaryBelow && (
-        <p className="margin-left-1 margin-top-0 margin-bottom-4">
-          {props.summary}
-        </p>
+        <MarkdownRender
+          source={props.summary}
+          className="margin-left-1 margin-top-0 margin-bottom-4 chartSummaryAbove"
+        />
       )}
       {data && data.length && (
         <ResponsiveContainer
@@ -97,8 +99,8 @@ const BarChartPreview = (props: Props) => {
             <XAxis
               type="number"
               domain={[
-                (dataMin) => 0,
-                (dataMax) => dataMax + Math.floor(dataMax * 0.2),
+                (dataMin: number) => 0,
+                (dataMax: number) => dataMax + Math.floor(dataMax * 0.2),
               ]}
             />
             <YAxis
@@ -145,9 +147,10 @@ const BarChartPreview = (props: Props) => {
         </ResponsiveContainer>
       )}
       {props.summaryBelow && (
-        <p className="margin-left-1 margin-top-1 margin-bottom-0">
-          {props.summary}
-        </p>
+        <MarkdownRender
+          source={props.summary}
+          className="margin-left-1 margin-top-1 margin-bottom-0 chartSummaryBelow"
+        />
       )}
     </div>
   );

--- a/frontend/src/components/ColumnChartPreview.tsx
+++ b/frontend/src/components/ColumnChartPreview.tsx
@@ -11,6 +11,7 @@ import {
 } from "recharts";
 import { useColors } from "../hooks";
 import UtilsService from "../services/UtilsService";
+import MarkdownRender from "./MarkdownRender";
 
 type Props = {
   title: string;
@@ -89,9 +90,10 @@ const ColumnChartPreview = (props: Props) => {
         {props.title}
       </h2>
       {!props.summaryBelow && (
-        <p className="margin-left-1 margin-top-0 margin-bottom-4">
-          {props.summary}
-        </p>
+        <MarkdownRender
+          source={props.summary}
+          className="margin-left-1 margin-top-0 margin-bottom-4 chartSummaryAbove"
+        />
       )}
       {data && data.length && (
         <ResponsiveContainer
@@ -133,9 +135,10 @@ const ColumnChartPreview = (props: Props) => {
         </ResponsiveContainer>
       )}
       {props.summaryBelow && (
-        <p className="margin-left-1 margin-top-1 margin-bottom-0">
-          {props.summary}
-        </p>
+        <MarkdownRender
+          source={props.summary}
+          className="margin-left-1 margin-top-1 margin-bottom-0 chartSummaryBelow"
+        />
       )}
     </div>
   );

--- a/frontend/src/components/ImagePreview.tsx
+++ b/frontend/src/components/ImagePreview.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import MarkdownRender from "./MarkdownRender";
 
 type Props = {
   title: string;
@@ -15,13 +16,19 @@ const ImagePreview = (props: Props) => {
     <div className="preview-container">
       <h2 className="margin-left-1 margin-top-1">{title}</h2>
       {!summaryBelow && (
-        <p className="margin-left-1 margin-top-0 margin-bottom-3">{summary}</p>
+        <MarkdownRender
+          source={summary}
+          className="margin-left-1 margin-top-0 margin-bottom-3 imageSummaryAbove"
+        />
       )}
       <div className="margin-left-1">
         <img src={file ? URL.createObjectURL(file) : ""} alt={altText}></img>
       </div>
       {summaryBelow && (
-        <p className="margin-left-1 margin-top-3 margin-bottom-0">{summary}</p>
+        <MarkdownRender
+          source={summary}
+          className="margin-left-1 margin-top-3 margin-bottom-0 imageSummaryBelow"
+        />
       )}
     </div>
   );

--- a/frontend/src/components/LineChartPreview.tsx
+++ b/frontend/src/components/LineChartPreview.tsx
@@ -11,6 +11,7 @@ import {
 } from "recharts";
 import { useColors } from "../hooks";
 import UtilsService from "../services/UtilsService";
+import MarkdownRender from "./MarkdownRender";
 
 type Props = {
   title: string;
@@ -88,14 +89,17 @@ const LineChartPreview = (props: Props) => {
         {props.title}
       </h2>
       {!props.summaryBelow && (
-        <p className="margin-left-1 margin-top-0 margin-bottom-4">
-          {props.summary}
-        </p>
+        <MarkdownRender
+          source={props.summary}
+          className="margin-left-1 margin-top-0 margin-bottom-4 chartSummaryAbove"
+        />
       )}
       {data && data.length && (
         <ResponsiveContainer
+          id={props.title}
           width={`${Math.max(widthPercent, 100)}%`}
           height={300}
+          data-testid="chartContainer"
         >
           <LineChart data={props.data} margin={{ right: 0, left: 0 }}>
             <CartesianGrid vertical={false} />
@@ -132,9 +136,10 @@ const LineChartPreview = (props: Props) => {
         </ResponsiveContainer>
       )}
       {props.summaryBelow && (
-        <p className="margin-left-1 margin-top-1 margin-bottom-0">
-          {props.summary}
-        </p>
+        <MarkdownRender
+          source={props.summary}
+          className="margin-left-1 margin-top-1 margin-bottom-0 chartSummaryBelow"
+        />
       )}
     </div>
   );

--- a/frontend/src/components/PartWholeChartPreview.tsx
+++ b/frontend/src/components/PartWholeChartPreview.tsx
@@ -9,6 +9,7 @@ import {
   CartesianGrid,
 } from "recharts";
 import { useColors } from "../hooks";
+import MarkdownRender from "./MarkdownRender";
 import "./PartWholeChartPreview.css";
 
 type Props = {
@@ -103,9 +104,10 @@ const PartWholeChartPreview = (props: Props) => {
         {props.title}
       </h2>
       {!props.summaryBelow && (
-        <p className="margin-left-1 margin-top-0 margin-bottom-4">
-          {props.summary}
-        </p>
+        <MarkdownRender
+          source={props.summary}
+          className="margin-left-1 margin-top-1 margin-bottom-0 chartSummaryAbove"
+        />
       )}
       {partWholeData.current.length && (
         <ResponsiveContainer
@@ -176,9 +178,10 @@ const PartWholeChartPreview = (props: Props) => {
         </ResponsiveContainer>
       )}
       {props.summaryBelow && (
-        <p className="margin-left-1 margin-top-1 margin-bottom-0">
-          {props.summary}
-        </p>
+        <MarkdownRender
+          source={props.summary}
+          className="margin-left-1 margin-top-1 margin-bottom-0 chartSummaryBelow"
+        />
       )}
     </div>
   );

--- a/frontend/src/components/TablePreview.tsx
+++ b/frontend/src/components/TablePreview.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from "react";
+import MarkdownRender from "./MarkdownRender";
 import Table from "./Table";
 
 type Props = {
@@ -16,7 +17,10 @@ const TablePreview = (props: Props) => {
     <div className="overflow-hidden">
       <h2 className="margin-left-1 margin-bottom-1">{title}</h2>
       {!summaryBelow && (
-        <p className="margin-left-1 margin-top-0 margin-bottom-3">{summary}</p>
+        <MarkdownRender
+          source={summary}
+          className="margin-left-1 margin-top-0 margin-bottom-3 tableSummaryAbove"
+        />
       )}
       <Table
         selection="none"
@@ -41,7 +45,10 @@ const TablePreview = (props: Props) => {
         )}
       />
       {summaryBelow && (
-        <p className="margin-left-1 margin-top-3 margin-bottom-0">{summary}</p>
+        <MarkdownRender
+          source={summary}
+          className="margin-left-1 margin-top-3 margin-bottom-0 tableSummaryBelow"
+        />
       )}
     </div>
   );

--- a/frontend/src/components/__tests__/BarChartPreview.test.tsx
+++ b/frontend/src/components/__tests__/BarChartPreview.test.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import BarChartPreview from "../BarChartPreview";
 
-test("renders the title and summary of the bar chart preview component", async () => {
-  const { getByText } = render(
+test("renders the chart title", async () => {
+  render(
     <BarChartPreview
       title="test title"
       summary="test summary"
@@ -14,15 +14,28 @@ test("renders the title and summary of the bar chart preview component", async (
     />,
     { wrapper: MemoryRouter }
   );
-  expect(getByText("test title")).toBeInTheDocument();
-  expect(getByText("test summary")).toBeInTheDocument();
-  expect(getByText("test summary").nextSibling).toHaveClass(
-    "recharts-responsive-container"
-  );
+  expect(screen.getByText("test title")).toBeInTheDocument();
 });
 
-test("renders the bar chart preview component with the summary below the chart", async () => {
-  const { getByText } = render(
+test("renders chart summary above the chart", async () => {
+  render(
+    <BarChartPreview
+      title="test title"
+      summary="test summary"
+      bars={["test"]}
+      data={[{ test: 1 }]}
+      summaryBelow={false}
+    />,
+    { wrapper: MemoryRouter }
+  );
+
+  const summary = screen.getByText("test summary");
+  expect(summary).toBeInTheDocument();
+  expect(summary.closest("div")).toHaveClass("chartSummaryAbove");
+});
+
+test("renders chart summary below the chart", async () => {
+  render(
     <BarChartPreview
       title="test title"
       summary="test summary"
@@ -32,9 +45,8 @@ test("renders the bar chart preview component with the summary below the chart",
     />,
     { wrapper: MemoryRouter }
   );
-  expect(getByText("test title")).toBeInTheDocument();
-  expect(getByText("test summary")).toBeInTheDocument();
-  expect(getByText("test summary").previousSibling).toHaveClass(
-    "recharts-responsive-container"
-  );
+
+  const summary = screen.getByText("test summary");
+  expect(summary).toBeInTheDocument();
+  expect(summary.closest("div")).toHaveClass("chartSummaryBelow");
 });

--- a/frontend/src/components/__tests__/ColumnChartPreview.test.tsx
+++ b/frontend/src/components/__tests__/ColumnChartPreview.test.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import ColumnChartPreview from "../ColumnChartPreview";
 
-test("renders the title and summary of the column chart preview component", async () => {
-  const { getByText } = render(
+test("renders the chart title", async () => {
+  render(
     <ColumnChartPreview
       title="test title"
       summary="test summary"
@@ -14,15 +14,28 @@ test("renders the title and summary of the column chart preview component", asyn
     />,
     { wrapper: MemoryRouter }
   );
-  expect(getByText("test title")).toBeInTheDocument();
-  expect(getByText("test summary")).toBeInTheDocument();
-  expect(getByText("test summary").nextSibling).toHaveClass(
-    "recharts-responsive-container"
-  );
+  expect(screen.getByText("test title")).toBeInTheDocument();
 });
 
-test("renders the title and summary of the column chart preview component with the summary below the chart", async () => {
-  const { getByText } = render(
+test("renders chart summary above the chart", async () => {
+  render(
+    <ColumnChartPreview
+      title="test title"
+      summary="test summary"
+      columns={["test"]}
+      data={[{ test: 1 }]}
+      summaryBelow={false}
+    />,
+    { wrapper: MemoryRouter }
+  );
+
+  const summary = screen.getByText("test summary");
+  expect(summary).toBeInTheDocument();
+  expect(summary.closest("div")).toHaveClass("chartSummaryAbove");
+});
+
+test("renders chart summary below the chart", async () => {
+  render(
     <ColumnChartPreview
       title="test title"
       summary="test summary"
@@ -32,9 +45,8 @@ test("renders the title and summary of the column chart preview component with t
     />,
     { wrapper: MemoryRouter }
   );
-  expect(getByText("test title")).toBeInTheDocument();
-  expect(getByText("test summary")).toBeInTheDocument();
-  expect(getByText("test summary").previousSibling).toHaveClass(
-    "recharts-responsive-container"
-  );
+
+  const summary = screen.getByText("test summary");
+  expect(summary).toBeInTheDocument();
+  expect(summary.closest("div")).toHaveClass("chartSummaryBelow");
 });

--- a/frontend/src/components/__tests__/ImagePreview.test.tsx
+++ b/frontend/src/components/__tests__/ImagePreview.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import ImagePreview from "../ImagePreview";
 
@@ -11,8 +11,8 @@ const imageFile = {
 
 window.URL.createObjectURL = jest.fn();
 
-test("renders the title and summary of the image preview component", async () => {
-  const { getByText } = render(
+test("renders the image title", async () => {
+  render(
     <ImagePreview
       title="test title"
       summary="test summary"
@@ -22,13 +22,11 @@ test("renders the title and summary of the image preview component", async () =>
     />,
     { wrapper: MemoryRouter }
   );
-  expect(getByText("test title")).toBeInTheDocument();
-  expect(getByText("test summary")).toBeInTheDocument();
-  expect(getByText("test summary").nextSibling).toContainHTML("img");
+  expect(screen.getByText("test title")).toBeInTheDocument();
 });
 
-test("renders the image preview component with the summary below the chart", async () => {
-  const { getByText } = render(
+test("renders the summary below the image", async () => {
+  render(
     <ImagePreview
       title="test title"
       summary="test summary"
@@ -38,9 +36,27 @@ test("renders the image preview component with the summary below the chart", asy
     />,
     { wrapper: MemoryRouter }
   );
-  expect(getByText("test title")).toBeInTheDocument();
-  expect(getByText("test summary")).toBeInTheDocument();
-  expect(getByText("test summary").previousSibling).toContainHTML("img");
+
+  const summary = screen.getByText("test summary");
+  expect(summary).toBeInTheDocument();
+  expect(summary.closest("div")).toHaveClass("imageSummaryBelow");
+});
+
+test("renders the summary above the image", async () => {
+  render(
+    <ImagePreview
+      title="test title"
+      summary="test summary"
+      file={imageFile}
+      summaryBelow={false}
+      altText="alt text"
+    />,
+    { wrapper: MemoryRouter }
+  );
+
+  const summary = screen.getByText("test summary");
+  expect(summary).toBeInTheDocument();
+  expect(summary.closest("div")).toHaveClass("imageSummaryAbove");
 });
 
 test("image preview should match snapshot", async () => {

--- a/frontend/src/components/__tests__/LineChartPreview.test.tsx
+++ b/frontend/src/components/__tests__/LineChartPreview.test.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import LineChartPreview from "../LineChartPreview";
 
-test("renders the title and summary of the line chart preview component", async () => {
-  const { getByText } = render(
+test("renders the chart title", async () => {
+  render(
     <LineChartPreview
       title="test title"
       summary="test summary"
@@ -14,15 +14,28 @@ test("renders the title and summary of the line chart preview component", async 
     />,
     { wrapper: MemoryRouter }
   );
-  expect(getByText("test title")).toBeInTheDocument();
-  expect(getByText("test summary")).toBeInTheDocument();
-  expect(getByText("test summary").nextSibling).toHaveClass(
-    "recharts-responsive-container"
-  );
+  expect(screen.getByText("test title")).toBeInTheDocument();
 });
 
-test("renders the line chart preview component with the summary below the chart", async () => {
-  const { getByText } = render(
+test("renders chart summary above the chart", async () => {
+  render(
+    <LineChartPreview
+      title="test title"
+      summary="test summary"
+      lines={["test"]}
+      data={[{ test: 1 }]}
+      summaryBelow={false}
+    />,
+    { wrapper: MemoryRouter }
+  );
+
+  const summary = screen.getByText("test summary");
+  expect(summary).toBeInTheDocument();
+  expect(summary.closest("div")).toHaveClass("chartSummaryAbove");
+});
+
+test("renders chart summary below the chart", async () => {
+  render(
     <LineChartPreview
       title="test title"
       summary="test summary"
@@ -32,9 +45,8 @@ test("renders the line chart preview component with the summary below the chart"
     />,
     { wrapper: MemoryRouter }
   );
-  expect(getByText("test title")).toBeInTheDocument();
-  expect(getByText("test summary")).toBeInTheDocument();
-  expect(getByText("test summary").previousSibling).toHaveClass(
-    "recharts-responsive-container"
-  );
+
+  const summary = screen.getByText("test summary");
+  expect(summary).toBeInTheDocument();
+  expect(summary.closest("div")).toHaveClass("chartSummaryBelow");
 });

--- a/frontend/src/components/__tests__/PartWholeChartPreview.test.tsx
+++ b/frontend/src/components/__tests__/PartWholeChartPreview.test.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import PartWholeChartPreview from "../PartWholeChartPreview";
 
-test("renders the title and summary of part whole chart preview component", async () => {
-  const { getByText } = render(
+test("renders the chart title", async () => {
+  render(
     <PartWholeChartPreview
       title="test title"
       summary="test summary"
@@ -14,15 +14,28 @@ test("renders the title and summary of part whole chart preview component", asyn
     />,
     { wrapper: MemoryRouter }
   );
-  expect(getByText("test title")).toBeInTheDocument();
-  expect(getByText("test summary")).toBeInTheDocument();
-  expect(getByText("test summary").nextSibling).toHaveClass(
-    "recharts-responsive-container"
-  );
+  expect(screen.getByText("test title")).toBeInTheDocument();
 });
 
-test("renders the part whole chart preview component with the summary below the chart", async () => {
-  const { getByText } = render(
+test("renders the summary above the chart", async () => {
+  render(
+    <PartWholeChartPreview
+      title="test title"
+      summary="test summary"
+      parts={["test"]}
+      summaryBelow={false}
+      data={[{}]}
+    />,
+    { wrapper: MemoryRouter }
+  );
+
+  const summary = screen.getByText("test summary");
+  expect(summary).toBeInTheDocument();
+  expect(summary.closest("div")).toHaveClass("chartSummaryAbove");
+});
+
+test("renders the summary below the chart", async () => {
+  render(
     <PartWholeChartPreview
       title="test title"
       summary="test summary"
@@ -32,9 +45,8 @@ test("renders the part whole chart preview component with the summary below the 
     />,
     { wrapper: MemoryRouter }
   );
-  expect(getByText("test title")).toBeInTheDocument();
-  expect(getByText("test summary")).toBeInTheDocument();
-  expect(getByText("test summary").previousSibling).toHaveClass(
-    "recharts-responsive-container"
-  );
+
+  const summary = screen.getByText("test summary");
+  expect(summary).toBeInTheDocument();
+  expect(summary.closest("div")).toHaveClass("chartSummaryBelow");
 });

--- a/frontend/src/components/__tests__/TablePreview.test.tsx
+++ b/frontend/src/components/__tests__/TablePreview.test.tsx
@@ -8,8 +8,8 @@ import { faCaretUp, faCaretDown } from "@fortawesome/free-solid-svg-icons";
 
 library.add(faCaretUp, faCaretDown);
 
-test("renders the title and summary of the table preview component", async () => {
-  const { getByText } = render(
+test("renders the table title", async () => {
+  render(
     <TablePreview
       title="test title"
       summary="test summary"
@@ -18,13 +18,16 @@ test("renders the title and summary of the table preview component", async () =>
     />,
     { wrapper: MemoryRouter }
   );
-  expect(getByText("test title")).toBeInTheDocument();
-  expect(getByText("test summary")).toBeInTheDocument();
-  expect(getByText("test summary").nextSibling).toHaveClass("usa-table");
+
+  expect(screen.getByText("test title")).toBeInTheDocument();
+
+  const summary = screen.getByText("test summary");
+  expect(summary).toBeInTheDocument();
+  expect(summary.closest("div")).toHaveClass("tableSummaryAbove");
 });
 
-test("renders the table preview component with the summary below the chart", async () => {
-  const { getByText } = render(
+test("renders the summary below the chart", async () => {
+  render(
     <TablePreview
       title="test title"
       summary="test summary"
@@ -33,9 +36,9 @@ test("renders the table preview component with the summary below the chart", asy
     />,
     { wrapper: MemoryRouter }
   );
-  expect(getByText("test title")).toBeInTheDocument();
-  expect(getByText("test summary")).toBeInTheDocument();
-  expect(getByText("test summary").previousSibling).toHaveClass("usa-table");
+  const summary = screen.getByText("test summary");
+  expect(summary).toBeInTheDocument();
+  expect(summary.closest("div")).toHaveClass("tableSummaryBelow");
 });
 
 test("table preview should match snapshot", async () => {
@@ -52,7 +55,7 @@ test("table preview should match snapshot", async () => {
 });
 
 test("table should not crash when a column header is an empty string", async () => {
-  const wrapper = render(
+  render(
     <TablePreview
       title="test title"
       summary="test summary"

--- a/frontend/src/components/__tests__/__snapshots__/ImagePreview.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/ImagePreview.test.tsx.snap
@@ -10,11 +10,13 @@ exports[`image preview should match snapshot 1`] = `
     >
       test title
     </h2>
-    <p
-      class="margin-left-1 margin-top-0 margin-bottom-3"
+    <div
+      class="Markdown margin-left-1 margin-top-0 margin-bottom-3 imageSummaryAbove"
     >
-      test summary
-    </p>
+      <p>
+        test summary
+      </p>
+    </div>
     <div
       class="margin-left-1"
     >

--- a/frontend/src/components/__tests__/__snapshots__/TablePreview.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/TablePreview.test.tsx.snap
@@ -10,11 +10,13 @@ exports[`table preview should match snapshot 1`] = `
     >
       test title
     </h2>
-    <p
-      class="margin-left-1 margin-top-0 margin-bottom-3"
+    <div
+      class="Markdown margin-left-1 margin-top-0 margin-bottom-3 tableSummaryAbove"
     >
-      test summary
-    </p>
+      <p>
+        test summary
+      </p>
+    </div>
     <table
       class="usa-table usa-table--borderless margin-left-1"
       role="table"


### PR DESCRIPTION
## Description

Added markdown support to Content Item summaries: BarChart, LineChart, ColumnChart, PartToWhole, Image and Table. 

## Testing

Refactored unit tests that verified the summary shows up below or above the chart as the DOM structure changed and the unit tests were breaking. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
