### PR TITLE
GTT-769 Showing preview of friendly URL with modal to edit

### DIFF
--- a/backend/src/lib/factories/__tests__/dashboard-factory.test.ts
+++ b/backend/src/lib/factories/__tests__/dashboard-factory.test.ts
@@ -208,10 +208,11 @@ describe("toVersion", () => {
   };
 
   it("should expose fields that are part of the version", () => {
-    const publicDashboard = factory.toVersion(dashboard);
-    expect(publicDashboard.id).toEqual(dashboard.id);
-    expect(publicDashboard.version).toEqual(dashboard.version);
-    expect(publicDashboard.state).toEqual(dashboard.state);
+    const dashboardVersion = factory.toVersion(dashboard);
+    expect(dashboardVersion.id).toEqual(dashboard.id);
+    expect(dashboardVersion.version).toEqual(dashboard.version);
+    expect(dashboardVersion.state).toEqual(dashboard.state);
+    expect(dashboardVersion.friendlyURL).toEqual(dashboard.friendlyURL);
   });
 });
 

--- a/backend/src/lib/factories/dashboard-factory.ts
+++ b/backend/src/lib/factories/dashboard-factory.ts
@@ -145,6 +145,7 @@ function toVersion(dashboard: Dashboard): DashboardVersion {
     id: dashboard.id,
     version: dashboard.version,
     state: dashboard.state,
+    friendlyURL: dashboard.friendlyURL,
   };
 }
 

--- a/backend/src/lib/models/dashboard.ts
+++ b/backend/src/lib/models/dashboard.ts
@@ -14,6 +14,7 @@ export interface DashboardVersion {
   id: string;
   version: number;
   state: DashboardState;
+  friendlyURL?: string;
 }
 
 export interface Dashboard {

--- a/frontend/src/components/FriendlyURLInput.tsx
+++ b/frontend/src/components/FriendlyURLInput.tsx
@@ -104,7 +104,7 @@ function FriendlyURLInput({ value, onChange, showWarning }: Props) {
         Edit or confirm the URL that will be used to publish this dashboard.
       </div>
       <p className="font-sans-lg margin-top-0">
-        {window.location.hostname}/{friendlyURL}
+        https://{window.location.hostname}/{friendlyURL}
         <Button
           type="button"
           variant="unstyled"

--- a/frontend/src/components/FriendlyURLInput.tsx
+++ b/frontend/src/components/FriendlyURLInput.tsx
@@ -1,0 +1,121 @@
+import React, { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import Button from "./Button";
+import Modal from "./Modal";
+
+interface Props {
+  value?: string;
+  onChange?: Function;
+  showWarning?: boolean;
+}
+
+interface FormValues {
+  friendlyURL: string;
+}
+
+function FriendlyURLInput({ value, onChange, showWarning }: Props) {
+  const [isEditing, setIsEditing] = useState(false);
+  const {
+    register,
+    reset,
+    errors,
+    watch,
+    getValues,
+    trigger,
+    setValue,
+  } = useForm<FormValues>({
+    defaultValues: {
+      friendlyURL: value,
+    },
+  });
+
+  useEffect(() => {
+    if (value) {
+      reset({
+        friendlyURL: value,
+      });
+    }
+  }, [value, reset]);
+
+  const onSubmit = async () => {
+    const isValid = await trigger();
+    if (isValid) {
+      if (onChange) {
+        const values = getValues();
+        onChange(values.friendlyURL);
+      }
+
+      setIsEditing(false);
+    }
+  };
+
+  const sanitizeUrl = (value: string) => {
+    let sanitized = value || "";
+    sanitized = sanitized.replace(/ /g, "-");
+    sanitized = sanitized.toLocaleLowerCase();
+    sanitized = sanitized.replace(/[!#$&'\(\)\*\+,\/:;=\?@\[\]]+/g, "");
+    setValue("friendlyURL", sanitized);
+  };
+
+  const friendlyURL = watch("friendlyURL");
+
+  return (
+    <>
+      <Modal
+        isOpen={isEditing}
+        title="Edit URL"
+        buttonType="Save"
+        buttonAction={onSubmit}
+        closeModal={() => setIsEditing(false)}
+        message={
+          <div className="usa-form-group">
+            <label htmlFor="friendlyURL" className="usa-label text-bold">
+              Dashboard URL
+            </label>
+            <div className="usa-hint">
+              {showWarning
+                ? "Are you sure you want to edit this dashboard's URL? " +
+                  "Users will not be able to access the dashboard with the old URL."
+                : "Edit the URL that will be used to publish this dashboard"}
+            </div>
+            {errors.friendlyURL && (
+              <span
+                className="usa-error-message"
+                id="input-error-message"
+                role="alert"
+              >
+                Please enter a valid URL
+              </span>
+            )}
+            <input
+              id="friendlyURL"
+              className="usa-input"
+              name="friendlyURL"
+              type="text"
+              onChange={(e: any) => sanitizeUrl(e.target.value)}
+              ref={register({
+                required: true,
+              })}
+            />
+          </div>
+        }
+      />
+      <div className="usa-hint">
+        Edit or confirm the URL that will be used to publish this dashboard.
+      </div>
+      <p className="font-sans-lg margin-top-0">
+        {window.location.hostname}/{friendlyURL}
+        <Button
+          type="button"
+          variant="unstyled"
+          className="margin-left-2"
+          onClick={() => setIsEditing(true)}
+        >
+          Edit URL
+        </Button>
+      </p>
+    </>
+  );
+}
+
+export default FriendlyURLInput;

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -9,14 +9,8 @@ interface PathParams {
   isOpen: boolean;
   closeModal: Function;
   title: string;
-  message: string;
-  buttonType:
-    | "Delete"
-    | "Prepare for publishing"
-    | "Archive"
-    | "Create draft"
-    | "Re-publish"
-    | "Resend";
+  message: string | React.ReactNode;
+  buttonType: string;
   buttonAction: Function;
   ariaHideApp?: boolean;
 }

--- a/frontend/src/components/__tests__/FriendlyURLInput.test.tsx
+++ b/frontend/src/components/__tests__/FriendlyURLInput.test.tsx
@@ -12,7 +12,7 @@ beforeEach(() => {
 
 test("renders the preview of the URL", async () => {
   const hostname = window.location.hostname;
-  expect(screen.getByText(`${hostname}/foo-bar`)).toBeInTheDocument();
+  expect(screen.getByText(`https://${hostname}/foo-bar`)).toBeInTheDocument();
 });
 
 test("edit link opens a modal to modify the URL", async () => {
@@ -30,5 +30,5 @@ test("edit link opens a modal to modify the URL", async () => {
 
   fireEvent.click(screen.getByRole("button", { name: "Save" }));
   const hostname = window.location.hostname;
-  await waitFor(() => screen.getByText(`${hostname}/fizzbuzz`));
+  await waitFor(() => screen.getByText(`https://${hostname}/fizzbuzz`));
 });

--- a/frontend/src/components/__tests__/FriendlyURLInput.test.tsx
+++ b/frontend/src/components/__tests__/FriendlyURLInput.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import FriendlyURLInput from "../FriendlyURLInput";
+
+const onChange = jest.fn();
+
+beforeEach(() => {
+  render(
+    <FriendlyURLInput value="foo-bar" onChange={onChange} showWarning={false} />
+  );
+});
+
+test("renders the preview of the URL", async () => {
+  const hostname = window.location.hostname;
+  expect(screen.getByText(`${hostname}/foo-bar`)).toBeInTheDocument();
+});
+
+test("edit link opens a modal to modify the URL", async () => {
+  const editLink = screen.getByRole("button", { name: "Edit URL" });
+  fireEvent.click(editLink);
+
+  const textInput = screen.getByLabelText("Dashboard URL");
+  await waitFor(() => expect(textInput).toBeInTheDocument());
+
+  fireEvent.input(textInput, {
+    target: {
+      value: "fizzbuzz",
+    },
+  });
+
+  fireEvent.click(screen.getByRole("button", { name: "Save" }));
+  const hostname = window.location.hostname;
+  await waitFor(() => screen.getByText(`${hostname}/fizzbuzz`));
+});

--- a/frontend/src/containers/PublishDashboard.tsx
+++ b/frontend/src/containers/PublishDashboard.tsx
@@ -235,10 +235,7 @@ function PublishDashboard() {
           showStepText={true}
         />
       </div>
-      <form
-        onSubmit={handleSubmit(onSubmit)}
-        className="usa-form usa-form--large"
-      >
+      <form onSubmit={handleSubmit(onSubmit)}>
         <div className="margin-y-2">
           <div hidden={step !== 0}>
             <TextField
@@ -271,7 +268,7 @@ function PublishDashboard() {
               value={desiredUrl || suggestedUrl.friendlyURL}
               showWarning={hasPublishedVersion()}
             />
-
+            <br />
             <div className="margin-top-3">
               <Button
                 variant="outline"
@@ -291,50 +288,44 @@ function PublishDashboard() {
           </div>
 
           <div hidden={step !== 2} className="padding-y-1">
-            <table
-              className="usa-table border-hidden"
-              style={{ width: "100%" }}
-            >
-              <tbody>
-                <tr>
-                  <td className="border-hidden text-top">
-                    <div className="usa-checkbox">
-                      <input
-                        type="checkbox"
-                        id="acknowledge"
-                        name="acknowledge"
-                        className="usa-checkbox__input"
-                        ref={register}
-                      />
-                      <label
-                        className="usa-checkbox__label margin-top-1"
-                        htmlFor="acknowledge"
-                        data-testid="AcknowledgementCheckboxLabel"
-                      />
-                    </div>
-                  </td>
-                  <td className="publishing-guidance border-hidden">
-                    <span className=" font-sans-sm">
-                      <MarkdownRender
-                        source={`${settings.publishingGuidance}${
-                          settings.publishingGuidance[
-                            settings.publishingGuidance.length - 1
-                          ] === "."
-                            ? ""
-                            : "."
-                        }`}
-                      />
-                    </span>
-                    {hasPublishedVersion() && (
-                      <p>
-                        I also understand that this will overwrite the existing
-                        published version of the dashboard.
-                      </p>
-                    )}
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+            <div className="display-flex padding-bottom-3">
+              <div>
+                <div className="usa-checkbox">
+                  <input
+                    type="checkbox"
+                    id="acknowledge"
+                    name="acknowledge"
+                    className="usa-checkbox__input"
+                    ref={register}
+                  />
+                  <label
+                    className="usa-checkbox__label margin-top-1"
+                    htmlFor="acknowledge"
+                    data-testid="AcknowledgementCheckboxLabel"
+                  />
+                </div>
+              </div>
+              <div>
+                <span className="font-sans-sm">
+                  <MarkdownRender
+                    className="margin-left-2 measure-2 publishing-guidance"
+                    source={`${settings.publishingGuidance}${
+                      settings.publishingGuidance[
+                        settings.publishingGuidance.length - 1
+                      ] === "."
+                        ? ""
+                        : "."
+                    }`}
+                  />
+                </span>
+                {hasPublishedVersion() && (
+                  <p>
+                    I also understand that this will overwrite the existing
+                    published version of the dashboard.
+                  </p>
+                )}
+              </div>
+            </div>
             <div className="margin-top-3">
               <Button
                 variant="outline"

--- a/frontend/src/containers/PublishDashboard.tsx
+++ b/frontend/src/containers/PublishDashboard.tsx
@@ -8,6 +8,8 @@ import {
   useFriendlyUrl,
 } from "../hooks";
 import { DashboardState, LocationState } from "../models";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCopy } from "@fortawesome/free-solid-svg-icons";
 import BackendService from "../services/BackendService";
 import Alert from "../components/Alert";
 import AlertContainer from "../containers/AlertContainer";
@@ -17,9 +19,8 @@ import Button from "../components/Button";
 import Breadcrumbs from "../components/Breadcrumbs";
 import dayjs from "dayjs";
 import Spinner from "../components/Spinner";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCopy } from "@fortawesome/free-solid-svg-icons";
 import MarkdownRender from "../components/MarkdownRender";
+import FriendlyURLInput from "../components/FriendlyURLInput";
 import "./PublishDashboard.css";
 
 interface PathParams {
@@ -29,20 +30,21 @@ interface PathParams {
 interface FormValues {
   releaseNotes: string;
   acknowledge: boolean;
-  friendlyURL: string;
 }
 
 function PublishDashboard() {
   const { dashboardId } = useParams<PathParams>();
   const history = useHistory<LocationState>();
-  const [step, setStep] = useState<number>(0);
+  const [step, setStep] = useState(0);
   const { settings } = useSettings();
   const { dashboard, reloadDashboard, setDashboard } = useDashboard(
     dashboardId
   );
 
-  const { friendlyURL } = useFriendlyUrl(dashboard);
   const { versions } = useDashboardVersions(dashboard?.parentDashboardId);
+  const [desiredUrl, setDesiredUrl] = useState("");
+  const suggestedUrl = useFriendlyUrl(dashboard, versions);
+
   const {
     register,
     errors,
@@ -54,10 +56,13 @@ function PublishDashboard() {
 
   const releaseNotes = watch("releaseNotes");
   const acknowledge = watch("acknowledge");
-  const published = versions.find((v) => v.state === DashboardState.Published);
 
   const onPreview = () => {
     history.push(`/admin/dashboard/${dashboardId}`);
+  };
+
+  const hasPublishedVersion = (): boolean => {
+    return !!versions.find((v) => v.state === DashboardState.Published);
   };
 
   const onContinue = async () => {
@@ -120,7 +125,7 @@ function PublishDashboard() {
           dashboardId,
           dashboard.updatedAt,
           values.releaseNotes,
-          values.friendlyURL || undefined
+          desiredUrl || suggestedUrl.friendlyURL
         );
 
         history.push(`/admin/dashboards?tab=published`, {
@@ -144,7 +149,7 @@ function PublishDashboard() {
     }
   };
 
-  if (!dashboard) {
+  if (!dashboard || !suggestedUrl) {
     return <Spinner className="text-center margin-top-9" label="Loading" />;
   }
 
@@ -261,14 +266,10 @@ function PublishDashboard() {
           </div>
 
           <div hidden={step !== 1}>
-            <TextField
-              id="friendlyURL"
-              name="friendlyURL"
-              label="Dashboard URL"
-              error={errors.friendlyURL && "Please enter a valid URL"}
-              hint="Edit or confirm the URL that will be used to publish this dashboard."
-              register={register}
-              defaultValue={friendlyURL}
+            <FriendlyURLInput
+              onChange={(url: string) => setDesiredUrl(url)}
+              value={desiredUrl || suggestedUrl.friendlyURL}
+              showWarning={hasPublishedVersion()}
             />
 
             <div className="margin-top-3">
@@ -324,14 +325,11 @@ function PublishDashboard() {
                         }`}
                       />
                     </span>
-                    {published &&
-                    published.state === DashboardState.Published ? (
+                    {hasPublishedVersion() && (
                       <p>
                         I also understand that this will overwrite the existing
                         published version of the dashboard.
                       </p>
-                    ) : (
-                      ""
                     )}
                   </td>
                 </tr>

--- a/frontend/src/hooks/dashboard-hooks.ts
+++ b/frontend/src/hooks/dashboard-hooks.ts
@@ -244,14 +244,26 @@ type UseFriendlyUrlHook = {
   friendlyURL: string;
 };
 
-export function useFriendlyUrl(dashboard?: Dashboard): UseFriendlyUrlHook {
+export function useFriendlyUrl(
+  dashboard?: Dashboard,
+  versions?: DashboardVersion[]
+): UseFriendlyUrlHook {
   const [friendlyURL, setFriendlyURL] = useState("");
   useEffect(() => {
     if (dashboard) {
-      const url = dashboard.friendlyURL
-        ? dashboard.friendlyURL
-        : FriendlyURLGenerator.generateFromDashboardName(dashboard.name);
-      setFriendlyURL(url);
+      const published = versions?.find(
+        (version) => version.state === DashboardState.Published
+      );
+
+      if (dashboard.friendlyURL) {
+        setFriendlyURL(dashboard.friendlyURL);
+      } else if (published && published.friendlyURL) {
+        setFriendlyURL(published.friendlyURL);
+      } else {
+        setFriendlyURL(
+          FriendlyURLGenerator.generateFromDashboardName(dashboard.name)
+        );
+      }
     }
   }, [dashboard]);
 

--- a/frontend/src/models/index.tsx
+++ b/frontend/src/models/index.tsx
@@ -63,6 +63,7 @@ export type DashboardVersion = {
   id: string;
   version: number;
   state: DashboardState;
+  friendlyURL?: string;
 };
 
 export type DashboardAuditLog = {


### PR DESCRIPTION
## Description

New component <FriendlyURLInput> that allows the user to preview the URL and edit it with a modal. This component also sanitizes the URL so that no special characters are added and spaces are replaced for the dash symbol '-'.  This PR also includes checking if there is already a published version with a friendlyURL and suggests the user to use that same URL instead of generating a new one. 

## Testing

You can test in my personal environment by going to Step 2 in the publishing workflow: 
https://fdingler.badger.wwps.aws.dev/admin/dashboard/8c9b6380-7fbe-420c-8081-dcd94fe53b64/publish

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
