### PR TITLE
Bumping up memory to 512MB for custom resource

### DIFF
--- a/cdk/lib/frontend-stack.ts
+++ b/cdk/lib/frontend-stack.ts
@@ -93,6 +93,7 @@ export class FrontendStack extends cdk.Stack {
       {
         sources: [s3Deploy.Source.asset("../frontend/build")],
         destinationBucket: this.frontendBucket,
+        memoryLimit: 512,
         prune: false,
         distribution,
       }


### PR DESCRIPTION
## Description

Lambda function that deploys the frontend needs more than 128 MB which is the default.

## Testing

Bumped up the memory manually and verified that the deploy succeeds now.  

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
