### PR TITLE
GTT-1007 Added dropdown menu to dashboards page with link to history

### DIFF
--- a/frontend/src/components/DraftsTab.tsx
+++ b/frontend/src/components/DraftsTab.tsx
@@ -7,6 +7,9 @@ import Search from "./Search";
 import ScrollTop from "./ScrollTop";
 import Table from "./Table";
 import Link from "./Link";
+import DropdownMenu from "../components/DropdownMenu";
+
+const { MenuItem, MenuLink } = DropdownMenu;
 
 interface Props {
   dashboards: Array<Dashboard>;
@@ -45,13 +48,24 @@ function DraftsTab(props: Props) {
         </div>
         <div className="tablet:grid-col-9 text-right">
           <span>
-            <Button
-              variant="outline"
-              disabled={selected.length === 0}
-              onClick={() => props.onDelete(selected)}
-            >
-              Delete
-            </Button>
+            <DropdownMenu buttonText="Actions" variant="outline">
+              <MenuLink
+                href={
+                  selected.length === 1
+                    ? `/admin/dashboard/${selected[0].id}/history`
+                    : "#"
+                }
+                disabled={selected.length !== 1}
+              >
+                View history
+              </MenuLink>
+              <MenuItem
+                onSelect={() => props.onDelete(selected)}
+                disabled={selected.length === 0}
+              >
+                Delete
+              </MenuItem>
+            </DropdownMenu>
           </span>
           <span>
             <Button onClick={createDashboard}>Create dashboard</Button>

--- a/frontend/src/components/DropdownMenu.css
+++ b/frontend/src/components/DropdownMenu.css
@@ -1,13 +1,20 @@
 [data-reach-menu-item] {
   cursor: pointer;
   margin-bottom: 10px;
-  margin-right: 40px;
+  margin-right: 10px;
   margin-left: 10px;
   font-size: 15px;
 }
 
-[data-reach-menu-item]:last-child {
+[data-reach-menu-link] {
+  text-decoration: none;
+  color: black;
+  display: block;
+}
+
+[data-reach-menu-list] > *:last-child {
   margin-bottom: 0px;
+  min-width: 120px;
 }
 
 [data-reach-menu-item][aria-disabled="true"] {

--- a/frontend/src/components/DropdownMenu.tsx
+++ b/frontend/src/components/DropdownMenu.tsx
@@ -7,7 +7,6 @@ import {
   MenuLink,
 } from "@reach/menu-button";
 import React, { ReactNode } from "react";
-import Dropdown from "./Dropdown";
 
 type Variant =
   | "base"

--- a/frontend/src/components/__tests__/DraftsTab.test.tsx
+++ b/frontend/src/components/__tests__/DraftsTab.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent, act } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import DraftsTab from "../DraftsTab";
 import { Dashboard } from "../../models";
+import userEvent from "@testing-library/user-event";
 
 jest.mock("../../hooks");
 
@@ -32,17 +33,6 @@ const dashboards: Array<Dashboard> = [
     widgets: [],
   },
 ];
-
-test("renders a button to delete", async () => {
-  const { getByRole } = render(
-    <DraftsTab dashboards={[]} onDelete={() => {}} />,
-    {
-      wrapper: MemoryRouter,
-    }
-  );
-  const button = getByRole("button", { name: "Delete" });
-  expect(button).toBeInTheDocument();
-});
 
 test("renders a button to create dashboard", async () => {
   const { getByRole } = render(
@@ -101,4 +91,45 @@ test("filters dashboards based on search input", async () => {
   // Dashboard one should dissapear
   expect(dashboard1).not.toBeInTheDocument();
   expect(dashboard2).toBeInTheDocument();
+});
+
+test("renders the dropdown menu", () => {
+  const { getByText } = render(
+    <DraftsTab dashboards={dashboards} onDelete={() => {}} />,
+    {
+      wrapper: MemoryRouter,
+    }
+  );
+  expect(getByText("Actions")).toBeInTheDocument();
+});
+
+test("when no dashboard is selected both dropdown options are disabled", () => {
+  const { getByText } = render(
+    <DraftsTab dashboards={dashboards} onDelete={() => {}} />,
+    {
+      wrapper: MemoryRouter,
+    }
+  );
+  userEvent.click(getByText("Actions"));
+  expect(getByText("View history")).toHaveAttribute("aria-disabled", "true");
+  expect(getByText("Delete")).toHaveAttribute("aria-disabled", "true");
+});
+
+test("view history navigates to the correct location", () => {
+  const { getByText, getByRole } = render(
+    <DraftsTab dashboards={dashboards} onDelete={() => {}} />,
+    {
+      wrapper: MemoryRouter,
+    }
+  );
+
+  const checkbox = getByRole("checkbox", { name: "Dashboard One" });
+  userEvent.click(checkbox);
+
+  userEvent.click(getByText("Actions"));
+
+  expect(getByText("View history").closest("a")).toHaveAttribute(
+    "href",
+    "/admin/dashboard/abc/history"
+  );
 });

--- a/frontend/src/containers/__tests__/DashboardListing.test.tsx
+++ b/frontend/src/containers/__tests__/DashboardListing.test.tsx
@@ -20,12 +20,11 @@ test("renders the tabs", async () => {
   expect(getByText("Published (1)")).toBeInTheDocument();
 });
 
-test("renders a button to delete", async () => {
-  const { getByRole } = render(<DashboardListing />, {
+test("renders a dropdown menu", async () => {
+  const { getByText } = render(<DashboardListing />, {
     wrapper: MemoryRouter,
   });
-  const button = getByRole("button", { name: "Delete" });
-  expect(button).toBeInTheDocument();
+  expect(getByText("Actions")).toBeInTheDocument();
 });
 
 test("renders a button to create dashboard", async () => {


### PR DESCRIPTION
## Description

Added the dropdown menu to the drafts tab of the dashboards page. Dropdown menu includes an option to view history for any individual dashboard. 

## Testing

Wrote tests and you can see it in action here --> https://dvinr4n9hngnv.cloudfront.net/admin/dashboards

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
