### PR TITLE
GTT-1033 Save release notes when user moves to step 2

### DIFF
--- a/frontend/src/containers/PublishDashboard.tsx
+++ b/frontend/src/containers/PublishDashboard.tsx
@@ -5,6 +5,7 @@ import { useDashboard, useDashboardVersions, useSettings } from "../hooks";
 import { DashboardState, LocationState } from "../models";
 import BackendService from "../services/BackendService";
 import Alert from "../components/Alert";
+import AlertContainer from "../containers/AlertContainer";
 import StepIndicator from "../components/StepIndicator";
 import TextField from "../components/TextField";
 import Button from "../components/Button";
@@ -22,20 +23,30 @@ interface PathParams {
 
 interface FormValues {
   releaseNotes: string;
+  acknowledge: boolean;
 }
 
 function PublishDashboard() {
   const { dashboardId } = useParams<PathParams>();
   const history = useHistory<LocationState>();
   const [step, setStep] = useState<number>(0);
-  const [acknowledge, setAcknowledge] = useState<boolean>(false);
-  const { dashboard, reloadDashboard, loading } = useDashboard(dashboardId);
   const { settings } = useSettings();
-  const { register, errors, handleSubmit, trigger } = useForm<FormValues>();
-  const [releaseNotes, setReleaseNotes] = useState("");
+  const { dashboard, reloadDashboard, setDashboard } = useDashboard(
+    dashboardId
+  );
 
   const { versions } = useDashboardVersions(dashboard?.parentDashboardId);
+  const {
+    register,
+    errors,
+    handleSubmit,
+    trigger,
+    getValues,
+    watch,
+  } = useForm<FormValues>();
 
+  const releaseNotes = watch("releaseNotes");
+  const acknowledge = watch("acknowledge");
   const published = versions.find((v) => v.state === DashboardState.Published);
 
   const onPreview = () => {
@@ -43,9 +54,29 @@ function PublishDashboard() {
   };
 
   const onContinue = async () => {
-    if (await trigger()) {
-      // validates form
-      setStep(step + 1);
+    const isFormValid = await trigger();
+    if (isFormValid && dashboard) {
+      try {
+        // Save release notes
+        const { releaseNotes } = getValues();
+        const updatedDashboard = await BackendService.publishPending(
+          dashboardId,
+          dashboard?.updatedAt,
+          releaseNotes
+        );
+
+        setDashboard(updatedDashboard);
+        setStep(step + 1);
+      } catch (err) {
+        await reloadDashboard();
+        history.push(`/admin/dashboard/${dashboardId}/publish`, {
+          id: "top-alert",
+          alert: {
+            type: "error",
+            message: "Failed to save release notes, please try again",
+          },
+        });
+      }
     }
   };
 
@@ -56,7 +87,6 @@ function PublishDashboard() {
 
     try {
       await BackendService.moveToDraft(dashboardId, dashboard.updatedAt);
-
       history.push(`/admin/dashboard/edit/${dashboardId}`, {
         alert: {
           type: "success",
@@ -65,8 +95,14 @@ function PublishDashboard() {
         id: "top-alert",
       });
     } catch (err) {
-      console.log("Failed to return to draft");
       await reloadDashboard();
+      history.push(`/admin/dashboard/${dashboardId}/publish`, {
+        id: "top-alert",
+        alert: {
+          type: "error",
+          message: "Failed to return dashboard to draft. Please try again.",
+        },
+      });
     }
   };
 
@@ -78,27 +114,31 @@ function PublishDashboard() {
           dashboard.updatedAt,
           values.releaseNotes
         );
-      } catch (err) {
-        console.log("Error publishing the dashboard", err);
-        return;
-      }
 
-      history.push(`/admin/dashboards?tab=published`, {
-        alert: {
-          type: "success",
-          message: `${dashboard.name} dashboard was successfully published.`,
-          to: `/${dashboardId}`,
-          linkLabel: "View the published dashboard",
-        },
-      });
+        history.push(`/admin/dashboards?tab=published`, {
+          alert: {
+            type: "success",
+            message: `${dashboard.name} dashboard was successfully published.`,
+            to: `/${dashboardId}`,
+            linkLabel: "View the published dashboard",
+          },
+        });
+      } catch (err) {
+        await reloadDashboard();
+        history.push(`/admin/dashboard/${dashboardId}/publish`, {
+          id: "top-alert",
+          alert: {
+            type: "error",
+            message: "Failed to publish dashboard. Please try again.",
+          },
+        });
+      }
     }
   };
 
-  const handleReleaseNotesInput = (
-    event: React.FormEvent<HTMLInputElement>
-  ) => {
-    setReleaseNotes((event.target as HTMLInputElement).value);
-  };
+  if (!dashboard) {
+    return <Spinner className="text-center margin-top-9" label="Loading" />;
+  }
 
   return (
     <>
@@ -114,171 +154,165 @@ function PublishDashboard() {
         ]}
       />
 
-      {loading ? (
-        <Spinner className="text-center margin-top-9" label="Loading" />
-      ) : (
-        <>
-          <div className="margin-y-2">
-            <Alert
-              type="info"
-              message={
-                "This dashboard is now in the publish pending state and " +
-                "cannot be edited unless returned to draft"
-              }
-              slim
-            />
-          </div>
-          <div className="grid-row">
-            <div className="grid-col text-left padding-top-2">
-              <ul className="usa-button-group">
-                <li className="usa-button-group__item">
-                  <span className="usa-tag" style={{ cursor: "text" }}>
-                    Publish Pending
-                  </span>
-                </li>
-                <li className="usa-button-group__item">
-                  <span className="text-underline text-middle">
-                    <FontAwesomeIcon icon={faCopy} className="margin-right-1" />
-                    Version {dashboard?.version}
-                  </span>
-                </li>
-              </ul>
-            </div>
-            <div className="grid-col text-right">
-              <span className="text-base margin-right-1">
-                {dashboard &&
-                  `Last saved ${dayjs(dashboard.updatedAt).fromNow()}`}
-              </span>
-              <Button variant="outline" onClick={onPreview}>
-                Preview
-              </Button>
-              <Button variant="outline" onClick={onReturnToDraft}>
-                Return to draft
-              </Button>
-            </div>
-          </div>
-          <div>
-            <h1 className="margin-bottom-0 display-inline-block">
-              {dashboard?.name}
-            </h1>
-            <div className="margin-top-1">
-              <span className="text-base text-italic">
-                {dashboard?.topicAreaName}
-              </span>
-            </div>
-          </div>
-          <div className="margin-y-3">
-            <StepIndicator
-              current={step}
-              segments={[
-                {
-                  label: "Internal version notes",
-                },
-                {
-                  label: "Review and publish",
-                },
-              ]}
-            />
-          </div>
-          <form
-            onSubmit={handleSubmit(onSubmit)}
-            className="usa-form usa-form--large"
-          >
-            <div className="margin-y-2">
-              <div hidden={step !== 0}>
-                <TextField
-                  id="releaseNotes"
-                  name="releaseNotes"
-                  label="Internal release notes"
-                  error={errors.releaseNotes && "Please enter release notes"}
-                  hint="Describe what changes you are publishing to the dashboard."
-                  onChange={handleReleaseNotesInput}
-                  register={register}
-                  required
-                  multiline
-                />
-              </div>
+      <div className="margin-y-2">
+        <Alert
+          type="info"
+          message={
+            "This dashboard is now in the publish pending state and " +
+            "cannot be edited unless returned to draft"
+          }
+          slim
+        />
 
-              <div hidden={step !== 1} className="padding-y-1">
-                <table className="usa-table border-hidden" width="100%">
-                  <tbody>
-                    <tr>
-                      <td className="border-hidden text-top">
-                        <div className="usa-checkbox">
-                          <input
-                            type="checkbox"
-                            id="acknowledge"
-                            name="acknowledge"
-                            className="usa-checkbox__input"
-                            onChange={(
-                              e: React.ChangeEvent<HTMLInputElement>
-                            ) => {
-                              setAcknowledge(e.target.checked);
-                            }}
-                          />
-                          <label
-                            className="usa-checkbox__label margin-top-1"
-                            htmlFor="acknowledge"
-                            data-testid="AcknowledgementCheckboxLabel"
-                          />
-                        </div>
-                      </td>
-                      <td className="publishing-guidance border-hidden">
-                        <span className=" font-sans-sm">
-                          <MarkdownRender
-                            source={`${settings.publishingGuidance}${
-                              settings.publishingGuidance[
-                                settings.publishingGuidance.length - 1
-                              ] === "."
-                                ? ""
-                                : "."
-                            }`}
-                          />
-                        </span>
-                        {published &&
-                        published.state === DashboardState.Published ? (
-                          <p>
-                            I also understand that this will overwrite the
-                            existing published version of the dashboard.
-                          </p>
-                        ) : (
-                          ""
-                        )}
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-            </div>
-            <div>
-              <span hidden={step === 0}>
-                <Button
-                  variant="outline"
-                  type="button"
-                  onClick={() => setStep(step - 1)}
-                >
-                  Back
-                </Button>
+        <AlertContainer id="top-alert" />
+      </div>
+      <div className="grid-row">
+        <div className="grid-col text-left padding-top-2">
+          <ul className="usa-button-group">
+            <li className="usa-button-group__item">
+              <span className="usa-tag" style={{ cursor: "text" }}>
+                Publish Pending
               </span>
-              <span hidden={step === 1}>
-                <Button
-                  variant="default"
-                  type="button"
-                  onClick={onContinue}
-                  disabled={releaseNotes === ""}
-                >
-                  Continue
-                </Button>
+            </li>
+            <li className="usa-button-group__item">
+              <span className="text-underline text-middle">
+                <FontAwesomeIcon icon={faCopy} className="margin-right-1" />
+                Version {dashboard?.version}
               </span>
-              <span hidden={step < 1}>
-                <Button variant="default" type="submit" disabled={!acknowledge}>
-                  Publish
-                </Button>
-              </span>
-            </div>
-          </form>
-        </>
-      )}
+            </li>
+          </ul>
+        </div>
+        <div className="grid-col text-right">
+          <span className="text-base margin-right-1">
+            {dashboard && `Last saved ${dayjs(dashboard.updatedAt).fromNow()}`}
+          </span>
+          <Button variant="outline" onClick={onPreview}>
+            Preview
+          </Button>
+          <Button variant="outline" onClick={onReturnToDraft}>
+            Return to draft
+          </Button>
+        </div>
+      </div>
+      <div>
+        <h1 className="margin-bottom-0 display-inline-block">
+          {dashboard.name}
+        </h1>
+        <div className="margin-top-1">
+          <span className="text-base text-italic">
+            {dashboard.topicAreaName}
+          </span>
+        </div>
+      </div>
+      <div className="margin-y-3">
+        <StepIndicator
+          current={step}
+          segments={[
+            {
+              label: "Internal version notes",
+            },
+            {
+              label: "Review and publish",
+            },
+          ]}
+        />
+      </div>
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className="usa-form usa-form--large"
+      >
+        <div className="margin-y-2">
+          <div hidden={step !== 0}>
+            <TextField
+              id="releaseNotes"
+              name="releaseNotes"
+              label="Internal release notes"
+              error={errors.releaseNotes && "Please enter release notes"}
+              hint="Describe what changes you are publishing to the dashboard."
+              register={register}
+              defaultValue={dashboard.releaseNotes}
+              required
+              multiline
+            />
+          </div>
+
+          <div hidden={step !== 1} className="padding-y-1">
+            <table
+              className="usa-table border-hidden"
+              style={{ width: "100%" }}
+            >
+              <tbody>
+                <tr>
+                  <td className="border-hidden text-top">
+                    <div className="usa-checkbox">
+                      <input
+                        type="checkbox"
+                        id="acknowledge"
+                        name="acknowledge"
+                        className="usa-checkbox__input"
+                        ref={register}
+                      />
+                      <label
+                        className="usa-checkbox__label margin-top-1"
+                        htmlFor="acknowledge"
+                        data-testid="AcknowledgementCheckboxLabel"
+                      />
+                    </div>
+                  </td>
+                  <td className="publishing-guidance border-hidden">
+                    <span className=" font-sans-sm">
+                      <MarkdownRender
+                        source={`${settings.publishingGuidance}${
+                          settings.publishingGuidance[
+                            settings.publishingGuidance.length - 1
+                          ] === "."
+                            ? ""
+                            : "."
+                        }`}
+                      />
+                    </span>
+                    {published &&
+                    published.state === DashboardState.Published ? (
+                      <p>
+                        I also understand that this will overwrite the existing
+                        published version of the dashboard.
+                      </p>
+                    ) : (
+                      ""
+                    )}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div>
+          <span hidden={step === 0}>
+            <Button
+              variant="outline"
+              type="button"
+              onClick={() => setStep(step - 1)}
+            >
+              Back
+            </Button>
+          </span>
+          <span hidden={step === 1}>
+            <Button
+              variant="default"
+              type="button"
+              onClick={onContinue}
+              disabled={!releaseNotes}
+            >
+              Continue
+            </Button>
+          </span>
+          <span hidden={step < 1}>
+            <Button variant="default" type="submit" disabled={!acknowledge}>
+              Publish
+            </Button>
+          </span>
+        </div>
+      </form>
     </>
   );
 }

--- a/frontend/src/containers/__tests__/PublishDashboard.test.tsx
+++ b/frontend/src/containers/__tests__/PublishDashboard.test.tsx
@@ -1,39 +1,46 @@
 import React from "react";
-import { render, RenderResult, fireEvent, act } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { render, fireEvent, act, screen } from "@testing-library/react";
+import { Router, Route } from "react-router-dom";
+import { createMemoryHistory } from "history";
 import BackendService from "../../services/BackendService";
 import PublishDashboard from "../PublishDashboard";
 
 jest.mock("../../services/BackendService");
 jest.mock("../../hooks");
 
-let wrapper: RenderResult;
 beforeEach(() => {
-  wrapper = render(<PublishDashboard />, {
-    wrapper: MemoryRouter,
-  });
+  const history = createMemoryHistory();
+  history.push("/admin/dashboard/123/publish");
+
+  render(
+    <Router history={history}>
+      <Route path="/admin/dashboard/:dashboardId/publish">
+        <PublishDashboard />
+      </Route>
+    </Router>
+  );
 });
 
 test("renders dashboard title", () => {
   expect(
-    wrapper.getByRole("heading", {
+    screen.getByRole("heading", {
       name: "My AWS Dashboard",
     })
   ).toBeInTheDocument();
 });
 
 test("renders topic area", () => {
-  expect(wrapper.getByText("Bananas")).toBeInTheDocument();
+  expect(screen.getByText("Bananas")).toBeInTheDocument();
 });
 
 test("renders step indicator in step 1", () => {
   expect(
-    wrapper.getByRole("heading", { name: "Step 1 of 2 Internal version notes" })
+    screen.getByRole("heading", { name: "Step 1 of 2 Internal version notes" })
   ).toBeInTheDocument();
 });
 
-test("continue button advances to step 2", async () => {
-  fireEvent.input(wrapper.getByLabelText("Internal release notes"), {
+test("continue button advances to step 2 and saves releaseNotes", async () => {
+  fireEvent.input(screen.getByLabelText("Internal release notes"), {
     target: {
       value: "Some release notes",
     },
@@ -41,39 +48,45 @@ test("continue button advances to step 2", async () => {
 
   await act(async () => {
     fireEvent.click(
-      wrapper.getByRole("button", {
+      screen.getByRole("button", {
         name: "Continue",
       })
     );
   });
 
+  expect(BackendService.publishPending).toBeCalledWith(
+    "123",
+    expect.anything(),
+    "Some release notes"
+  );
+
   expect(
-    wrapper.getByRole("heading", {
+    screen.getByRole("heading", {
       name: "Step 2 of 2 Review and publish",
     })
   ).toBeInTheDocument();
 });
 
 test("publish button invokes BackendService", async () => {
-  fireEvent.input(wrapper.getByLabelText("Internal release notes"), {
+  fireEvent.input(screen.getByLabelText("Internal release notes"), {
     target: {
       value: "Some release notes",
     },
   });
 
   fireEvent.click(
-    wrapper.getByRole("button", {
+    screen.getByRole("button", {
       name: "Continue",
     })
   );
 
   await act(async () => {
-    fireEvent.click(wrapper.getByTestId("AcknowledgementCheckboxLabel"));
+    fireEvent.click(screen.getByTestId("AcknowledgementCheckboxLabel"));
   });
 
   await act(async () => {
     fireEvent.click(
-      wrapper.getByRole("button", {
+      screen.getByRole("button", {
         name: "Publish",
       })
     );
@@ -85,7 +98,7 @@ test("publish button invokes BackendService", async () => {
 test("return to draft button invokes BackendService", async () => {
   await act(async () => {
     fireEvent.click(
-      wrapper.getByRole("button", {
+      screen.getByRole("button", {
         name: "Return to draft",
       })
     );

--- a/frontend/src/services/BackendService.ts
+++ b/frontend/src/services/BackendService.ts
@@ -352,13 +352,15 @@ async function createDraft(dashboardId: string): Promise<Dashboard> {
 
 async function publishPending(
   dashboardId: string,
-  lastUpdatedAt: Date
+  lastUpdatedAt: Date,
+  releaseNotes?: string
 ): Promise<Dashboard> {
   const headers = await authHeaders();
   return await API.put(apiName, `dashboard/${dashboardId}/publishpending`, {
     headers,
     body: {
       updatedAt: lastUpdatedAt,
+      releaseNotes: releaseNotes,
     },
   });
 }

--- a/frontend/src/services/__tests__/BackendService.test.ts
+++ b/frontend/src/services/__tests__/BackendService.test.ts
@@ -248,16 +248,27 @@ test("createDraft makes a POST request to dashboard API", async () => {
 
 test("publishPending makes a PUT request to dashboard API", async () => {
   const lastUpdatedAt = new Date();
-  await BackendService.publishPending("123", lastUpdatedAt);
+  const releaseNotes = "Lorem ipsum";
+  await BackendService.publishPending("123", lastUpdatedAt, releaseNotes);
   expect(API.put).toBeCalledWith(
     "BackendApi",
     "dashboard/123/publishpending",
     expect.objectContaining({
       body: {
         updatedAt: lastUpdatedAt,
+        releaseNotes: releaseNotes,
       },
     })
   );
+});
+
+test("publishPending returns the updated dashboard", async () => {
+  const lastUpdatedAt = new Date();
+  const updatedDashboard = {};
+  API.put = jest.fn().mockReturnValueOnce(updatedDashboard);
+
+  const dashboard = await BackendService.publishPending("123", lastUpdatedAt);
+  expect(dashboard).toBe(updatedDashboard);
 });
 
 test("moveToDraft makes a PUT request to dashboard API", async () => {


### PR DESCRIPTION
## Description

Saving release notes when user presses the Continue button. Also added error handling on the PublishGuidance screen and made some minor refactors to use react hook form instead of `onChange` handlers to monitor changes to the form fields. 

## Testing

You can test in my personal environment and make sure that the release notes are saved when user presses Continue button: https://fdingler.badger.wwps.aws.dev/admin/dashboard/4da29347-9396-4d45-b360-0e475dac6a32/publish 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
