### PR TITLE
GTT-1101 Added columns metadata for Chart and Table content items in Backend

### DIFF
--- a/backend/src/lib/factories/__tests__/widget-factory.test.ts
+++ b/backend/src/lib/factories/__tests__/widget-factory.test.ts
@@ -77,6 +77,8 @@ describe("createChartWidget", () => {
         json: "abc.json",
       },
       fileName: "abc.csv",
+      sortByColumn: "cases",
+      sortByDesc: false,
       columnsMetadata: [
         {
           hidden: false,
@@ -111,6 +113,8 @@ describe("createChartWidget", () => {
     expect(widget.content.chartType).toEqual("LineChart");
     expect(widget.content.summaryBelow).toBe(false);
     expect(widget.content.columnsMetadata).toHaveLength(2);
+    expect(widget.content.sortByColumn).toEqual("cases");
+    expect(widget.content.sortByDesc).toBe(false);
   });
 
   it("throws an error if chart title is undefined", () => {
@@ -230,6 +234,8 @@ describe("createTableWidget", () => {
         json: "abc.json",
       },
       fileName: "abc.csv",
+      sortByColumn: "cases",
+      sortByDesc: false,
       columnsMetadata: [
         {
           hidden: false,
@@ -262,6 +268,8 @@ describe("createTableWidget", () => {
     );
     expect(widget.content.summaryBelow).toBe(false);
     expect(widget.content.columnsMetadata).toHaveLength(2);
+    expect(widget.content.sortByColumn).toEqual("cases");
+    expect(widget.content.sortByDesc).toBe(false);
   });
 
   it("throws an error if table title is undefined", () => {
@@ -335,6 +343,8 @@ describe("fromItem", () => {
         summary: "test summary",
         summaryBelow: false,
         datasetId: "090b0410",
+        sortByColumn: "foo",
+        sortByDesc: false,
         columnsMetadata: [
           {
             columnName: "foo",
@@ -361,6 +371,8 @@ describe("fromItem", () => {
     expect(widget.content.summary).toEqual("test summary");
     expect(widget.content.summaryBelow).toBe(false);
     expect(widget.content.chartType).toEqual("LineChart");
+    expect(widget.content.sortByColumn).toEqual("foo");
+    expect(widget.content.sortByDesc).toBe(false);
     expect(widget.content.columnsMetadata).toEqual([
       {
         columnName: "foo",
@@ -385,6 +397,15 @@ describe("fromItem", () => {
         datasetId: "090b0410",
         summary: "test summary",
         summaryBelow: false,
+        sortByColumn: "foo",
+        sortByDesc: false,
+        columnsMetadata: [
+          {
+            columnName: "foo",
+            dataType: "Text",
+            hidden: false,
+          },
+        ],
       },
     };
 
@@ -403,6 +424,15 @@ describe("fromItem", () => {
     );
     expect(widget.content.summary).toEqual("test summary");
     expect(widget.content.summaryBelow).toBe(false);
+    expect(widget.content.sortByColumn).toEqual("foo");
+    expect(widget.content.sortByDesc).toBe(false);
+    expect(widget.content.columnsMetadata).toEqual([
+      {
+        columnName: "foo",
+        dataType: ColumnDataType.Text,
+        hidden: false,
+      },
+    ]);
   });
 
   it("handles an invalid widget type gracefully", () => {
@@ -483,6 +513,8 @@ describe("toItem", () => {
           json: "abc.json",
         },
         fileName: "abc.csv",
+        sortByColumn: "cases",
+        sortByDesc: true,
         columnsMetadata: [
           {
             hidden: false,
@@ -519,6 +551,8 @@ describe("toItem", () => {
         json: "abc.json",
       },
       fileName: "abc.csv",
+      sortByColumn: "cases",
+      sortByDesc: true,
       columnsMetadata: [
         {
           hidden: false,
@@ -554,6 +588,8 @@ describe("toItem", () => {
           json: "abc.json",
         },
         fileName: "abc.csv",
+        sortByColumn: "deaths",
+        sortByDesc: true,
         columnsMetadata: [
           {
             hidden: false,
@@ -589,6 +625,8 @@ describe("toItem", () => {
         json: "abc.json",
       },
       fileName: "abc.csv",
+      sortByColumn: "deaths",
+      sortByDesc: true,
       columnsMetadata: [
         {
           hidden: false,

--- a/backend/src/lib/factories/__tests__/widget-factory.test.ts
+++ b/backend/src/lib/factories/__tests__/widget-factory.test.ts
@@ -9,6 +9,7 @@ import {
   ChartType,
   MetricsWidget,
   ImageWidget,
+  ColumnDataType,
 } from "../../models/widget";
 
 const dummyWidgetName = "Some widget";
@@ -76,6 +77,18 @@ describe("createChartWidget", () => {
         json: "abc.json",
       },
       fileName: "abc.csv",
+      columnsMetadata: [
+        {
+          hidden: false,
+          columnName: "cases",
+          dataType: "Number",
+        },
+        {
+          hidden: false,
+          columnName: "deaths",
+          dataType: "Number",
+        },
+      ],
     };
 
     const widget = WidgetFactory.createWidget({
@@ -97,6 +110,7 @@ describe("createChartWidget", () => {
     expect(widget.content.summary).toEqual("test summary");
     expect(widget.content.chartType).toEqual("LineChart");
     expect(widget.content.summaryBelow).toBe(false);
+    expect(widget.content.columnsMetadata).toHaveLength(2);
   });
 
   it("throws an error if chart title is undefined", () => {
@@ -216,6 +230,18 @@ describe("createTableWidget", () => {
         json: "abc.json",
       },
       fileName: "abc.csv",
+      columnsMetadata: [
+        {
+          hidden: false,
+          columnName: "cases",
+          dataType: "Number",
+        },
+        {
+          hidden: false,
+          columnName: "deaths",
+          dataType: "Number",
+        },
+      ],
     };
 
     const widget = WidgetFactory.createWidget({
@@ -235,6 +261,7 @@ describe("createTableWidget", () => {
       "Correlation of COVID cases to deaths"
     );
     expect(widget.content.summaryBelow).toBe(false);
+    expect(widget.content.columnsMetadata).toHaveLength(2);
   });
 
   it("throws an error if table title is undefined", () => {
@@ -308,6 +335,13 @@ describe("fromItem", () => {
         summary: "test summary",
         summaryBelow: false,
         datasetId: "090b0410",
+        columnsMetadata: [
+          {
+            columnName: "foo",
+            dataType: "Text",
+            hidden: false,
+          },
+        ],
       },
     };
 
@@ -327,6 +361,13 @@ describe("fromItem", () => {
     expect(widget.content.summary).toEqual("test summary");
     expect(widget.content.summaryBelow).toBe(false);
     expect(widget.content.chartType).toEqual("LineChart");
+    expect(widget.content.columnsMetadata).toEqual([
+      {
+        columnName: "foo",
+        dataType: ColumnDataType.Text,
+        hidden: false,
+      },
+    ]);
   });
 
   it("converts a dynamodb item into a TableWidget object", () => {
@@ -442,6 +483,18 @@ describe("toItem", () => {
           json: "abc.json",
         },
         fileName: "abc.csv",
+        columnsMetadata: [
+          {
+            hidden: false,
+            columnName: "cases",
+            dataType: ColumnDataType.Number,
+          },
+          {
+            hidden: false,
+            columnName: "deaths",
+            dataType: ColumnDataType.Number,
+          },
+        ],
       },
     };
 
@@ -466,6 +519,18 @@ describe("toItem", () => {
         json: "abc.json",
       },
       fileName: "abc.csv",
+      columnsMetadata: [
+        {
+          hidden: false,
+          columnName: "cases",
+          dataType: "Number",
+        },
+        {
+          hidden: false,
+          columnName: "deaths",
+          dataType: "Number",
+        },
+      ],
     });
   });
 
@@ -489,6 +554,18 @@ describe("toItem", () => {
           json: "abc.json",
         },
         fileName: "abc.csv",
+        columnsMetadata: [
+          {
+            hidden: false,
+            columnName: "cases",
+            dataType: ColumnDataType.Number,
+          },
+          {
+            hidden: false,
+            columnName: "deaths",
+            dataType: ColumnDataType.Number,
+          },
+        ],
       },
     };
 
@@ -512,6 +589,18 @@ describe("toItem", () => {
         json: "abc.json",
       },
       fileName: "abc.csv",
+      columnsMetadata: [
+        {
+          hidden: false,
+          columnName: "cases",
+          dataType: "Number",
+        },
+        {
+          hidden: false,
+          columnName: "deaths",
+          dataType: "Number",
+        },
+      ],
     });
   });
 });

--- a/backend/src/lib/factories/widget-factory.ts
+++ b/backend/src/lib/factories/widget-factory.ts
@@ -164,6 +164,7 @@ function createChartWidget(widget: Widget): ChartWidget {
       s3Key: widget.content.s3Key,
       fileName: widget.content.fileName,
       datasetType: widget.content.datasetType,
+      columnsMetadata: widget.content.columnsMetadata || [],
     },
   };
 }
@@ -195,6 +196,7 @@ function createTableWidget(widget: Widget): TableWidget {
       s3Key: widget.content.s3Key,
       fileName: widget.content.fileName,
       datasetType: widget.content.datasetType,
+      columnsMetadata: widget.content.columnsMetadata || [],
     },
   };
 }

--- a/backend/src/lib/factories/widget-factory.ts
+++ b/backend/src/lib/factories/widget-factory.ts
@@ -165,6 +165,8 @@ function createChartWidget(widget: Widget): ChartWidget {
       fileName: widget.content.fileName,
       datasetType: widget.content.datasetType,
       columnsMetadata: widget.content.columnsMetadata || [],
+      sortByColumn: widget.content.sortByColumn,
+      sortByDesc: widget.content.sortByDesc,
     },
   };
 }
@@ -197,6 +199,8 @@ function createTableWidget(widget: Widget): TableWidget {
       fileName: widget.content.fileName,
       datasetType: widget.content.datasetType,
       columnsMetadata: widget.content.columnsMetadata || [],
+      sortByColumn: widget.content.sortByColumn,
+      sortByDesc: widget.content.sortByDesc,
     },
   };
 }

--- a/backend/src/lib/models/widget.ts
+++ b/backend/src/lib/models/widget.ts
@@ -67,6 +67,8 @@ export interface ChartWidget extends Widget {
     };
     fileName: string;
     columnsMetadata: ColumnMetadata[];
+    sortByColumn?: string;
+    sortByDesc?: boolean;
   };
 }
 
@@ -83,6 +85,8 @@ export interface TableWidget extends Widget {
     };
     fileName: string;
     columnsMetadata: ColumnMetadata[];
+    sortByColumn?: string;
+    sortByDesc?: boolean;
   };
 }
 

--- a/backend/src/lib/models/widget.ts
+++ b/backend/src/lib/models/widget.ts
@@ -13,6 +13,17 @@ export enum ChartType {
   PartWholeChart = "PartWholeChart",
 }
 
+export enum ColumnDataType {
+  Number = "Number",
+  Text = "Text",
+}
+
+export interface ColumnMetadata {
+  columnName: string;
+  dataType: ColumnDataType;
+  hidden: boolean;
+}
+
 export interface Widget {
   id: string;
   name: string;
@@ -55,6 +66,7 @@ export interface ChartWidget extends Widget {
       json: string;
     };
     fileName: string;
+    columnsMetadata: ColumnMetadata[];
   };
 }
 
@@ -70,6 +82,7 @@ export interface TableWidget extends Widget {
       json: string;
     };
     fileName: string;
+    columnsMetadata: ColumnMetadata[];
   };
 }
 


### PR DESCRIPTION
## Description

Added new properties `columnsMetadata`, `sortByColumn` and `sortByDesc` to Chart and Table widgets. The columnsMetadata property describes optional metadata like data format for the columns. 

When creating or updating a Chart or Table widget, you can send this payload to the endpoint now: 

```json
{
    "name": "Covid Cases vs Deaths",
    "widgetType": "Chart",
    "content": {
        "title": "Covid Cases vs Deaths",
        "chartType": "LineChart",
        "datasetId": "7f24b2ad-fc7d-443a-8b23-b62c6212aee2",
        "s3Key": {
            "raw": "123.csv",
            "json": "123.json"
        },
        "sortByColumn": "Covid Cases",
        "sortByDesc": false,
        "columnsMetadata": [
            {
                "columnName": "Covid Cases",
                "dataType": "Number",
                "hidden": false
            },
            {
                "columnName": "Covid Deaths",
                "dataType": "Number",
                "hidden": false
            }
        ]
    }
}
```

## Testing

Used postman to create and update widgets to add columnsMetadata. Verified it gets saved in DynamoDB and it is retrieved when fetching the dashboard. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
