### PR TITLE
GTT-1120 Added full screen preview

### DIFF
--- a/frontend/src/components/Visualize.tsx
+++ b/frontend/src/components/Visualize.tsx
@@ -25,6 +25,8 @@ interface Props {
   advanceStep: Function;
   fileLoading: boolean;
   creatingWidget: boolean;
+  fullPreviewButton: JSX.Element;
+  fullPreview: boolean;
 }
 
 function Visualize(props: Props) {
@@ -62,7 +64,7 @@ function Visualize(props: Props) {
   return (
     <>
       <div className="grid-row width-desktop">
-        <div className="grid-col-5">
+        <div className="grid-col-5" hidden={props.fullPreview}>
           <TextField
             id="title"
             name="title"
@@ -151,10 +153,37 @@ function Visualize(props: Props) {
               Show summary below chart
             </label>
           </div>
+          <br />
+          <br />
+          <hr />
+          <Button variant="outline" type="button" onClick={props.backStep}>
+            Back
+          </Button>
+          <Button
+            onClick={props.advanceStep}
+            type="submit"
+            disabled={
+              !props.json.length ||
+              !title ||
+              props.fileLoading ||
+              props.creatingWidget
+            }
+          >
+            Add Chart
+          </Button>
+          <Button
+            variant="unstyled"
+            className="text-base-dark hover:text-base-darker active:text-base-darkest"
+            type="button"
+            onClick={props.onCancel}
+          >
+            Cancel
+          </Button>
         </div>
 
-        <div className="grid-col-7">
+        <div className={props.fullPreview ? "grid-col-12" : "grid-col-7"}>
           <div hidden={!props.json.length} className="margin-left-4">
+            {props.fullPreviewButton}
             <h4>Preview</h4>
             {props.datasetLoading ? (
               <Spinner className="text-center margin-top-6" label="Loading" />
@@ -258,32 +287,6 @@ function Visualize(props: Props) {
           </div>
         </div>
       </div>
-      <br />
-      <br />
-      <hr />
-      <Button variant="outline" type="button" onClick={props.backStep}>
-        Back
-      </Button>
-      <Button
-        onClick={props.advanceStep}
-        type="submit"
-        disabled={
-          !props.json.length ||
-          !title ||
-          props.fileLoading ||
-          props.creatingWidget
-        }
-      >
-        Add Chart
-      </Button>
-      <Button
-        variant="unstyled"
-        className="text-base-dark hover:text-base-darker active:text-base-darkest"
-        type="button"
-        onClick={props.onCancel}
-      >
-        Cancel
-      </Button>
     </>
   );
 }

--- a/frontend/src/components/__tests__/__snapshots__/Visualize.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/Visualize.test.tsx.snap
@@ -207,6 +207,28 @@ exports[`renders the Check Data component 1`] = `
           Show summary below chart
         </label>
       </div>
+      <br />
+      <br />
+      <hr />
+      <button
+        class="usa-button usa-button--outline"
+        type="button"
+      >
+        Back
+      </button>
+      <button
+        class="usa-button usa-button--base"
+        disabled=""
+        type="submit"
+      >
+        Add Chart
+      </button>
+      <button
+        class="usa-button usa-button--unstyled text-base-dark hover:text-base-darker active:text-base-darkest"
+        type="button"
+      >
+        Cancel
+      </button>
     </div>
     <div
       class="grid-col-7"
@@ -236,27 +258,5 @@ exports[`renders the Check Data component 1`] = `
       </div>
     </div>
   </div>
-  <br />
-  <br />
-  <hr />
-  <button
-    class="usa-button usa-button--outline"
-    type="button"
-  >
-    Back
-  </button>
-  <button
-    class="usa-button usa-button--base"
-    disabled=""
-    type="submit"
-  >
-    Add Chart
-  </button>
-  <button
-    class="usa-button usa-button--unstyled text-base-dark hover:text-base-darker active:text-base-darkest"
-    type="button"
-  >
-    Cancel
-  </button>
 </div>
 `;

--- a/frontend/src/containers/AddChart.tsx
+++ b/frontend/src/containers/AddChart.tsx
@@ -72,7 +72,6 @@ function AddChart() {
     undefined
   );
   const [sortByDesc, setSortByDesc] = useState<boolean | undefined>(undefined);
-  const { settings } = useSettings();
   const {
     fullPreviewToggle,
     fullPreviewButton,
@@ -382,6 +381,8 @@ function AddChart() {
               advanceStep={advanceStep}
               fileLoading={fileLoading}
               creatingWidget={creatingWidget}
+              fullPreviewButton={fullPreviewButton}
+              fullPreview={fullPreview}
             />
           </div>
         </form>

--- a/frontend/src/containers/AddChart.tsx
+++ b/frontend/src/containers/AddChart.tsx
@@ -9,6 +9,7 @@ import {
   useDateTimeFormatter,
   useSettings,
   useDatasets,
+  useFullPreview,
 } from "../hooks";
 import StorageService from "../services/StorageService";
 import BackendService from "../services/BackendService";
@@ -98,6 +99,11 @@ function AddChart() {
   const [sortByDesc, setSortByDesc] = useState<boolean | undefined>(undefined);
 
   const { settings } = useSettings();
+  const {
+    fullPreviewToggle,
+    fullPreviewButton,
+    fullPreview,
+  } = useFullPreview();
 
   useMemo(() => {
     let headers = currentJson.length
@@ -347,12 +353,12 @@ function AddChart() {
   return (
     <>
       <Breadcrumbs crumbs={crumbs} />
-      <h1>Add chart</h1>
+      <h1 hidden={fullPreview}>Add chart</h1>
 
       <div className="grid-row width-desktop">
         <form onSubmit={handleSubmit(onSubmit)}>
           <div className="grid-col-12">
-            <div className="grid-col-6">
+            <div className="grid-col-6" hidden={fullPreview}>
               <StepIndicator
                 current={step}
                 segments={[
@@ -613,7 +619,7 @@ function AddChart() {
 
           <div hidden={step !== 2}>
             <div className="grid-row width-desktop">
-              <div className="grid-col-5">
+              <div className="grid-col-5" hidden={fullPreview}>
                 <TextField
                   id="title"
                   name="title"
@@ -709,10 +715,37 @@ function AddChart() {
                     Show summary below chart
                   </label>
                 </div>
+                <br />
+                <br />
+                <hr />
+                <Button variant="outline" type="button" onClick={backStep}>
+                  Back
+                </Button>
+                <Button
+                  onClick={advanceStep}
+                  type="submit"
+                  disabled={
+                    !filteredJson.length ||
+                    !title ||
+                    fileLoading ||
+                    creatingWidget
+                  }
+                >
+                  Add Chart
+                </Button>
+                <Button
+                  variant="unstyled"
+                  className="text-base-dark hover:text-base-darker active:text-base-darkest"
+                  type="button"
+                  onClick={onCancel}
+                >
+                  Cancel
+                </Button>
               </div>
 
-              <div className="grid-col-7">
+              <div className={fullPreview ? "grid-col-12" : "grid-col-7"}>
                 <div hidden={!filteredJson.length} className="margin-left-4">
+                  {fullPreviewButton}
                   <h4>Preview</h4>
                   {datasetLoading ? (
                     <Spinner
@@ -822,29 +855,6 @@ function AddChart() {
                 </div>
               </div>
             </div>
-            <br />
-            <br />
-            <hr />
-            <Button variant="outline" type="button" onClick={backStep}>
-              Back
-            </Button>
-            <Button
-              onClick={advanceStep}
-              type="submit"
-              disabled={
-                !filteredJson.length || !title || fileLoading || creatingWidget
-              }
-            >
-              Add Chart
-            </Button>
-            <Button
-              variant="unstyled"
-              className="text-base-dark hover:text-base-darker active:text-base-darkest"
-              type="button"
-              onClick={onCancel}
-            >
-              Cancel
-            </Button>
           </div>
         </form>
       </div>

--- a/frontend/src/containers/AddImage.tsx
+++ b/frontend/src/containers/AddImage.tsx
@@ -3,7 +3,7 @@ import { useForm } from "react-hook-form";
 import { useHistory, useParams } from "react-router-dom";
 import { WidgetType } from "../models";
 import BackendService from "../services/BackendService";
-import { useDashboard } from "../hooks";
+import { useDashboard, useFullPreview } from "../hooks";
 import StorageService from "../services/StorageService";
 import Breadcrumbs from "../components/Breadcrumbs";
 import TextField from "../components/TextField";
@@ -37,6 +37,12 @@ function AddImage() {
   const [imageUploading, setImageUploading] = useState(false);
 
   const supportedImageFileTypes = Object.values(StorageService.imageFileTypes);
+
+  const {
+    fullPreview,
+    fullPreviewToggle,
+    fullPreviewButton,
+  } = useFullPreview();
 
   const onSubmit = async (values: FormValues) => {
     try {
@@ -133,15 +139,16 @@ function AddImage() {
   return (
     <>
       <Breadcrumbs crumbs={crumbs} />
-      <h1>Add Image</h1>
+      <div hidden={fullPreview}>
+        <h1>Add Image</h1>
 
-      <div className="text-base text-italic">Step 2 of 2</div>
-      <div className="margin-y-1 text-semibold display-inline-block font-sans-lg">
-        Configure image
+        <div className="text-base text-italic">Step 2 of 2</div>
+        <div className="margin-y-1 text-semibold display-inline-block font-sans-lg">
+          Configure image
+        </div>
       </div>
-
       <div className="grid-row width-desktop">
-        <div className="grid-col-6">
+        <div className="grid-col-6" hidden={fullPreview}>
           <form
             className="usa-form usa-form--large"
             onSubmit={handleSubmit(onSubmit)}
@@ -274,7 +281,8 @@ function AddImage() {
             </Button>
           </form>
         </div>
-        <div className="grid-col-6">
+        <div className={fullPreview ? "gril-col-12" : "grid-col-6"}>
+          {fullPreviewButton}
           <h4 className="margin-top-4">Preview</h4>
           <ImageWidget
             title={showTitle ? title : ""}

--- a/frontend/src/containers/AddMetrics.tsx
+++ b/frontend/src/containers/AddMetrics.tsx
@@ -14,6 +14,7 @@ import {
   useDateTimeFormatter,
   useSettings,
   useDatasets,
+  useFullPreview,
 } from "../hooks";
 import BackendService from "../services/BackendService";
 import Breadcrumbs from "../components/Breadcrumbs";
@@ -77,6 +78,11 @@ function AddMetrics() {
   const [datasetType, setDatasetType] = useState<DatasetType | undefined>(
     state && state.metrics ? DatasetType.CreateNew : undefined
   );
+  const {
+    fullPreview,
+    fullPreviewToggle,
+    fullPreviewButton,
+  } = useFullPreview();
 
   useEffect(() => {
     if (datasetType) {
@@ -302,7 +308,7 @@ function AddMetrics() {
   return (
     <>
       <Breadcrumbs crumbs={crumbs} />
-      <h1>Add metrics</h1>
+      <h1 hidden={fullPreview}>Add metrics</h1>
 
       {fileLoading || creatingWidget ? (
         <Spinner
@@ -313,7 +319,7 @@ function AddMetrics() {
         <div className="grid-row width-desktop">
           <form onChange={onFormChange} onSubmit={handleSubmit(onSubmit)}>
             <div className="grid-col-12">
-              <div className="grid-col-6">
+              <div className="grid-col-6" hidden={fullPreview}>
                 <StepIndicator
                   current={step}
                   segments={[
@@ -463,7 +469,7 @@ function AddMetrics() {
 
             <div hidden={step !== 1}>
               <div className="grid-row width-desktop">
-                <div className="grid-col-5">
+                <div className="grid-col-5" hidden={fullPreview}>
                   <fieldset className="usa-fieldset">
                     <TextField
                       id="title"
@@ -526,7 +532,8 @@ function AddMetrics() {
                     Cancel
                   </Button>
                 </div>
-                <div className="grid-col-7">
+                <div className={fullPreview ? "grid-col-12" : "grid-col-7"}>
+                  {fullPreviewButton}
                   <div className="margin-left-4">
                     <h4 className="margin-top-4">Preview</h4>
                     <MetricsWidget

--- a/frontend/src/containers/AddTable.tsx
+++ b/frontend/src/containers/AddTable.tsx
@@ -616,7 +616,7 @@ function AddTable() {
                 </div>
               </div>
 
-              <div className={fullPreview ? "gril-col-12" : "grid-col-7"}>
+              <div className={fullPreview ? "grid-col-12" : "grid-col-7"}>
                 <div hidden={!currentJson.length} className="margin-left-4">
                   {fullPreviewButton}
                   <h4>Preview</h4>

--- a/frontend/src/containers/AddTable.tsx
+++ b/frontend/src/containers/AddTable.tsx
@@ -4,7 +4,12 @@ import { useHistory, useParams } from "react-router-dom";
 import { LocationState } from "../models";
 import { Dataset, DatasetType, WidgetType } from "../models";
 import BackendService from "../services/BackendService";
-import { useDashboard, useDateTimeFormatter, useSettings } from "../hooks";
+import {
+  useDashboard,
+  useDateTimeFormatter,
+  useSettings,
+  useFullPreview,
+} from "../hooks";
 import StorageService from "../services/StorageService";
 import DatasetParsingService from "../services/DatasetParsingService";
 import Breadcrumbs from "../components/Breadcrumbs";
@@ -74,6 +79,11 @@ function AddTable() {
   );
   const [showAlert, setShowAlert] = useState(true);
   const [step, setStep] = useState<number>(state && state.json ? 1 : 0);
+  const {
+    fullPreview,
+    fullPreviewToggle,
+    fullPreviewButton,
+  } = useFullPreview();
 
   const uploadDataset = async (): Promise<Dataset> => {
     if (!csvFile) {
@@ -292,12 +302,12 @@ function AddTable() {
   return (
     <>
       <Breadcrumbs crumbs={crumbs} />
-      <h1>Add table</h1>
+      <h1 hidden={fullPreview}>Add table</h1>
 
       <div className="grid-row width-desktop">
         <form onSubmit={handleSubmit(onSubmit)}>
           <div className="grid-col-12">
-            <div className="grid-col-6">
+            <div className="grid-col-6" hidden={fullPreview}>
               <StepIndicator
                 current={step}
                 segments={[
@@ -539,7 +549,7 @@ function AddTable() {
 
           <div hidden={step !== 1}>
             <div className="grid-row width-desktop">
-              <div className="grid-col-5">
+              <div className="grid-col-5" hidden={fullPreview}>
                 <TextField
                   id="title"
                   name="title"
@@ -606,8 +616,9 @@ function AddTable() {
                 </div>
               </div>
 
-              <div className="grid-col-7">
+              <div className={fullPreview ? "gril-col-12" : "grid-col-7"}>
                 <div hidden={!currentJson.length} className="margin-left-4">
+                  {fullPreviewButton}
                   <h4>Preview</h4>
                   {datasetLoading ? (
                     <Spinner

--- a/frontend/src/containers/AddText.tsx
+++ b/frontend/src/containers/AddText.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useHistory, useParams } from "react-router-dom";
 import { WidgetType } from "../models";
-import { useDashboard } from "../hooks";
+import { useDashboard, useFullPreview } from "../hooks";
 import BackendService from "../services/BackendService";
 import Breadcrumbs from "../components/Breadcrumbs";
 import TextField from "../components/TextField";
@@ -31,6 +31,11 @@ function AddText() {
   const [title, setTitle] = useState("");
   const [text, setText] = useState("");
   const [showTitle, setShowTitle] = useState(true);
+  const {
+    fullPreview,
+    fullPreviewToggle,
+    fullPreviewButton,
+  } = useFullPreview();
 
   const onSubmit = async (values: FormValues) => {
     try {
@@ -94,19 +99,20 @@ function AddText() {
   return (
     <>
       <Breadcrumbs crumbs={crumbs} />
-      <h1>Add text</h1>
+      <div hidden={fullPreview}>
+        <h1>Add text</h1>
 
-      <div className="text-base text-italic">Step 2 of 2</div>
-      <div className="margin-y-1 text-semibold display-inline-block font-sans-lg">
-        Configure text content
+        <div className="text-base text-italic">Step 2 of 2</div>
+        <div className="margin-y-1 text-semibold display-inline-block font-sans-lg">
+          Configure text content
+        </div>
       </div>
-
       {creatingWidget ? (
         <Spinner className="text-center margin-top-6" label="Creating text" />
       ) : (
         <>
           <div className="grid-row width-desktop">
-            <div className="grid-col-6">
+            <div className="grid-col-6" hidden={fullPreview}>
               <form
                 className="usa-form usa-form--large"
                 onChange={onFormChange}
@@ -178,7 +184,8 @@ function AddText() {
                 </Button>
               </form>
             </div>
-            <div className="grid-col-6">
+            <div className={fullPreview ? "grid-col-12" : "grid-col-6"}>
+              {fullPreviewButton}
               <h4 className="margin-top-4">Preview</h4>
               {showTitle ? (
                 <h2 className="margin-top-4 margin-left-2px">{title}</h2>

--- a/frontend/src/containers/EditChart.tsx
+++ b/frontend/src/containers/EditChart.tsx
@@ -19,6 +19,7 @@ import {
   useDashboard,
   useDateTimeFormatter,
   useSettings,
+  useFullPreview,
 } from "../hooks";
 import Spinner from "../components/Spinner";
 import UtilsService from "../services/UtilsService";
@@ -82,6 +83,11 @@ function EditChart() {
     setDynamicJson,
     setCsvJson,
   } = useWidget(dashboardId, widgetId);
+  const {
+    fullPreviewToggle,
+    fullPreviewButton,
+    fullPreview,
+  } = useFullPreview();
 
   const [title, setTitle] = useState("");
   const [showTitle, setShowTitle] = useState(false);
@@ -446,7 +452,7 @@ function EditChart() {
   return (
     <>
       <Breadcrumbs crumbs={crumbs} />
-      <h1>Edit chart</h1>
+      <h1 hidden={fullPreview}>Edit chart</h1>
 
       {loading ||
       loadingDatasets ||
@@ -459,7 +465,7 @@ function EditChart() {
           <div className="grid-row width-desktop">
             <form onChange={onFormChange} onSubmit={handleSubmit(onSubmit)}>
               <div className="grid-col-12">
-                <div className="grid-col-6">
+                <div className="grid-col-6" hidden={fullPreview}>
                   <ul className="usa-button-group usa-button-group--segmented">
                     <li className="usa-button-group__item">
                       <button
@@ -662,7 +668,7 @@ function EditChart() {
               </div>
               <div hidden={step !== 1}>
                 <div className="grid-row width-desktop">
-                  <div className="grid-col-5">
+                  <div className="grid-col-5" hidden={fullPreview}>
                     <fieldset className="usa-fieldset">
                       <TextField
                         id="title"
@@ -765,14 +771,45 @@ function EditChart() {
                               Show summary below chart
                             </label>
                           </div>
+                          <br />
+                          <br />
+                          <hr />
+                          <Button
+                            variant="outline"
+                            type="button"
+                            onClick={backStep}
+                          >
+                            Back
+                          </Button>
+                          <Button
+                            onClick={advanceStep}
+                            type="submit"
+                            disabled={
+                              !displayedJson.length ||
+                              !title ||
+                              fileLoading ||
+                              editingWidget
+                            }
+                          >
+                            Save
+                          </Button>
+                          <Button
+                            variant="unstyled"
+                            className="text-base-dark hover:text-base-darker active:text-base-darkest"
+                            type="button"
+                            onClick={onCancel}
+                          >
+                            Cancel
+                          </Button>
                         </div>
                       ) : (
                         ""
                       )}
                     </fieldset>
                   </div>
-                  <div className="grid-col-7">
+                  <div className={fullPreview ? "grid-col-12" : "grid-col-7"}>
                     <div className="margin-left-4">
+                      {fullPreviewButton}
                       <h4>Preview</h4>
                       {datasetLoading ? (
                         <Spinner
@@ -848,32 +885,6 @@ function EditChart() {
                     </div>
                   </div>
                 </div>
-                <br />
-                <br />
-                <hr />
-                <Button variant="outline" type="button" onClick={backStep}>
-                  Back
-                </Button>
-                <Button
-                  onClick={advanceStep}
-                  type="submit"
-                  disabled={
-                    !displayedJson.length ||
-                    !title ||
-                    fileLoading ||
-                    editingWidget
-                  }
-                >
-                  Save
-                </Button>
-                <Button
-                  variant="unstyled"
-                  className="text-base-dark hover:text-base-darker active:text-base-darkest"
-                  type="button"
-                  onClick={onCancel}
-                >
-                  Cancel
-                </Button>
               </div>
             </form>
           </div>

--- a/frontend/src/containers/EditImage.tsx
+++ b/frontend/src/containers/EditImage.tsx
@@ -7,7 +7,7 @@ import Breadcrumbs from "../components/Breadcrumbs";
 import TextField from "../components/TextField";
 import FileInput from "../components/FileInput";
 import Button from "../components/Button";
-import { useDashboard, useWidget, useImage } from "../hooks";
+import { useDashboard, useWidget, useImage, useFullPreview } from "../hooks";
 import Spinner from "../components/Spinner";
 import ImageWidget from "../components/ImageWidget";
 import Link from "../components/Link";
@@ -38,6 +38,12 @@ function EditImage() {
   const [imageUploading, setImageUploading] = useState(false);
 
   const supportedImageFileTypes = Object.values(StorageService.imageFileTypes);
+
+  const {
+    fullPreview,
+    fullPreviewToggle,
+    fullPreviewButton,
+  } = useFullPreview();
 
   const onSubmit = async (values: FormValues) => {
     if (!widget) {
@@ -166,14 +172,14 @@ function EditImage() {
   return (
     <>
       <Breadcrumbs crumbs={crumbs} />
-      <h1>Edit Image</h1>
+      <h1 hidden={fullPreview}>Edit Image</h1>
 
       {!widget || loading || loadingFile ? (
         <Spinner className="text-center margin-top-6" label="Loading" />
       ) : (
         <>
           <div className="grid-row width-desktop">
-            <div className="grid-col-6">
+            <div className="grid-col-6" hidden={fullPreview}>
               <form
                 className="usa-form usa-form--large"
                 onSubmit={handleSubmit(onSubmit)}
@@ -300,8 +306,9 @@ function EditImage() {
                 </Button>
               </form>
             </div>
-            <div className="grid-col-6">
+            <div className={fullPreview ? "gril-col-12" : "grid-col-6"}>
               <div hidden={false} className="margin-left-4">
+                {fullPreviewButton}
                 <h4>Preview</h4>
                 {loadingFile ? (
                   <Spinner

--- a/frontend/src/containers/EditMetrics.tsx
+++ b/frontend/src/containers/EditMetrics.tsx
@@ -8,7 +8,7 @@ import {
   DatasetSchema,
   DatasetType,
 } from "../models";
-import { useDashboard, useWidget } from "../hooks";
+import { useDashboard, useWidget, useFullPreview } from "../hooks";
 import BackendService from "../services/BackendService";
 import Breadcrumbs from "../components/Breadcrumbs";
 import MetricsWidget from "../components/MetricsWidget";
@@ -50,6 +50,11 @@ function EditMetrics() {
   const [showTitle, setShowTitle] = useState(false);
   const [oneMetricPerRow, setOneMetricPerRow] = useState(false);
   const [metrics, setMetrics] = useState<Array<Metric>>([]);
+  const {
+    fullPreview,
+    fullPreviewToggle,
+    fullPreviewButton,
+  } = useFullPreview();
 
   useEffect(() => {
     if (widget && currentJson) {
@@ -215,7 +220,7 @@ function EditMetrics() {
   return (
     <>
       <Breadcrumbs crumbs={crumbs} />
-      <h1>Edit metrics</h1>
+      <h1 hidden={fullPreview}>Edit metrics</h1>
 
       {loading || !widget || !currentJson || fileLoading || editingWidget ? (
         <Spinner
@@ -230,7 +235,7 @@ function EditMetrics() {
         />
       ) : (
         <div className="grid-row width-desktop">
-          <div className="grid-col-6">
+          <div className="grid-col-6" hidden={fullPreview}>
             <form
               className="usa-form usa-form--large"
               onChange={onFormChange}
@@ -296,7 +301,8 @@ function EditMetrics() {
               </Button>
             </form>
           </div>
-          <div className="grid-col-6">
+          <div className={fullPreview ? "grid-col-12" : "grid-col-6"}>
+            {fullPreviewButton}
             <h4 className="margin-top-4">Preview</h4>
             <MetricsWidget
               title={showTitle ? title : ""}

--- a/frontend/src/containers/EditTable.tsx
+++ b/frontend/src/containers/EditTable.tsx
@@ -11,7 +11,12 @@ import FileInput from "../components/FileInput";
 import Button from "../components/Button";
 import { parse, ParseResult } from "papaparse";
 import TableWidget from "../components/TableWidget";
-import { useWidget, useDashboard, useDateTimeFormatter } from "../hooks";
+import {
+  useWidget,
+  useDashboard,
+  useDateTimeFormatter,
+  useFullPreview,
+} from "../hooks";
 import Spinner from "../components/Spinner";
 import Link from "../components/Link";
 import { useDatasets, useSettings } from "../hooks";
@@ -74,6 +79,11 @@ function EditTable() {
     setDynamicJson,
     setCsvJson,
   } = useWidget(dashboardId, widgetId);
+  const {
+    fullPreview,
+    fullPreviewToggle,
+    fullPreviewButton,
+  } = useFullPreview();
 
   const [title, setTitle] = useState("");
   const [showTitle, setShowTitle] = useState(false);
@@ -438,7 +448,7 @@ function EditTable() {
   return (
     <>
       <Breadcrumbs crumbs={crumbs} />
-      <h1>Edit table</h1>
+      <h1 hidden={fullPreview}>Edit table</h1>
 
       {loading ||
       loadingDatasets ||
@@ -451,7 +461,7 @@ function EditTable() {
           <div className="grid-row width-desktop">
             <form onChange={onFormChange} onSubmit={handleSubmit(onSubmit)}>
               <div className="grid-col-12">
-                <div className="grid-col-6">
+                <div className="grid-col-6" hidden={fullPreview}>
                   <ul className="usa-button-group usa-button-group--segmented">
                     <li className="usa-button-group__item">
                       <button
@@ -654,7 +664,7 @@ function EditTable() {
               </div>
               <div hidden={step !== 1}>
                 <div className="grid-row width-desktop">
-                  <div className="grid-col-5">
+                  <div className="grid-col-5" hidden={fullPreview}>
                     <fieldset className="usa-fieldset">
                       <TextField
                         id="title"
@@ -730,8 +740,9 @@ function EditTable() {
                       )}
                     </fieldset>
                   </div>
-                  <div className="grid-col-7">
+                  <div className={fullPreview ? "grid-col-12" : "grid-col-7"}>
                     <div className="margin-left-4">
+                      {fullPreviewButton}
                       <h4>Preview</h4>
                       {datasetLoading ? (
                         <Spinner

--- a/frontend/src/containers/EditText.tsx
+++ b/frontend/src/containers/EditText.tsx
@@ -6,7 +6,7 @@ import Breadcrumbs from "../components/Breadcrumbs";
 import TextField from "../components/TextField";
 import Button from "../components/Button";
 import MarkdownRender from "../components/MarkdownRender";
-import { useWidget, useDashboard } from "../hooks";
+import { useWidget, useDashboard, useFullPreview } from "../hooks";
 import Spinner from "../components/Spinner";
 import Link from "../components/Link";
 
@@ -28,6 +28,7 @@ function EditText() {
   const { register, errors, handleSubmit, getValues } = useForm<FormValues>();
   const [editingWidget, setEditingWidget] = useState(false);
   const { widget, setWidget } = useWidget(dashboardId, widgetId);
+  const { fullPreview, fullPreviewButton } = useFullPreview();
 
   const onSubmit = async (values: FormValues) => {
     if (!widget) {
@@ -98,7 +99,7 @@ function EditText() {
   return (
     <>
       <Breadcrumbs crumbs={crumbs} />
-      <h1>Edit text</h1>
+      <h1 hidden={fullPreview}>Edit text</h1>
 
       {loading || !widget || editingWidget ? (
         <Spinner
@@ -108,7 +109,7 @@ function EditText() {
       ) : (
         <>
           <div className="grid-row width-desktop">
-            <div className="grid-col-6">
+            <div className="grid-col-6" hidden={fullPreview}>
               <form
                 className="usa-form usa-form--large"
                 onChange={onFormChange}
@@ -179,7 +180,8 @@ function EditText() {
                 </Button>
               </form>
             </div>
-            <div className="grid-col-6">
+            <div className={fullPreview ? "grid-col-12" : "grid-col-6"}>
+              {fullPreviewButton}
               <h4 className="margin-top-4">Preview</h4>
               {widget.showTitle ? (
                 <h2 className="margin-top-4 margin-left-2px">{widget.name}</h2>

--- a/frontend/src/containers/__tests__/AddImage.test.tsx
+++ b/frontend/src/containers/__tests__/AddImage.test.tsx
@@ -93,3 +93,10 @@ test("on submit, it calls createWidget api and uploads dataset", async () => {
   expect(BackendService.createWidget).toHaveBeenCalled();
   expect(StorageService.uploadImage).toHaveBeenCalled();
 });
+
+test("renders the expand preview button", async () => {
+  render(<AddImage />, { wrapper: MemoryRouter });
+  expect(
+    screen.getByRole("button", { name: "Expand preview" })
+  ).toBeInTheDocument();
+});

--- a/frontend/src/containers/__tests__/AddText.test.tsx
+++ b/frontend/src/containers/__tests__/AddText.test.tsx
@@ -52,3 +52,8 @@ test("on submit, it calls createWidget api", async () => {
 
   expect(BackendService.createWidget).toHaveBeenCalled();
 });
+
+test("renders the expand preview button", async () => {
+  const { getByRole } = render(<AddText />, { wrapper: MemoryRouter });
+  expect(getByRole("button", { name: "Expand preview" })).toBeInTheDocument();
+});

--- a/frontend/src/containers/__tests__/EditImage.test.tsx
+++ b/frontend/src/containers/__tests__/EditImage.test.tsx
@@ -105,3 +105,10 @@ test("on submit, it calls editWidget api and uploads dataset", async () => {
   expect(BackendService.editWidget).toHaveBeenCalled();
   expect(StorageService.uploadImage).toHaveBeenCalled();
 });
+
+test("renders the expand preview button", async () => {
+  render(<EditImage />, { wrapper: MemoryRouter });
+  expect(
+    screen.getByRole("button", { name: "Expand preview" })
+  ).toBeInTheDocument();
+});

--- a/frontend/src/containers/__tests__/EditText.test.tsx
+++ b/frontend/src/containers/__tests__/EditText.test.tsx
@@ -27,3 +27,8 @@ test("renders a text input for content", async () => {
   const { getByLabelText } = render(<EditText />, { wrapper: MemoryRouter });
   expect(getByLabelText("Text")).toBeInTheDocument();
 });
+
+test("renders the expand preview button", async () => {
+  const { getByRole } = render(<EditText />, { wrapper: MemoryRouter });
+  expect(getByRole("button", { name: "Expand preview" })).toBeInTheDocument();
+});

--- a/frontend/src/hooks/__mocks__/index.tsx
+++ b/frontend/src/hooks/__mocks__/index.tsx
@@ -12,6 +12,7 @@ import {
   DashboardAuditLog,
   Widget,
 } from "../../models";
+import React from "react";
 
 const dummyDashboard = {
   id: "123",
@@ -511,5 +512,12 @@ export function useFriendlyUrl() {
   const [friendlyURL] = useState("/foo");
   return {
     friendlyURL,
+  };
+}
+
+export function useFullPreview() {
+  return {
+    fullPreview: false,
+    fullPreviewButton: <button type="button">Expand preview</button>,
   };
 }

--- a/frontend/src/hooks/dashboard-preview-hooks.tsx
+++ b/frontend/src/hooks/dashboard-preview-hooks.tsx
@@ -1,0 +1,26 @@
+import React, { useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faPlusSquare, faMinusSquare } from "@fortawesome/free-solid-svg-icons";
+import Button from "../components/Button";
+
+export function useFullPreview() {
+  const [fullPreview, setFullPreview] = useState(false);
+
+  const fullPreviewToggle = () => {
+    setFullPreview(!fullPreview);
+  };
+
+  const fullPreviewButton = fullPreview ? (
+    <Button onClick={fullPreviewToggle} variant="outline" type="button">
+      <FontAwesomeIcon icon={faMinusSquare} className={"margin-right-1"} />
+      Close preview
+    </Button>
+  ) : (
+    <Button onClick={fullPreviewToggle} variant="outline" type="button">
+      <FontAwesomeIcon icon={faPlusSquare} className={"margin-right-1"} />
+      Expand preview
+    </Button>
+  );
+
+  return { fullPreviewToggle, fullPreviewButton, fullPreview };
+}

--- a/frontend/src/hooks/index.tsx
+++ b/frontend/src/hooks/index.tsx
@@ -16,6 +16,7 @@ import { useDateTimeFormatter } from "./datetime-hooks";
 import { useImage } from "./image-hooks";
 import { useLogo } from "./logo-hooks";
 import { useDatasets } from "./dataset-hooks";
+import { useFullPreview } from "./dashboard-preview-hooks";
 
 /**
  * No unit tests for custom hooks?
@@ -50,4 +51,5 @@ export {
   useLogo,
   useFriendlyUrl,
   useDatasets,
+  useFullPreview,
 };


### PR DESCRIPTION
## Description

Added the option to make the preview of a dashboard widget full screen on the add and edit pages for all 5 widget types.

## Testing

Added unit tests for the widget types that have mocked preview content.
See it in action here --> https://dvinr4n9hngnv.cloudfront.net/admin

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
