### PR TITLE
GTT-1017: Take deletedBy in the AuditLogProcessor as the source for the user who deleted a dashboard

### DIFF
--- a/backend/src/lib/factories/__tests__/auditlog-factory.test.ts
+++ b/backend/src/lib/factories/__tests__/auditlog-factory.test.ts
@@ -113,6 +113,7 @@ describe("buildDashboardAuditLogFromEvent", () => {
       createdBy: "johndoe",
       updatedBy: "johndoe",
       updatedAt: new Date(),
+      deletedBy: "johndoe",
       state: DashboardState.Draft,
     };
 
@@ -126,7 +127,7 @@ describe("buildDashboardAuditLogFromEvent", () => {
     expect(auditLog.sk).toEqual(timestamp.toISOString());
     expect(auditLog.pk).toEqual("Dashboard#d5f6b6e4bb22");
     expect(auditLog.type).toEqual(DASHBOARD_ITEM_TYPE);
-    expect(auditLog.userId).toEqual("unknown");
+    expect(auditLog.userId).toEqual("johndoe");
     expect(auditLog.version).toEqual(1);
   });
 });

--- a/backend/src/lib/factories/auditlog-factory.ts
+++ b/backend/src/lib/factories/auditlog-factory.ts
@@ -29,6 +29,9 @@ function buildDashboardAuditLogFromEvent(
     case ItemEvent.Update:
       userId = dashboard.updatedBy ?? "unknown";
       break;
+    case ItemEvent.Delete:
+      userId = dashboard.deletedBy ?? "unknown";
+      break;
   }
 
   const auditLog: DashboardAuditLogItem = {

--- a/backend/src/lib/factories/dashboard-factory.ts
+++ b/backend/src/lib/factories/dashboard-factory.ts
@@ -85,6 +85,7 @@ function toItem(dashboard: Dashboard): DashboardItem {
     createdBy: dashboard.createdBy,
     updatedAt: dashboard.updatedAt.toISOString(),
     updatedBy: dashboard.updatedBy,
+    deletedBy: dashboard.deletedBy,
     releaseNotes: dashboard.releaseNotes,
     friendlyURL: dashboard.friendlyURL,
   };
@@ -104,6 +105,7 @@ function fromItem(item: DashboardItem): Dashboard {
     parentDashboardId: item.parentDashboardId,
     updatedAt: item.updatedAt ? new Date(item.updatedAt) : new Date(),
     updatedBy: item.updatedBy,
+    deletedBy: item.deletedBy,
     state: (item.state as DashboardState) || DashboardState.Draft,
     releaseNotes: item.releaseNotes,
     friendlyURL: item.friendlyURL,

--- a/backend/src/lib/services/audit-trail.ts
+++ b/backend/src/lib/services/audit-trail.ts
@@ -6,7 +6,7 @@ import AuditLogRepository from "../repositories/auditlog-repo";
 import logger from "./logger";
 
 /**
- * Handles a Create, Delete or Updat eevent that happened to
+ * Handles a Create, Delete or Update event that happened to
  * a DynamoDB item on the main table. i.e. Dashboard was updated.
  */
 async function handleItemEvent(


### PR DESCRIPTION
## Description

Take deletedBy in the AuditLogProcessor as the source for the user who deleted a dashboard.

## Testing

Tested it in my local environment.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
