### PR TITLE
GTT-769 - Added confirm URL input to publish workflow

### DIFF
--- a/frontend/src/containers/PublishDashboard.tsx
+++ b/frontend/src/containers/PublishDashboard.tsx
@@ -24,6 +24,7 @@ interface PathParams {
 interface FormValues {
   releaseNotes: string;
   acknowledge: boolean;
+  friendlyURL: string;
 }
 
 function PublishDashboard() {
@@ -112,7 +113,8 @@ function PublishDashboard() {
         await BackendService.publishDashboard(
           dashboardId,
           dashboard.updatedAt,
-          values.releaseNotes
+          values.releaseNotes,
+          values.friendlyURL || undefined
         );
 
         history.push(`/admin/dashboards?tab=published`, {
@@ -212,6 +214,9 @@ function PublishDashboard() {
               label: "Internal version notes",
             },
             {
+              label: "Confirm URL",
+            },
+            {
               label: "Review and publish",
             },
           ]}
@@ -234,9 +239,48 @@ function PublishDashboard() {
               required
               multiline
             />
+
+            <div className="margin-top-3">
+              <Button
+                variant="default"
+                type="button"
+                onClick={onContinue}
+                disabled={!releaseNotes}
+              >
+                Continue
+              </Button>
+            </div>
           </div>
 
-          <div hidden={step !== 1} className="padding-y-1">
+          <div hidden={step !== 1}>
+            <TextField
+              id="friendlyURL"
+              name="friendlyURL"
+              label="Dashboard URL"
+              error={errors.friendlyURL && "Please enter a valid URL"}
+              hint="Edit or confirm the URL that will be used to publish this dashboard."
+              register={register}
+            />
+
+            <div className="margin-top-3">
+              <Button
+                variant="outline"
+                type="button"
+                onClick={() => setStep(step - 1)}
+              >
+                Back
+              </Button>
+              <Button
+                variant="default"
+                type="button"
+                onClick={() => setStep(step + 1)}
+              >
+                Continue
+              </Button>
+            </div>
+          </div>
+
+          <div hidden={step !== 2} className="padding-y-1">
             <table
               className="usa-table border-hidden"
               style={{ width: "100%" }}
@@ -284,33 +328,19 @@ function PublishDashboard() {
                 </tr>
               </tbody>
             </table>
+            <div className="margin-top-3">
+              <Button
+                variant="outline"
+                type="button"
+                onClick={() => setStep(step - 1)}
+              >
+                Back
+              </Button>
+              <Button variant="default" type="submit" disabled={!acknowledge}>
+                Publish
+              </Button>
+            </div>
           </div>
-        </div>
-        <div>
-          <span hidden={step === 0}>
-            <Button
-              variant="outline"
-              type="button"
-              onClick={() => setStep(step - 1)}
-            >
-              Back
-            </Button>
-          </span>
-          <span hidden={step === 1}>
-            <Button
-              variant="default"
-              type="button"
-              onClick={onContinue}
-              disabled={!releaseNotes}
-            >
-              Continue
-            </Button>
-          </span>
-          <span hidden={step < 1}>
-            <Button variant="default" type="submit" disabled={!acknowledge}>
-              Publish
-            </Button>
-          </span>
         </div>
       </form>
     </>

--- a/frontend/src/containers/PublishDashboard.tsx
+++ b/frontend/src/containers/PublishDashboard.tsx
@@ -1,7 +1,12 @@
 import React, { useState } from "react";
 import { useParams, useHistory } from "react-router-dom";
 import { useForm } from "react-hook-form";
-import { useDashboard, useDashboardVersions, useSettings } from "../hooks";
+import {
+  useDashboard,
+  useDashboardVersions,
+  useSettings,
+  useFriendlyUrl,
+} from "../hooks";
 import { DashboardState, LocationState } from "../models";
 import BackendService from "../services/BackendService";
 import Alert from "../components/Alert";
@@ -36,6 +41,7 @@ function PublishDashboard() {
     dashboardId
   );
 
+  const { friendlyURL } = useFriendlyUrl(dashboard);
   const { versions } = useDashboardVersions(dashboard?.parentDashboardId);
   const {
     register,
@@ -260,6 +266,7 @@ function PublishDashboard() {
               error={errors.friendlyURL && "Please enter a valid URL"}
               hint="Edit or confirm the URL that will be used to publish this dashboard."
               register={register}
+              defaultValue={friendlyURL}
             />
 
             <div className="margin-top-3">

--- a/frontend/src/containers/__tests__/PublishDashboard.test.tsx
+++ b/frontend/src/containers/__tests__/PublishDashboard.test.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { render, fireEvent, act, screen } from "@testing-library/react";
+import {
+  render,
+  fireEvent,
+  act,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { Router, Route } from "react-router-dom";
 import { createMemoryHistory } from "history";
 import BackendService from "../../services/BackendService";
@@ -35,7 +41,7 @@ test("renders topic area", () => {
 
 test("renders step indicator in step 1", () => {
   expect(
-    screen.getByRole("heading", { name: "Step 1 of 2 Internal version notes" })
+    screen.getByRole("heading", { name: "Step 1 of 3 Internal version notes" })
   ).toBeInTheDocument();
 });
 
@@ -62,7 +68,7 @@ test("continue button advances to step 2 and saves releaseNotes", async () => {
 
   expect(
     screen.getByRole("heading", {
-      name: "Step 2 of 2 Review and publish",
+      name: "Step 2 of 3 Confirm URL",
     })
   ).toBeInTheDocument();
 });
@@ -74,6 +80,15 @@ test("publish button invokes BackendService", async () => {
     },
   });
 
+  // Move to step 2
+  fireEvent.click(
+    screen.getByRole("button", {
+      name: "Continue",
+    })
+  );
+
+  // Move to step 3, but wait for release notes to be saved first
+  await waitFor(() => expect(BackendService.publishPending).toHaveBeenCalled());
   fireEvent.click(
     screen.getByRole("button", {
       name: "Continue",
@@ -83,6 +98,12 @@ test("publish button invokes BackendService", async () => {
   await act(async () => {
     fireEvent.click(screen.getByTestId("AcknowledgementCheckboxLabel"));
   });
+
+  expect(
+    screen.getByRole("heading", {
+      name: "Step 3 of 3 Review and publish",
+    })
+  ).toBeInTheDocument();
 
   await act(async () => {
     fireEvent.click(

--- a/frontend/src/hooks/__mocks__/index.tsx
+++ b/frontend/src/hooks/__mocks__/index.tsx
@@ -482,3 +482,10 @@ export function useWidgetDataset(widget: Widget) {
     jsonHeaders,
   };
 }
+
+export function useFriendlyUrl() {
+  const [friendlyURL] = useState("/foo");
+  return {
+    friendlyURL,
+  };
+}

--- a/frontend/src/hooks/dashboard-hooks.ts
+++ b/frontend/src/hooks/dashboard-hooks.ts
@@ -8,6 +8,7 @@ import {
 } from "../models";
 import BackendService from "../services/BackendService";
 import AuditTrailService from "../services/AuditTrailService";
+import FriendlyURLGenerator from "../services/FriendlyURLGenerator";
 
 type UseDashboardHook = {
   loading: boolean;
@@ -236,5 +237,25 @@ export function useDashboardHistory(
   return {
     loading,
     auditlogs,
+  };
+}
+
+type UseFriendlyUrlHook = {
+  friendlyURL: string;
+};
+
+export function useFriendlyUrl(dashboard?: Dashboard): UseFriendlyUrlHook {
+  const [friendlyURL, setFriendlyURL] = useState("");
+  useEffect(() => {
+    if (dashboard) {
+      const url = dashboard.friendlyURL
+        ? dashboard.friendlyURL
+        : FriendlyURLGenerator.generateFromDashboardName(dashboard.name);
+      setFriendlyURL(url);
+    }
+  }, [dashboard]);
+
+  return {
+    friendlyURL,
   };
 }

--- a/frontend/src/hooks/index.tsx
+++ b/frontend/src/hooks/index.tsx
@@ -4,6 +4,7 @@ import {
   usePublicDashboard,
   useDashboardVersions,
   useDashboardHistory,
+  useFriendlyUrl,
 } from "./dashboard-hooks";
 import { useWidget, useColors, useWidgetDataset } from "./widget-hooks";
 import { useTopicAreas, useTopicArea } from "./topicarea-hooks";
@@ -46,4 +47,5 @@ export {
   useCurrentAuthenticatedUser,
   useImage,
   useLogo,
+  useFriendlyUrl,
 };

--- a/frontend/src/services/BackendService.ts
+++ b/frontend/src/services/BackendService.ts
@@ -129,7 +129,8 @@ async function editDashboard(
 async function publishDashboard(
   dashboardId: string,
   updatedAt: Date,
-  releaseNotes: string
+  releaseNotes: string,
+  friendlyURL?: string
 ) {
   const headers = await authHeaders();
   return await API.put(apiName, `dashboard/${dashboardId}/publish`, {
@@ -137,6 +138,7 @@ async function publishDashboard(
     body: {
       updatedAt,
       releaseNotes,
+      friendlyURL,
     },
   });
 }

--- a/frontend/src/services/FriendlyURLGenerator.ts
+++ b/frontend/src/services/FriendlyURLGenerator.ts
@@ -1,0 +1,15 @@
+function generateFromDashboardName(dashboardName: string): string {
+  return dashboardName
+    .trim()
+    .toLocaleLowerCase()
+    .replace(/[!#$&'\(\)\*\+,\/:;=\?@\[\]]+/g, " ") // remove RFC-3986 reserved characters
+    .replace(/\s+/g, "-") // replace spaces for dashes
+    .replace(/-+/g, "-") // convert consecutive dashes to singular dash
+    .replace(/^-+|-+$/g, ""); // remove dashes at the end and beginning
+}
+
+const FriendlyURLGenerator = {
+  generateFromDashboardName,
+};
+
+export default FriendlyURLGenerator;

--- a/frontend/src/services/__tests__/BackendService.test.ts
+++ b/frontend/src/services/__tests__/BackendService.test.ts
@@ -83,8 +83,14 @@ test("publishDashboard should make a PUT request with payload", async () => {
   const dashboardId = "123";
   const updatedAt = new Date("2020-09-17T21:01:00.780Z");
   const releaseNotes = "Made changes to the revenue metrics";
+  const friendlyURL = "bananas";
 
-  await BackendService.publishDashboard(dashboardId, updatedAt, releaseNotes);
+  await BackendService.publishDashboard(
+    dashboardId,
+    updatedAt,
+    releaseNotes,
+    friendlyURL
+  );
 
   expect(API.put).toHaveBeenCalledWith(
     "BackendApi",
@@ -93,6 +99,7 @@ test("publishDashboard should make a PUT request with payload", async () => {
       body: {
         updatedAt,
         releaseNotes,
+        friendlyURL,
       },
     })
   );

--- a/frontend/src/services/__tests__/FriendlyURLGenerator.test.ts
+++ b/frontend/src/services/__tests__/FriendlyURLGenerator.test.ts
@@ -1,0 +1,46 @@
+import FriendlyURLGenerator from "../FriendlyURLGenerator";
+
+describe("generateFromDashboardName", () => {
+  test("generates a sanitized URL", () => {
+    const scenarios = [
+      {
+        dashboardName: "COVID-19",
+        expectedUrl: "covid-19",
+      },
+      {
+        dashboardName: "La Construcción",
+        expectedUrl: "la-construcción",
+      },
+      {
+        dashboardName: "Jen'O Brien",
+        expectedUrl: "jen-o-brien",
+      },
+      {
+        dashboardName: "Performance Dashboard @ AWS",
+        expectedUrl: "performance-dashboard-aws",
+      },
+      {
+        dashboardName: "This is - great",
+        expectedUrl: "this-is-great",
+      },
+      {
+        dashboardName: "A Construção",
+        expectedUrl: "a-construção",
+      },
+      {
+        dashboardName: "訳サービスで、テキストや",
+        expectedUrl: "訳サービスで、テキストや",
+      },
+      {
+        dashboardName: "!	#	$	&	'	(	)	*	+	,	/	:	;	=	?	@	[	] hi",
+        expectedUrl: "hi",
+      },
+    ];
+
+    scenarios.forEach((scenario) => {
+      expect(
+        FriendlyURLGenerator.generateFromDashboardName(scenario.dashboardName)
+      ).toEqual(scenario.expectedUrl);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Frontend changes to the publishing workflow to auto-suggest a friendly URL for the dashboard. But also give the user the chance to modify it. 

In the next PR I will address the following 2 things that I'm missing: 
1. Handle error when the URL is already taken. 
2. Show a preview of the URL so that the user gets an idea of how the URL will look like for end users: http://www.example.com/my-friendly-url

## Testing

Updated unit tests to consider the new Step in the workflow. You can test on my personal environment: 
https://fdingler.badger.wwps.aws.dev/admin/dashboard/4da29347-9396-4d45-b360-0e475dac6a32/publish

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
