### PR TITLE
fix: User list wasn't refreshed after deleting users

### DIFF
--- a/frontend/src/containers/UserListing.tsx
+++ b/frontend/src/containers/UserListing.tsx
@@ -43,7 +43,14 @@ function UserListing() {
             message: `Successfully removed ${selected.length} users`,
           },
         });
+
+        // Reload users but also update the UI optimistically because
+        // the backend sometimes returns the same list of users including
+        // the deleted one due to eventual consistency.
+        await reloadUsers();
+        setUsers(users.filter((user) => !usernames.includes(user.userId)));
       } catch (err) {
+        await reloadUsers();
         history.replace("/admin/users", {
           alert: {
             type: "error",
@@ -51,12 +58,6 @@ function UserListing() {
           },
         });
       } finally {
-        // Reload users but also update the UI optimistically because
-        // the backend sometimes returns the same list of users including
-        // the deleted one due to eventual consistency.
-        await reloadUsers();
-        setUsers(users.filter((user) => !usernames.includes(user.userId)));
-
         setIsOpenRemoveUsersModal(false);
       }
     }

--- a/frontend/src/containers/UserListing.tsx
+++ b/frontend/src/containers/UserListing.tsx
@@ -16,7 +16,7 @@ const MenuItem = DropdownMenu.MenuItem;
 
 function UserListing() {
   const history = useHistory<LocationState>();
-  const { users, reloadUsers } = useUsers();
+  const { users, reloadUsers, setUsers } = useUsers();
   const [filter, setFilter] = useState("");
   const [selected, setSelected] = useState<Array<User>>([]);
   const [isOpenResendInviteModal, setIsOpenResendInviteModal] = useState(false);
@@ -34,8 +34,8 @@ function UserListing() {
 
   const removeUsers = async () => {
     if (selected.length) {
+      const usernames = selected.map((user) => user.userId);
       try {
-        const usernames = selected.map((user) => user.userId);
         await BackendService.removeUsers(usernames);
         history.replace("/admin/users", {
           alert: {
@@ -51,7 +51,12 @@ function UserListing() {
           },
         });
       } finally {
+        // Reload users but also update the UI optimistically because
+        // the backend sometimes returns the same list of users including
+        // the deleted one due to eventual consistency.
         await reloadUsers();
+        setUsers(users.filter((user) => !usernames.includes(user.userId)));
+
         setIsOpenRemoveUsersModal(false);
       }
     }

--- a/frontend/src/hooks/user-hooks.ts
+++ b/frontend/src/hooks/user-hooks.ts
@@ -52,6 +52,7 @@ type UsersHook = {
   users: User[];
   loading: boolean;
   reloadUsers: Function;
+  setUsers: Function;
 };
 
 export function useUsers(): UsersHook {
@@ -73,5 +74,6 @@ export function useUsers(): UsersHook {
     loading,
     users,
     reloadUsers: fetchData,
+    setUsers,
   };
 }


### PR DESCRIPTION
## Description

After deleting a user, the success alert will show up but the UI will still show the deleted user. I was able to reproduce this issue by calling the backend directly to delete a user and immediately request the list of users again. I confirmed that the deleted user is still part of the users list. Which leads me to believe that Cognito is eventually consistent, the users are actually deleted but reading them immediately after deleting doesn't show accurate data. 

My solution was to optimistically update the UI to remove the deleted users only if we succeed to delete them from Cognito. If we fail to delete them, then we simply reload the list as we did before. 

## Testing

Tested locally to make sure the users list is updated correctly after deletion. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
