### PR TITLE
GTT-1024: Fix issue where XAxis numeric scaling is making annual charts unpresentable

### DIFF
--- a/frontend/src/components/BarChartPreview.tsx
+++ b/frontend/src/components/BarChartPreview.tsx
@@ -113,8 +113,10 @@ const BarChartPreview = (props: Props) => {
                 yAxisLabelMaxWidth
               )}
               minTickGap={0}
-              domain={[0, "dataMax + 1"]}
+              domain={["dataMin - 1", "dataMax + 1"]}
+              scale={yAxisType() === "number" ? "linear" : "auto"}
               tickFormatter={formatYAxisLabel}
+              reversed={true}
             />
             <Tooltip cursor={{ fill: "#F0F0F0" }} isAnimationActive={false} />
             {!props.hideLegend && (

--- a/frontend/src/components/ColumnChartPreview.tsx
+++ b/frontend/src/components/ColumnChartPreview.tsx
@@ -106,10 +106,11 @@ const ColumnChartPreview = (props: Props) => {
               dataKey={props.columns.length ? props.columns[0] : ""}
               type={xAxisType()}
               padding={{ left: 20, right: 20 }}
-              domain={[0, "dataMax"]}
+              domain={["dataMin", "dataMax"]}
               interval={0}
+              scale={xAxisType() === "number" ? "linear" : "auto"}
             />
-            <YAxis type="number" domain={[0, "dataMax"]} />
+            <YAxis type="number" />
             <Tooltip cursor={{ fill: "#F0F0F0" }} isAnimationActive={false} />
             {!props.hideLegend && (
               <Legend

--- a/frontend/src/components/LineChartPreview.tsx
+++ b/frontend/src/components/LineChartPreview.tsx
@@ -107,8 +107,9 @@ const LineChartPreview = (props: Props) => {
               dataKey={props.lines.length ? props.lines[0] : ""}
               type={xAxisType()}
               padding={{ left: 50, right: 50 }}
-              domain={[0, "dataMax"]}
+              domain={["dataMin", "dataMax"]}
               interval={0}
+              scale={xAxisType() === "number" ? "linear" : "auto"}
             />
             <YAxis type="number" />
             <Tooltip cursor={{ fill: "#F0F0F0" }} isAnimationActive={false} />

--- a/frontend/src/services/UtilsService.ts
+++ b/frontend/src/services/UtilsService.ts
@@ -56,7 +56,7 @@ function getLargestHeader(headers: Array<string>, data?: Array<any>) {
   return (
     data
       ?.map((d) => (d as any)[headers.length ? headers[0] : ""])
-      .map((c) => (c as string).length)
+      .map((c) => c.toString().length)
       .reduce((a, b) => (a > b ? a : b), 0) || 0
   );
 }


### PR DESCRIPTION
## Description

Fix issue where XAxis numeric scaling is making annual charts unpresentable

## Testing

I tested it in my personal environment: https://migdizn.badger.wwps.aws.dev/admin/dashboard/ab13ccfa-17e5-4f5f-826d-0c628a621edc/edit-chart/0b2228cb-9404-4a64-8586-c433015c7ae4

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
