### PR TITLE
GTT-1041 Tick formatter function

### DIFF
--- a/frontend/src/services/TickFormatter.ts
+++ b/frontend/src/services/TickFormatter.ts
@@ -1,0 +1,44 @@
+const ONE_THOUSAND = 1000;
+const ONE_MILLION = 1000000;
+const ONE_BILLION = 1000000000;
+
+const THOUSANDS_LABEL = "K";
+const MILLIONS_LABEL = "M";
+const BILLIONS_LABEL = "B";
+
+function formatNumber(
+  num: number,
+  largestTick: number,
+  significantDigitLabels: boolean
+): string {
+  if (isNaN(num)) {
+    return "";
+  }
+
+  if (!significantDigitLabels || num === 0) {
+    return num.toLocaleString();
+  }
+
+  if (Math.abs(largestTick) >= ONE_BILLION) {
+    const value = num / ONE_BILLION;
+    return value.toLocaleString() + BILLIONS_LABEL;
+  }
+
+  if (Math.abs(largestTick) >= ONE_MILLION) {
+    const value = num / ONE_MILLION;
+    return value.toLocaleString() + MILLIONS_LABEL;
+  }
+
+  if (Math.abs(largestTick) >= ONE_THOUSAND) {
+    const value = num / ONE_THOUSAND;
+    return value.toLocaleString() + THOUSANDS_LABEL;
+  }
+
+  return num.toLocaleString();
+}
+
+const TickFormatter = {
+  formatNumber,
+};
+
+export default TickFormatter;

--- a/frontend/src/services/__tests__/TickFormatter.test.ts
+++ b/frontend/src/services/__tests__/TickFormatter.test.ts
@@ -1,0 +1,53 @@
+import TickFormatter from "../TickFormatter";
+
+describe("formatNumber with significantDigitLabels enabled", () => {
+  it("does not add significant digit label when largestTick is < 1000", () => {
+    const largestTick = 500;
+    expect(TickFormatter.formatNumber(100, largestTick, true)).toEqual("100");
+    expect(TickFormatter.formatNumber(0.5, largestTick, true)).toEqual("0.5");
+  });
+
+  it("adds K when largestTick is greater than 1K", () => {
+    const largestTick = 1500;
+    expect(TickFormatter.formatNumber(100, largestTick, true)).toEqual("0.1K");
+    expect(TickFormatter.formatNumber(1800, largestTick, true)).toEqual("1.8K");
+    expect(TickFormatter.formatNumber(2000, largestTick, true)).toEqual("2K");
+    expect(TickFormatter.formatNumber(999999, largestTick, true)).toEqual(
+      "999.999K"
+    );
+  });
+
+  it("adds M when largestTick is greater than 1M", () => {
+    const largestTick = 1500000;
+    expect(TickFormatter.formatNumber(1500000, largestTick, true)).toEqual(
+      "1.5M"
+    );
+  });
+
+  it("adds B when largestTick is greater than 1B", () => {
+    const largestTick = 1000000000;
+    expect(TickFormatter.formatNumber(1000000000, largestTick, true)).toEqual(
+      "1B"
+    );
+  });
+
+  it("handles negative values by taking the absolute value", () => {
+    const largestTick = -1500;
+    expect(TickFormatter.formatNumber(1000, largestTick, true)).toEqual("1K");
+    expect(TickFormatter.formatNumber(-1000, largestTick, true)).toEqual("-1K");
+  });
+
+  it("does not add label when value is zero", () => {
+    const largestTick = 1000;
+    expect(TickFormatter.formatNumber(0, largestTick, true)).toEqual("0");
+  });
+});
+
+describe("formatNumber with significantDigitLabels disabled", () => {
+  it("returns number in locale string", () => {
+    const largestTick = 25000;
+    expect(TickFormatter.formatNumber(25000, largestTick, false)).toEqual(
+      "25,000"
+    );
+  });
+});


### PR DESCRIPTION
## Description

Wrote a tick formatter function that I will use to format numbers in yAxis labels. I am splitting the frontend work in separate PRs to keep them small. The next PR will be implementing this in the Charts and then Table and Metrics. 

## Testing

Verified unit tests pass. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
