### PR TITLE
GTT-570: Remove unneeded permission from Authenticated Cognito Identity Pool role

### DIFF
--- a/cdk/lib/auth-stack.ts
+++ b/cdk/lib/auth-stack.ts
@@ -217,14 +217,6 @@ export class AuthStack extends cdk.Stack {
       })
     );
 
-    authRole.addToPolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ["cognito-sync:*", "cognito-identity:*"],
-        resources: ["*"],
-      })
-    );
-
     return authRole;
   }
 


### PR DESCRIPTION
## Description

While running cfn-nag, an issue was reported that the permission below is too permissive.  After reviewing, we determined that the permission isn't needed

new iam.PolicyStatement({
        effect: iam.Effect.ALLOW,
        actions: ["cognito-sync:*", "cognito-identity:*"],
        resources: ["*"],
      })

## Testing

Deployed into a new environment, ran integration tests, and performed UI testing (manager users, create and publish dashboards) to do regression testing

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
