### PR TITLE
Backend - Add significantDigitLabels property to Chart, Table and Metrics

### DIFF
--- a/backend/src/lib/factories/__tests__/widget-factory.test.ts
+++ b/backend/src/lib/factories/__tests__/widget-factory.test.ts
@@ -79,6 +79,7 @@ describe("createChartWidget", () => {
       fileName: "abc.csv",
       sortByColumn: "cases",
       sortByDesc: false,
+      significantDigitLabels: true,
       columnsMetadata: [
         {
           hidden: false,
@@ -115,6 +116,7 @@ describe("createChartWidget", () => {
     expect(widget.content.columnsMetadata).toHaveLength(2);
     expect(widget.content.sortByColumn).toEqual("cases");
     expect(widget.content.sortByDesc).toBe(false);
+    expect(widget.content.significantDigitLabels).toBe(true);
   });
 
   it("throws an error if chart title is undefined", () => {
@@ -236,6 +238,7 @@ describe("createTableWidget", () => {
       fileName: "abc.csv",
       sortByColumn: "cases",
       sortByDesc: false,
+      significantDigitLabels: true,
       columnsMetadata: [
         {
           hidden: false,
@@ -270,6 +273,7 @@ describe("createTableWidget", () => {
     expect(widget.content.columnsMetadata).toHaveLength(2);
     expect(widget.content.sortByColumn).toEqual("cases");
     expect(widget.content.sortByDesc).toBe(false);
+    expect(widget.content.significantDigitLabels).toBe(true);
   });
 
   it("throws an error if table title is undefined", () => {
@@ -345,6 +349,7 @@ describe("fromItem", () => {
         datasetId: "090b0410",
         sortByColumn: "foo",
         sortByDesc: false,
+        significantDigitLabels: false,
         columnsMetadata: [
           {
             columnName: "foo",
@@ -373,6 +378,7 @@ describe("fromItem", () => {
     expect(widget.content.chartType).toEqual("LineChart");
     expect(widget.content.sortByColumn).toEqual("foo");
     expect(widget.content.sortByDesc).toBe(false);
+    expect(widget.content.significantDigitLabels).toBe(false);
     expect(widget.content.columnsMetadata).toEqual([
       {
         columnName: "foo",
@@ -399,6 +405,7 @@ describe("fromItem", () => {
         summaryBelow: false,
         sortByColumn: "foo",
         sortByDesc: false,
+        significantDigitLabels: true,
         columnsMetadata: [
           {
             columnName: "foo",
@@ -426,6 +433,7 @@ describe("fromItem", () => {
     expect(widget.content.summaryBelow).toBe(false);
     expect(widget.content.sortByColumn).toEqual("foo");
     expect(widget.content.sortByDesc).toBe(false);
+    expect(widget.content.significantDigitLabels).toBe(true);
     expect(widget.content.columnsMetadata).toEqual([
       {
         columnName: "foo",
@@ -515,6 +523,7 @@ describe("toItem", () => {
         fileName: "abc.csv",
         sortByColumn: "cases",
         sortByDesc: true,
+        significantDigitLabels: true,
         columnsMetadata: [
           {
             hidden: false,
@@ -553,6 +562,7 @@ describe("toItem", () => {
       fileName: "abc.csv",
       sortByColumn: "cases",
       sortByDesc: true,
+      significantDigitLabels: true,
       columnsMetadata: [
         {
           hidden: false,
@@ -590,6 +600,7 @@ describe("toItem", () => {
         fileName: "abc.csv",
         sortByColumn: "deaths",
         sortByDesc: true,
+        significantDigitLabels: true,
         columnsMetadata: [
           {
             hidden: false,
@@ -627,6 +638,7 @@ describe("toItem", () => {
       fileName: "abc.csv",
       sortByColumn: "deaths",
       sortByDesc: true,
+      significantDigitLabels: true,
       columnsMetadata: [
         {
           hidden: false,
@@ -704,6 +716,7 @@ describe("createMetricsWidget", () => {
       json: "abc.json",
     },
     oneMetricPerRow: false,
+    significantDigitLabels: true,
   };
 
   it("builds a metrics widget", () => {
@@ -726,6 +739,7 @@ describe("createMetricsWidget", () => {
       json: "abc.json",
     });
     expect(widget.content.oneMetricPerRow).toEqual(false);
+    expect(widget.content.significantDigitLabels).toEqual(true);
   });
 
   it("throws an error if datasetId is undefined", () => {

--- a/backend/src/lib/factories/widget-factory.ts
+++ b/backend/src/lib/factories/widget-factory.ts
@@ -86,15 +86,81 @@ function fromItem(item: WidgetItem): Widget {
   switch (item.widgetType) {
     case WidgetType.Text:
       return widget as TextWidget;
+
     case WidgetType.Chart:
-      return widget as ChartWidget;
+      return fromChartItem(widget);
+
     case WidgetType.Table:
-      return widget as TableWidget;
+      return fromTableItem(widget);
+
     case WidgetType.Metrics:
-      return widget as MetricsWidget;
+      return fromMetricsItem(widget);
+
     default:
       return widget;
   }
+}
+
+function fromChartItem(widget: Widget): ChartWidget {
+  const chartWidget = widget as ChartWidget;
+  return {
+    ...widget,
+    content: {
+      ...widget.content,
+      /**
+       * This is an opportunity to define default values for
+       * properties that may not exist in the dynamodb item.
+       */
+      sortByDesc:
+        chartWidget.content.sortByDesc !== undefined
+          ? chartWidget.content.sortByDesc
+          : false,
+      significantDigitLabels:
+        chartWidget.content.significantDigitLabels !== undefined
+          ? chartWidget.content.significantDigitLabels
+          : false,
+    },
+  };
+}
+
+function fromTableItem(widget: Widget): TableWidget {
+  const tableWidget = widget as TableWidget;
+  return {
+    ...widget,
+    content: {
+      ...widget.content,
+      /**
+       * This is an opportunity to define default values for
+       * properties that may not exist in the dynamodb item.
+       */
+      sortByDesc:
+        tableWidget.content.sortByDesc !== undefined
+          ? tableWidget.content.sortByDesc
+          : false,
+      significantDigitLabels:
+        tableWidget.content.significantDigitLabels !== undefined
+          ? tableWidget.content.significantDigitLabels
+          : false,
+    },
+  };
+}
+
+function fromMetricsItem(widget: Widget): MetricsWidget {
+  const metricsWidget = widget as MetricsWidget;
+  return {
+    ...widget,
+    content: {
+      ...metricsWidget.content,
+      /**
+       * This is an opportunity to define default values for
+       * properties that may not exist in the dynamodb item.
+       */
+      significantDigitLabels:
+        metricsWidget.content.significantDigitLabels !== undefined
+          ? metricsWidget.content.significantDigitLabels
+          : false,
+    },
+  };
 }
 
 function fromItems(items: Array<WidgetItem>): Array<Widget> {
@@ -167,6 +233,10 @@ function createChartWidget(widget: Widget): ChartWidget {
       columnsMetadata: widget.content.columnsMetadata || [],
       sortByColumn: widget.content.sortByColumn,
       sortByDesc: widget.content.sortByDesc,
+      significantDigitLabels:
+        widget.content.significantDigitLabels !== undefined
+          ? widget.content.significantDigitLabels
+          : false,
     },
   };
 }
@@ -201,6 +271,10 @@ function createTableWidget(widget: Widget): TableWidget {
       columnsMetadata: widget.content.columnsMetadata || [],
       sortByColumn: widget.content.sortByColumn,
       sortByDesc: widget.content.sortByDesc,
+      significantDigitLabels:
+        widget.content.significantDigitLabels !== undefined
+          ? widget.content.significantDigitLabels
+          : false,
     },
   };
 }
@@ -252,6 +326,10 @@ function createMetricsWidget(widget: Widget): MetricsWidget {
       oneMetricPerRow: widget.content.oneMetricPerRow,
       s3Key: widget.content.s3Key,
       datasetType: widget.content.datasetType,
+      significantDigitLabels:
+        widget.content.significantDigitLabels !== undefined
+          ? widget.content.significantDigitLabels
+          : false,
     },
   };
 }

--- a/backend/src/lib/models/widget.ts
+++ b/backend/src/lib/models/widget.ts
@@ -61,14 +61,15 @@ export interface ChartWidget extends Widget {
     summary?: string;
     summaryBelow: boolean;
     datasetType?: string;
-    s3Key: {
-      raw: string;
-      json: string;
-    };
     fileName: string;
     columnsMetadata: ColumnMetadata[];
     sortByColumn?: string;
     sortByDesc?: boolean;
+    significantDigitLabels: boolean;
+    s3Key: {
+      raw: string;
+      json: string;
+    };
   };
 }
 
@@ -79,14 +80,15 @@ export interface TableWidget extends Widget {
     summary?: string;
     summaryBelow: boolean;
     datasetType?: string;
-    s3Key: {
-      raw: string;
-      json: string;
-    };
     fileName: string;
     columnsMetadata: ColumnMetadata[];
     sortByColumn?: string;
     sortByDesc?: boolean;
+    significantDigitLabels: boolean;
+    s3Key: {
+      raw: string;
+      json: string;
+    };
   };
 }
 
@@ -96,10 +98,10 @@ export interface ImageWidget extends Widget {
     imageAltText: string;
     summary?: string;
     summaryBelow: boolean;
+    fileName: string;
     s3Key: {
       raw: string;
     };
-    fileName: string;
   };
 }
 
@@ -109,6 +111,7 @@ export interface MetricsWidget extends Widget {
     datasetId: string;
     oneMetricPerRow: boolean;
     datasetType?: string;
+    significantDigitLabels: boolean;
     s3Key: {
       raw: string;
       json: string;


### PR DESCRIPTION
## Description

Added new property `significantDigitLabels` in Chart, Table and Metrics widgets. Refactored the `fromItem` function in WidgetFactory to support defining default values for properties that don't exist in the item in dynamodb. This will happen more often as we add new properties to our models that won't be present in existing old items. 

## Testing

Ran locally and verified with postman that the new property is being saved and retrieved. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
