### PR TITLE
GTT-980: Special characters not encoded properly when in uploaded files

### DIFF
--- a/frontend/src/containers/AddChart.tsx
+++ b/frontend/src/containers/AddChart.tsx
@@ -181,6 +181,7 @@ function AddChart() {
         dynamicTyping: true,
         skipEmptyLines: true,
         comments: "#",
+        encoding: "ISO-8859-1",
         complete: async function (results: ParseResult<object>) {
           if (results.errors.length) {
             setCsvErrors(results.errors);

--- a/frontend/src/containers/AddTable.tsx
+++ b/frontend/src/containers/AddTable.tsx
@@ -165,6 +165,7 @@ function AddTable() {
       dynamicTyping: true,
       skipEmptyLines: true,
       comments: "#",
+      encoding: "ISO-8859-1",
       complete: function (results: ParseResult<object>) {
         if (results.errors.length) {
           setCsvErrors(results.errors);

--- a/frontend/src/containers/EditChart.tsx
+++ b/frontend/src/containers/EditChart.tsx
@@ -133,6 +133,7 @@ function EditChart() {
         dynamicTyping: true,
         skipEmptyLines: true,
         comments: "#",
+        encoding: "ISO-8859-1",
         complete: function (results: ParseResult<object>) {
           if (results.errors.length) {
             setCsvErrors(results.errors);

--- a/frontend/src/containers/EditTable.tsx
+++ b/frontend/src/containers/EditTable.tsx
@@ -124,6 +124,7 @@ function EditTable() {
         dynamicTyping: true,
         skipEmptyLines: true,
         comments: "#",
+        encoding: "ISO-8859-1",
         complete: function (results: ParseResult<object>) {
           if (results.errors.length) {
             setCsvErrors(results.errors);

--- a/frontend/src/containers/FormattingCSV.tsx
+++ b/frontend/src/containers/FormattingCSV.tsx
@@ -32,6 +32,12 @@ function FormattingCSV() {
           items. Below are examples of content types with formatted CSV files
           for your reference.
         </p>
+        <h3>Mac Operating Systems</h3>
+        <p>
+          CSV files created in excel will have issues displaying special
+          characters on the website. The workaround is to save the file in excel
+          as a CSV UTF-8 file.
+        </p>
       </div>
 
       <h2>Line chart</h2>

--- a/frontend/src/hooks/dataset-hooks.ts
+++ b/frontend/src/hooks/dataset-hooks.ts
@@ -103,6 +103,7 @@ export function useSampleDataset(sampleCSV: string): SampleDatasetsHook {
         dynamicTyping: true,
         skipEmptyLines: true,
         comments: "#",
+        encoding: "ISO-8859-1",
         complete: (results: ParseResult<object>) => {
           if (results.errors.length === 0) {
             setDataset({


### PR DESCRIPTION
## Description

When you upload a CSV file with special characters such as ü, they appear as unknown characters on badger. This is because papaparse was not configured to handle special characters, as no encoding was set. If you set the encoding to "ISO-8859-1", this allows for csv files made in excel (on a PC) to upload files with speical characters with no problem.

However, there is currently no way to get a csv file made in excel (on a mac) with special characters, to work properly. The only work around for a mac, is for the user in excel to save the file as a UTF-8 CSV file.

This fix allows PCs to upload files with special characters with no issue.

## Testing

I tested with @jasongudalis by deploying to my environment, and having him upload csv files made on his PC with special characters. He was able to successfully upload files with the below fix, and have special characters show up properly.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
