### PR TITLE
GTT-1032 Publish pending endpoint now allows update of release notes

### DIFF
--- a/backend/src/lib/controllers/__tests__/dashboard-ctrl.test.ts
+++ b/backend/src/lib/controllers/__tests__/dashboard-ctrl.test.ts
@@ -306,7 +306,9 @@ describe("publishPendingDashboard", () => {
     repository.getDashboardById = jest.fn().mockReturnValue(dashboard);
     await DashboardCtrl.publishPendingDashboard(req, res);
     expect(res.status).toBeCalledWith(409);
-    expect(res.send).toBeCalledWith("Dashboard must be in draft state");
+    expect(res.send).toBeCalledWith(
+      "Dashboard must be in draft or publish pending state"
+    );
   });
 
   it("allows the update of release notes", async () => {

--- a/backend/src/lib/controllers/__tests__/dashboard-ctrl.test.ts
+++ b/backend/src/lib/controllers/__tests__/dashboard-ctrl.test.ts
@@ -309,7 +309,36 @@ describe("publishPendingDashboard", () => {
     expect(res.send).toBeCalledWith("Dashboard must be in draft state");
   });
 
-  it("update the dashboard", async () => {
+  it("allows the update of release notes", async () => {
+    const dashboard: Dashboard = {
+      id: "123",
+      version: 1,
+      parentDashboardId: "123",
+      name: "My Dashboard",
+      topicAreaId: "abc",
+      topicAreaName: "My Topic Area",
+      updatedAt: new Date(),
+      createdBy: "johndoe",
+      state: DashboardState.PublishPending, // dashboard can already be in publish pending
+      description: "",
+      widgets: [],
+      releaseNotes: "",
+    };
+
+    req.body.releaseNotes = "Lorem ipsum";
+    repository.getDashboardById = jest.fn().mockReturnValue(dashboard);
+    await DashboardCtrl.publishPendingDashboard(req, res);
+
+    expect(res.json).toBeCalled();
+    expect(repository.publishPendingDashboard).toHaveBeenCalledWith(
+      "123",
+      now.toISOString(),
+      user,
+      "Lorem ipsum"
+    );
+  });
+
+  it("sets the dashboard to publish pending", async () => {
     const dashboard: Dashboard = {
       id: "123",
       version: 1,
@@ -324,12 +353,15 @@ describe("publishPendingDashboard", () => {
       widgets: [],
       releaseNotes: "release note test",
     };
+
     repository.getDashboardById = jest.fn().mockReturnValue(dashboard);
     await DashboardCtrl.publishPendingDashboard(req, res);
+
     expect(repository.publishPendingDashboard).toHaveBeenCalledWith(
       "123",
       now.toISOString(),
-      user
+      user,
+      undefined
     );
   });
 });

--- a/backend/src/lib/controllers/dashboard-ctrl.ts
+++ b/backend/src/lib/controllers/dashboard-ctrl.ts
@@ -238,7 +238,7 @@ async function publishPendingDashboard(req: Request, res: Response) {
     dashboard.state !== DashboardState.PublishPending
   ) {
     res.status(409);
-    return res.send("Dashboard must be in draft state");
+    return res.send("Dashboard must be in draft or publish pending state");
   }
 
   const updatedDashboard = await repo.publishPendingDashboard(

--- a/backend/src/lib/controllers/dashboard-ctrl.ts
+++ b/backend/src/lib/controllers/dashboard-ctrl.ts
@@ -224,7 +224,7 @@ async function publishDashboard(req: Request, res: Response) {
 async function publishPendingDashboard(req: Request, res: Response) {
   const user = req.user;
   const { id } = req.params;
-  const { updatedAt } = req.body;
+  const { updatedAt, releaseNotes } = req.body;
 
   if (!updatedAt) {
     res.status(400).send("Missing required body `updatedAt`");
@@ -232,15 +232,23 @@ async function publishPendingDashboard(req: Request, res: Response) {
   }
 
   const repo = DashboardRepository.getInstance();
-
   const dashboard = await repo.getDashboardById(id);
-  if (dashboard.state !== DashboardState.Draft) {
+  if (
+    dashboard.state !== DashboardState.Draft &&
+    dashboard.state !== DashboardState.PublishPending
+  ) {
     res.status(409);
     return res.send("Dashboard must be in draft state");
   }
 
-  await repo.publishPendingDashboard(id, updatedAt, user);
-  res.send();
+  const updatedDashboard = await repo.publishPendingDashboard(
+    id,
+    updatedAt,
+    user,
+    releaseNotes
+  );
+
+  res.json(updatedDashboard);
 }
 
 async function archiveDashboard(req: Request, res: Response) {


### PR DESCRIPTION
## Description

The endpoint to set a dashboard to publish pending now allows to pass `releaseNotes` as an optional property in the request body. This will allow the frontend to save the release notes as many times as necessary without moving the dashboard to published state. 

I also updated the endpoint to return the newly updated dashboard. We should refactor all the other endpoints to do the same. Whenever we update a dashboard via a PUT request, the endpoint should return the updated entry. This will save a GET call to fetch it right after an update. 

## Testing

Ran all the integration tests locally to make sure I didn't break backwards compatibility with the API. I updated the unit tests and also added new ones. I also updated our Postman collection to add the new optional field `releaseNotes` in the request body. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
