### PR TITLE
GTT-1041 Add significant digit labels checkbox to Add/Edit Chart screens

### DIFF
--- a/frontend/src/components/VisualizeChart.tsx
+++ b/frontend/src/components/VisualizeChart.tsx
@@ -34,57 +34,19 @@ interface Props {
   sortByDesc?: boolean;
   setSortByColumn: Function;
   setSortByDesc: Function;
-  title?: string;
-  summary?: string;
-  chartType?: ChartType;
-  showTitle?: boolean;
-  summaryBelow?: boolean;
-  horizontalScroll?: boolean;
+  title: string;
+  summary: string;
+  chartType: ChartType;
+  showTitle: boolean;
+  summaryBelow: boolean;
   significantDigitLabels: boolean;
+  horizontalScroll: boolean;
 }
 
 function VisualizeChart(props: Props) {
   const { t } = useTranslation();
   const [showAlert, setShowAlert] = useState(true);
-  const [title, setTitle] = useState(props.title || "");
-  const [summary, setSummary] = useState(props.summary || "");
-  const [chartType, setChartType] = useState<ChartType>(
-    props.chartType || ChartType.LineChart
-  );
-  const [showTitle, setShowTitle] = useState(
-    props.showTitle === undefined ? true : props.showTitle
-  );
-  const [summaryBelow, setSummaryBelow] = useState<boolean>(
-    props.summaryBelow === undefined ? true : props.summaryBelow
-  );
-  const [horizontalScroll, setHorizontalScroll] = useState<boolean>(
-    props.horizontalScroll === undefined ? true : props.horizontalScroll
-  );
   const [widthPercent, setWidthPercent] = useState(0);
-
-  const handleTitleChange = (event: React.FormEvent<HTMLInputElement>) => {
-    setTitle((event.target as HTMLInputElement).value);
-  };
-
-  const handleSummaryChange = (event: React.FormEvent<HTMLTextAreaElement>) => {
-    setSummary((event.target as HTMLTextAreaElement).value);
-  };
-
-  const handleSummaryBelowChange = (
-    event: React.FormEvent<HTMLInputElement>
-  ) => {
-    setSummaryBelow((event.target as HTMLInputElement).checked);
-  };
-
-  const handleShowTitleChange = (event: React.FormEvent<HTMLInputElement>) => {
-    setShowTitle((event.target as HTMLInputElement).checked);
-  };
-
-  const handleChartTypeChange = (
-    event: React.FormEvent<HTMLFieldSetElement>
-  ) => {
-    setChartType((event.target as HTMLInputElement).value as ChartType);
-  };
 
   const handleSortDataChange = (event: React.FormEvent<HTMLInputElement>) => {
     const target = event.target as HTMLInputElement;
@@ -114,12 +76,6 @@ function VisualizeChart(props: Props) {
     });
   });
 
-  const handleHorizontalScrollChange = (
-    event: React.FormEvent<HTMLInputElement>
-  ) => {
-    setHorizontalScroll((event.target as HTMLInputElement).checked);
-  };
-
   return (
     <div className="grid-row width-desktop">
       <div className="grid-col-5" hidden={props.fullPreview}>
@@ -129,7 +85,6 @@ function VisualizeChart(props: Props) {
           label="Chart title"
           hint="Give your chart a descriptive title."
           error={props.errors.title && "Please specify a chart title"}
-          onChange={handleTitleChange}
           required
           register={props.register}
         />
@@ -141,7 +96,6 @@ function VisualizeChart(props: Props) {
             type="checkbox"
             name="showTitle"
             defaultChecked={true}
-            onChange={handleShowTitleChange}
             ref={props.register()}
           />
           <label className="usa-checkbox__label" htmlFor="display-title">
@@ -156,7 +110,6 @@ function VisualizeChart(props: Props) {
           hint="Choose a chart type."
           register={props.register}
           error={props.errors.chartType && "Please select a chart type"}
-          onChange={handleChartTypeChange}
           defaultValue={ChartType.LineChart}
           required
           options={[
@@ -194,7 +147,11 @@ function VisualizeChart(props: Props) {
           />
         </div>
 
-        <div hidden={chartType !== ChartType.LineChart || widthPercent <= 100}>
+        <div
+          hidden={
+            props.chartType !== ChartType.LineChart || widthPercent <= 100
+          }
+        >
           <label className="usa-label text-bold">
             {t("ChartOptionsLabel")}
           </label>
@@ -223,7 +180,6 @@ function VisualizeChart(props: Props) {
               type="checkbox"
               name="horizontalScroll"
               defaultChecked
-              onChange={handleHorizontalScrollChange}
               ref={props.register()}
             />
             <label className="usa-checkbox__label" htmlFor="horizontalScroll">
@@ -247,7 +203,6 @@ function VisualizeChart(props: Props) {
             </>
           }
           register={props.register}
-          onChange={handleSummaryChange}
           multiline
           rows={5}
         />
@@ -258,7 +213,6 @@ function VisualizeChart(props: Props) {
             type="checkbox"
             name="summaryBelow"
             defaultChecked={false}
-            onChange={handleSummaryBelowChange}
             ref={props.register()}
           />
           <label className="usa-checkbox__label" htmlFor="summary-below">
@@ -276,7 +230,7 @@ function VisualizeChart(props: Props) {
           type="submit"
           disabled={
             !props.json.length ||
-            !title ||
+            !props.title ||
             props.fileLoading ||
             props.processingWidget
           }
@@ -343,60 +297,60 @@ function VisualizeChart(props: Props) {
               ) : (
                 ""
               )}
-              {chartType === ChartType.LineChart && (
+              {props.chartType === ChartType.LineChart && (
                 <LineChartWidget
-                  title={showTitle ? title : ""}
-                  summary={summary}
+                  title={props.showTitle ? props.title : ""}
+                  summary={props.summary}
                   lines={
                     props.json.length
                       ? (Object.keys(props.json[0]) as Array<string>)
                       : []
                   }
                   data={props.json}
-                  summaryBelow={summaryBelow}
+                  summaryBelow={props.summaryBelow}
                   isPreview={true}
-                  horizontalScroll={horizontalScroll}
+                  horizontalScroll={props.horizontalScroll}
                   setWidthPercent={setWidthPercent}
                 />
               )}
-              {chartType === ChartType.ColumnChart && (
+              {props.chartType === ChartType.ColumnChart && (
                 <ColumnChartWidget
-                  title={showTitle ? title : ""}
-                  summary={summary}
+                  title={props.showTitle ? props.title : ""}
+                  summary={props.summary}
                   columns={
                     props.json.length
                       ? (Object.keys(props.json[0]) as Array<string>)
                       : []
                   }
                   data={props.json}
-                  summaryBelow={summaryBelow}
+                  summaryBelow={props.summaryBelow}
                   isPreview={true}
                 />
               )}
-              {chartType === ChartType.BarChart && (
+              {props.chartType === ChartType.BarChart && (
                 <BarChartWidget
-                  title={showTitle ? title : ""}
-                  summary={summary}
+                  title={props.showTitle ? props.title : ""}
+                  summary={props.summary}
                   bars={
                     props.json.length
                       ? (Object.keys(props.json[0]) as Array<string>)
                       : []
                   }
                   data={props.json}
-                  summaryBelow={summaryBelow}
+                  summaryBelow={props.summaryBelow}
                 />
               )}
-              {chartType === ChartType.PartWholeChart && (
+              {props.chartType === ChartType.PartWholeChart && (
                 <PartWholeChartWidget
-                  title={showTitle ? title : ""}
-                  summary={summary}
+                  title={props.showTitle ? props.title : ""}
+                  summary={props.summary}
                   parts={
                     props.json.length
                       ? (Object.keys(props.json[0]) as Array<string>)
                       : []
                   }
                   data={props.json}
-                  summaryBelow={summaryBelow}
+                  summaryBelow={props.summaryBelow}
                 />
               )}
             </>

--- a/frontend/src/components/VisualizeChart.tsx
+++ b/frontend/src/components/VisualizeChart.tsx
@@ -1,6 +1,7 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import React, { useCallback, useState } from "react";
+import React, { useState } from "react";
 import { ChartType, DatasetType } from "../models";
+import { useTranslation } from "react-i18next";
 import Alert from "./Alert";
 import BarChartWidget from "./BarChartWidget";
 import Button from "./Button";
@@ -39,9 +40,11 @@ interface Props {
   showTitle?: boolean;
   summaryBelow?: boolean;
   horizontalScroll?: boolean;
+  significantDigitLabels: boolean;
 }
 
 function VisualizeChart(props: Props) {
+  const { t } = useTranslation();
   const [showAlert, setShowAlert] = useState(true);
   const [title, setTitle] = useState(props.title || "");
   const [summary, setSummary] = useState(props.summary || "");
@@ -192,7 +195,27 @@ function VisualizeChart(props: Props) {
         </div>
 
         <div hidden={chartType !== ChartType.LineChart || widthPercent <= 100}>
-          <legend className="usa-legend text-bold">Line chart options</legend>
+          <label className="usa-label text-bold">
+            {t("ChartOptionsLabel")}
+          </label>
+          <div className="usa-hint">{t("ChartOptionsDescription")}</div>
+          <div className="usa-checkbox">
+            <input
+              className="usa-checkbox__input"
+              id="significantDigitLabels"
+              type="checkbox"
+              name="significantDigitLabels"
+              defaultChecked={false}
+              ref={props.register()}
+            />
+            <label
+              className="usa-checkbox__label"
+              htmlFor="significantDigitLabels"
+            >
+              {t("SignificantDigitLabels")}
+            </label>
+          </div>
+
           <div className="usa-checkbox">
             <input
               className="usa-checkbox__input"

--- a/frontend/src/components/VisualizeChart.tsx
+++ b/frontend/src/components/VisualizeChart.tsx
@@ -147,11 +147,7 @@ function VisualizeChart(props: Props) {
           />
         </div>
 
-        <div
-          hidden={
-            props.chartType !== ChartType.LineChart || widthPercent <= 100
-          }
-        >
+        <div>
           <label className="usa-label text-bold">
             {t("ChartOptionsLabel")}
           </label>
@@ -173,7 +169,12 @@ function VisualizeChart(props: Props) {
             </label>
           </div>
 
-          <div className="usa-checkbox">
+          <div
+            className="usa-checkbox"
+            hidden={
+              props.chartType !== ChartType.LineChart || widthPercent <= 100
+            }
+          >
             <input
               className="usa-checkbox__input"
               id="horizontalScroll"

--- a/frontend/src/components/__tests__/VisualizeChart.test.tsx
+++ b/frontend/src/components/__tests__/VisualizeChart.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { render } from "@testing-library/react";
 import VisualizeChart from "../VisualizeChart";
 import { MemoryRouter } from "react-router-dom";
-import { DatasetType } from "../../models";
+import { ChartType, DatasetType } from "../../models";
 import Button from "../Button";
 
 test("renders the VisualizeChart component", async () => {
@@ -42,6 +42,7 @@ test("renders the VisualizeChart component", async () => {
       setSortByColumn={() => {}}
       setSortByDesc={() => {}}
       horizontalScroll={true}
+      significantDigitLabels={false}
     />,
     { wrapper: MemoryRouter }
   );
@@ -85,6 +86,7 @@ test("renders the VisualizeChart component without horizontal scrolling", async 
       setSortByColumn={() => {}}
       setSortByDesc={() => {}}
       horizontalScroll={false}
+      significantDigitLabels={false}
     />,
     { wrapper: MemoryRouter }
   );

--- a/frontend/src/components/__tests__/__snapshots__/VisualizeChart.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/VisualizeChart.test.tsx.snap
@@ -230,17 +230,9 @@ exports[`renders the VisualizeChart component 1`] = `
             Significant digit labels (123K, 1.2M)
           </label>
         </div>
-      </div>
-      <div
-        hidden=""
-      >
-        <legend
-          class="usa-legend text-bold"
-        >
-          Line chart options
-        </legend>
         <div
           class="usa-checkbox"
+          hidden=""
         >
           <input
             checked=""
@@ -359,21 +351,6 @@ exports[`renders the VisualizeChart component 1`] = `
           Preview
         </h4>
         
-        <div
-          class="overflow-hidden"
-        >
-          <h2
-            class="margin-bottom-1"
-          />
-          <div
-            class="Markdown usa-prose margin-top-0 margin-bottom-4 chartSummaryAbove"
-          />
-          <div
-            class="recharts-responsive-container"
-            id=""
-            style="width: 100%; height: 300px;"
-          />
-        </div>
       </div>
     </div>
   </div>
@@ -583,16 +560,36 @@ exports[`renders the VisualizeChart component without horizontal scrolling 1`] =
           </select>
         </div>
       </div>
-      <div
-        hidden=""
-      >
-        <legend
-          class="usa-legend text-bold"
+      <div>
+        <label
+          class="usa-label text-bold"
         >
-          Line chart options
-        </legend>
+          Chart Options
+        </label>
+        <div
+          class="usa-hint"
+        >
+          Format your line chart
+        </div>
         <div
           class="usa-checkbox"
+        >
+          <input
+            class="usa-checkbox__input"
+            id="significantDigitLabels"
+            name="significantDigitLabels"
+            type="checkbox"
+          />
+          <label
+            class="usa-checkbox__label"
+            for="significantDigitLabels"
+          >
+            Significant digit labels (123K, 1.2M)
+          </label>
+        </div>
+        <div
+          class="usa-checkbox"
+          hidden=""
         >
           <input
             checked=""
@@ -684,6 +681,7 @@ exports[`renders the VisualizeChart component without horizontal scrolling 1`] =
       </button>
       <button
         class="usa-button usa-button--base"
+        disabled=""
         type="submit"
       >
         Add Chart
@@ -710,27 +708,6 @@ exports[`renders the VisualizeChart component without horizontal scrolling 1`] =
           Preview
         </h4>
         
-        <div
-          class="overflow-hidden"
-        >
-          <h2
-            class="margin-bottom-1"
-          >
-            My Line Chart
-          </h2>
-          <div
-            class="Markdown usa-prose margin-top-0 margin-bottom-4 chartSummaryAbove"
-          >
-            <p>
-              Lorem ipsum
-            </p>
-          </div>
-          <div
-            class="recharts-responsive-container"
-            id="My Line Chart"
-            style="width: 100%; height: 300px;"
-          />
-        </div>
       </div>
     </div>
   </div>

--- a/frontend/src/components/__tests__/__snapshots__/VisualizeChart.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/VisualizeChart.test.tsx.snap
@@ -203,6 +203,34 @@ exports[`renders the VisualizeChart component 1`] = `
           </select>
         </div>
       </div>
+      <div>
+        <label
+          class="usa-label text-bold"
+        >
+          Chart Options
+        </label>
+        <div
+          class="usa-hint"
+        >
+          Format your line chart
+        </div>
+        <div
+          class="usa-checkbox"
+        >
+          <input
+            class="usa-checkbox__input"
+            id="significantDigitLabels"
+            name="significantDigitLabels"
+            type="checkbox"
+          />
+          <label
+            class="usa-checkbox__label"
+            for="significantDigitLabels"
+          >
+            Significant digit labels (123K, 1.2M)
+          </label>
+        </div>
+      </div>
       <div
         hidden=""
       >

--- a/frontend/src/components/__tests__/__snapshots__/VisualizeChart.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/VisualizeChart.test.tsx.snap
@@ -684,7 +684,6 @@ exports[`renders the VisualizeChart component without horizontal scrolling 1`] =
       </button>
       <button
         class="usa-button usa-button--base"
-        disabled=""
         type="submit"
       >
         Add Chart
@@ -716,13 +715,19 @@ exports[`renders the VisualizeChart component without horizontal scrolling 1`] =
         >
           <h2
             class="margin-bottom-1"
-          />
+          >
+            My Line Chart
+          </h2>
           <div
             class="Markdown usa-prose margin-top-0 margin-bottom-4 chartSummaryAbove"
-          />
+          >
+            <p>
+              Lorem ipsum
+            </p>
+          </div>
           <div
             class="recharts-responsive-container"
-            id=""
+            id="My Line Chart"
             style="width: 100%; height: 300px;"
           />
         </div>

--- a/frontend/src/containers/AddChart.tsx
+++ b/frontend/src/containers/AddChart.tsx
@@ -22,7 +22,8 @@ interface FormValues {
   showTitle: boolean;
   summaryBelow: boolean;
   datasetType: string;
-  horizontalScroll?: boolean;
+  horizontalScroll: boolean;
+  significantDigitLabels: boolean;
 }
 
 interface PathParams {
@@ -36,7 +37,13 @@ function AddChart() {
   const { dashboardId } = useParams<PathParams>();
   const { dashboard, loading } = useDashboard(dashboardId);
   const { dynamicDatasets } = useDatasets();
-  const { register, errors, handleSubmit, reset } = useForm<FormValues>();
+  const {
+    register,
+    errors,
+    handleSubmit,
+    reset,
+    watch,
+  } = useForm<FormValues>();
   const [currentJson, setCurrentJson] = useState<Array<any>>(
     state && state.json ? state.json : []
   );
@@ -77,6 +84,14 @@ function AddChart() {
   const [dataTypes, setDataTypes] = useState<Map<string, ColumnDataType>>(
     new Map<string, ColumnDataType>()
   );
+
+  const title = watch("title");
+  const summary = watch("summary");
+  const summaryBelow = watch("summaryBelow");
+  const chartType = watch("chartType");
+  const showTitle = watch("showTitle");
+  const horizontalScroll = watch("horizontalScroll");
+  const significantDigitLabels = watch("significantDigitLabels");
 
   useMemo(() => {
     let headers = currentJson.length
@@ -155,6 +170,7 @@ function AddChart() {
             : staticDataset?.fileName,
           sortByColumn,
           sortByDesc,
+          significantDigitLabels: values.significantDigitLabels,
           columnsMetadata: Array.from(selectedHeaders).map((header) => {
             return {
               columnName: header,
@@ -387,6 +403,13 @@ function AddChart() {
               sortByDesc={sortByDesc}
               setSortByColumn={setSortByColumn}
               setSortByDesc={setSortByDesc}
+              title={title}
+              summary={summary}
+              summaryBelow={summaryBelow}
+              showTitle={showTitle}
+              chartType={chartType as ChartType}
+              significantDigitLabels={significantDigitLabels}
+              horizontalScroll={horizontalScroll}
             />
           </div>
         </form>

--- a/frontend/src/containers/EditChart.tsx
+++ b/frontend/src/containers/EditChart.tsx
@@ -32,6 +32,7 @@ interface FormValues {
   datasetType: string;
   sortData: string;
   horizontalScroll?: boolean;
+  significantDigitLabels: boolean;
 }
 
 interface PathParams {
@@ -99,6 +100,7 @@ function EditChart() {
   const summaryBelow = watch("summaryBelow");
   const chartType = watch("chartType");
   const horizontalScroll = watch("horizontalScroll");
+  const significantDigitLabels = watch("significantDigitLabels");
 
   const [displayedJson, setDisplayedJson] = useState<any[]>([]);
   const [filteredJson, setFilteredJson] = useState<any[]>([]);
@@ -151,6 +153,7 @@ function EditChart() {
         summaryBelow,
         chartType,
         horizontalScroll,
+        significantDigitLabels: widget.content.significantDigitLabels,
         dynamicDatasets:
           widget.content.datasetType === DatasetType.DynamicDataset
             ? widget.content.s3Key.json
@@ -337,6 +340,7 @@ function EditChart() {
             : staticDataset?.fileName,
           sortByColumn,
           sortByDesc,
+          significantDigitLabels: values.significantDigitLabels,
           columnsMetadata: Array.from(selectedHeaders).map((header) => {
             return {
               columnName: header,
@@ -566,6 +570,7 @@ function EditChart() {
                 setSortByColumn={setSortByColumn}
                 setSortByDesc={setSortByDesc}
                 horizontalScroll={horizontalScroll}
+                significantDigitLabels={significantDigitLabels}
               />
             </div>
           </form>

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -30,5 +30,8 @@
   "Edit": "Edit",
   "SureDelete": "Are you sure you want to delete this",
   "ZeroDashboards": "that have zero dashboards",
-  "CanDelete": "You can only delete"
+  "CanDelete": "You can only delete",
+  "SignificantDigitLabels": "Significant digit labels (123K, 1.2M)",
+  "ChartOptionsLabel": "Chart Options",
+  "ChartOptionsDescription": "Format your line chart"
 }


### PR DESCRIPTION
## Description

Added the option to enable/disable significant digit labels in both Edit and Add Chart screens. I also refactored the way <VisualizeChart> component handles form values to make it simpler by using the `watch` function from react hook form. 

## Testing

Verified that enabling or disabling the significant digit labels works properly. You can test in my personal environment by adding or editing a chart. https://fdingler.badger.wwps.aws.dev/admin/dashboard/572df231-29ca-4139-ae34-46c485a0c9d4/add-chart 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
