### PR TITLE
fix: MarkdownRender crashed with undefined source

### DIFF
--- a/frontend/src/components/MarkdownRender.tsx
+++ b/frontend/src/components/MarkdownRender.tsx
@@ -21,7 +21,7 @@ const MarkdownRender = (props: MarkdownRenderProps) => {
       ]}
       linkTarget="_blank"
       className={`Markdown ${props.className}`}
-      source={props.source}
+      source={props.source || ""}
     />
   );
 };


### PR DESCRIPTION
## Description

The MarkDownRender component allows `source` to be undefined however this caused a Warning message saying that the value must be a string. My guess is that this will fix the current issue we see in Gamma. The reason why I'm not completely positive about it is because we don't have enough detail on the gamma error, but it does suggest that it happens in the MarkdownRender component. 

## Testing

Verified unit tests. Tested locally to make sure I no longer get the warning. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
