### PR TITLE
fix: Frontend deployment with custom resource was failing

### DIFF
--- a/cdk/lib/frontend-stack.ts
+++ b/cdk/lib/frontend-stack.ts
@@ -89,7 +89,7 @@ export class FrontendStack extends cdk.Stack {
      */
     const frontendDeploy = new s3Deploy.BucketDeployment(
       this,
-      "DeployWithInvalidation",
+      "DeployFrontend",
       {
         sources: [s3Deploy.Source.asset("../frontend/build")],
         destinationBucket: this.frontendBucket,


### PR DESCRIPTION
## Description

Renamed the custom resource to force re-creation with a higher memory size of 512MB. 

## Testing

Deployed to my personal environment and verified it does not fail. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
