### PR TITLE
GTT-769 - Backend publish endpoint now receives friendlyURL as optional parameter

### DIFF
--- a/backend/src/lib/controllers/__tests__/dashboard-ctrl.test.ts
+++ b/backend/src/lib/controllers/__tests__/dashboard-ctrl.test.ts
@@ -227,6 +227,46 @@ describe("publishDashboard", () => {
     );
   });
 
+  it("takes the friendlyURL from the request if one is provided", async () => {
+    // Dashboard being published
+    repository.getDashboardById = jest.fn().mockReturnValue({
+      id: "123",
+      version: 1,
+      parentDashboardId: "456",
+      name: "My Dashboard",
+      topicAreaId: "abc",
+      topicAreaName: "My Topic Area",
+      updatedAt: new Date(),
+      createdBy: "johndoe",
+      state: DashboardState.PublishPending,
+      description: "",
+    });
+
+    // Simulate friendlyURL is not already taken
+    repository.getDashboardByFriendlyURL = jest
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new ItemNotFound();
+      });
+
+    req.body.friendlyURL = "user-provided-friendly-url";
+    await DashboardCtrl.publishDashboard(req, res);
+
+    expect(repository.publishDashboard).toHaveBeenCalledWith(
+      "123",
+      "456",
+      now.toISOString(),
+      "release note test",
+      user,
+      "user-provided-friendly-url"
+    );
+
+    // Also make sure that we validate the friendlyURL is not taken
+    expect(repository.getDashboardByFriendlyURL).toBeCalledWith(
+      "user-provided-friendly-url"
+    );
+  });
+
   it("publishes the dashboard", async () => {
     const dashboard: Dashboard = {
       id: "123",

--- a/backend/src/lib/controllers/dashboard-ctrl.ts
+++ b/backend/src/lib/controllers/dashboard-ctrl.ts
@@ -177,6 +177,7 @@ async function publishDashboard(req: Request, res: Response) {
   const user = req.user;
   const { id } = req.params;
   const { updatedAt, releaseNotes } = req.body;
+  let { friendlyURL } = req.body;
 
   if (!updatedAt) {
     res.status(400).send("Missing required body `updatedAt`");
@@ -194,9 +195,12 @@ async function publishDashboard(req: Request, res: Response) {
     return res.send("Dashboard must be in publish pending or archived state");
   }
 
-  // Automatically generate a friendlyURL for this dashboard. In a future sprint,
-  // we will allow the user to define the URL in the UI before publishing.
-  const friendlyURL = DashboardFactory.generateFriendlyURL(dashboard.name);
+  if (!friendlyURL) {
+    // For backwards compatibility, if the request comes without a friendlyURL,
+    // we generate one based on the dashboard name.
+    friendlyURL = DashboardFactory.generateFriendlyURL(dashboard.name);
+  }
+
   try {
     // Make sure the URL is not being used already by another dashboard family
     const existingDashboard = await repo.getDashboardByFriendlyURL(friendlyURL);


### PR DESCRIPTION
## Description

The endpoint for publishing a dashboard was always generating a friendlyURL automatically. Now we are giving the user the option to provide their friendlyURL in the publishing workflow. To preserve backwards compatibility with this endpoint, I have made this request parameter optional. In the case where this parameter is undefined we default to generating a friendlyURL automatically like we did before. 

## Testing

Verified in my local environment by running the integration tests. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
