### PR TITLE
GTT-1041 - Add significant digit labels to all chart types

### DIFF
--- a/frontend/src/components/ChartWidget.tsx
+++ b/frontend/src/components/ChartWidget.tsx
@@ -51,6 +51,7 @@ function ChartWidgetComponent(props: Props) {
           lines={keys}
           data={filteredJson}
           horizontalScroll={content.horizontalScroll}
+          significantDigitLabels={content.significantDigitLabels}
         />
       );
 
@@ -62,6 +63,7 @@ function ChartWidgetComponent(props: Props) {
           summaryBelow={content.summaryBelow}
           columns={keys}
           data={filteredJson}
+          significantDigitLabels={content.significantDigitLabels}
         />
       );
 
@@ -73,6 +75,7 @@ function ChartWidgetComponent(props: Props) {
           summaryBelow={content.summaryBelow}
           bars={keys}
           data={filteredJson}
+          significantDigitLabels={content.significantDigitLabels}
         />
       );
 
@@ -84,6 +87,7 @@ function ChartWidgetComponent(props: Props) {
           summaryBelow={content.summaryBelow}
           parts={keys}
           data={filteredJson}
+          significantDigitLabels={content.significantDigitLabels}
         />
       );
 

--- a/frontend/src/components/VisualizeChart.tsx
+++ b/frontend/src/components/VisualizeChart.tsx
@@ -43,7 +43,7 @@ interface Props {
   showTitle: boolean;
   summaryBelow: boolean;
   significantDigitLabels: boolean;
-  horizontalScroll?: boolean;
+  horizontalScroll: boolean;
 }
 
 function VisualizeChart(props: Props) {
@@ -304,6 +304,7 @@ function VisualizeChart(props: Props) {
                   isPreview={true}
                   horizontalScroll={props.horizontalScroll}
                   setWidthPercent={setWidthPercent}
+                  significantDigitLabels={props.significantDigitLabels}
                 />
               )}
               {props.chartType === ChartType.ColumnChart && (
@@ -318,6 +319,7 @@ function VisualizeChart(props: Props) {
                   data={props.json}
                   summaryBelow={props.summaryBelow}
                   isPreview={true}
+                  significantDigitLabels={props.significantDigitLabels}
                 />
               )}
               {props.chartType === ChartType.BarChart && (
@@ -331,6 +333,7 @@ function VisualizeChart(props: Props) {
                   }
                   data={props.json}
                   summaryBelow={props.summaryBelow}
+                  significantDigitLabels={props.significantDigitLabels}
                 />
               )}
               {props.chartType === ChartType.PartWholeChart && (
@@ -344,6 +347,7 @@ function VisualizeChart(props: Props) {
                   }
                   data={props.json}
                   summaryBelow={props.summaryBelow}
+                  significantDigitLabels={props.significantDigitLabels}
                 />
               )}
             </>

--- a/frontend/src/containers/EditChart.tsx
+++ b/frontend/src/containers/EditChart.tsx
@@ -33,7 +33,7 @@ interface FormValues {
   summaryBelow: boolean;
   datasetType: string;
   sortData: string;
-  horizontalScroll?: boolean;
+  horizontalScroll: boolean;
   significantDigitLabels: boolean;
 }
 

--- a/frontend/src/hooks/__mocks__/index.tsx
+++ b/frontend/src/hooks/__mocks__/index.tsx
@@ -522,3 +522,19 @@ export function useFullPreview() {
     fullPreviewButton: <button type="button">Expand preview</button>,
   };
 }
+
+export function useYAxisMetadata() {
+  const [yAxisLargestValue] = useState(100);
+  const [yAxisMargin] = useState(0);
+  return {
+    yAxisLargestValue,
+    yAxisMargin,
+  };
+}
+
+export function useXAxisMetadata() {
+  const [xAxisLargestValue] = useState(0);
+  return {
+    xAxisLargestValue,
+  };
+}

--- a/frontend/src/hooks/chart-hooks.ts
+++ b/frontend/src/hooks/chart-hooks.ts
@@ -1,0 +1,67 @@
+import React, { useState, MutableRefObject } from "react";
+// @ts-ignore
+import { CategoricalChartWrapper } from "recharts";
+import UtilsService from "../services/UtilsService";
+
+type UseYAxisMetadataHook = {
+  yAxisLargestValue: number;
+  yAxisMargin: number;
+};
+
+export function useYAxisMetadata(
+  chartRef: MutableRefObject<null>,
+  chartLoaded: boolean,
+  significantDigitLabels: boolean
+): UseYAxisMetadataHook {
+  const [yAxisLargestValue, setYAxisLargestValue] = useState(0);
+  const [yAxisMargin, setYAxisMargin] = useState(0);
+
+  React.useEffect(() => {
+    if (chartRef && chartRef.current) {
+      const currentRef = chartRef.current as CategoricalChartWrapper;
+      const yAxisMap = currentRef.state.yAxisMap;
+      if (yAxisMap && yAxisMap[0]) {
+        const largestTick = Math.max(...yAxisMap[0].niceTicks);
+        const margin = UtilsService.calculateYAxisMargin(
+          largestTick,
+          significantDigitLabels
+        );
+
+        setYAxisLargestValue(largestTick);
+        setYAxisMargin(margin);
+      }
+    }
+  }, [chartRef, chartRef.current, chartLoaded, significantDigitLabels]);
+
+  return {
+    yAxisLargestValue,
+    yAxisMargin,
+  };
+}
+
+type UseXAxisMetadataHook = {
+  xAxisLargestValue: number;
+};
+
+export function useXAxisMetadata(
+  chartRef: MutableRefObject<null>,
+  chartLoaded: boolean,
+  significantDigitLabels: boolean
+): UseXAxisMetadataHook {
+  const [xAxisLargestValue, setXAxisLargestValue] = useState(0);
+
+  React.useEffect(() => {
+    if (chartRef && chartRef.current) {
+      const currentRef = chartRef.current as CategoricalChartWrapper;
+      const xAxisMap = currentRef.state.xAxisMap;
+      if (xAxisMap && xAxisMap[0]) {
+        const largestTick = Math.max(...xAxisMap[0].niceTicks);
+        setXAxisLargestValue(largestTick);
+      }
+    }
+  }, [chartRef, chartRef.current, chartLoaded, significantDigitLabels]);
+
+  return {
+    xAxisLargestValue,
+  };
+}

--- a/frontend/src/hooks/index.tsx
+++ b/frontend/src/hooks/index.tsx
@@ -17,6 +17,7 @@ import { useImage } from "./image-hooks";
 import { useLogo } from "./logo-hooks";
 import { useDatasets } from "./dataset-hooks";
 import { useFullPreview } from "./dashboard-preview-hooks";
+import { useYAxisMetadata, useXAxisMetadata } from "./chart-hooks";
 
 /**
  * No unit tests for custom hooks?
@@ -52,4 +53,6 @@ export {
   useFriendlyUrl,
   useDatasets,
   useFullPreview,
+  useYAxisMetadata,
+  useXAxisMetadata,
 };

--- a/frontend/src/models/index.tsx
+++ b/frontend/src/models/index.tsx
@@ -122,6 +122,7 @@ export interface ChartWidget extends Widget {
     sortByColumn?: string;
     sortByDesc?: boolean;
     horizontalScroll?: boolean;
+    significantDigitLabels: boolean;
   };
 }
 
@@ -139,6 +140,7 @@ export interface TableWidget extends Widget {
     columnsMetadata: ColumnMetadata[];
     sortByColumn?: string;
     sortByDesc?: boolean;
+    significantDigitLabels: boolean;
   };
 }
 
@@ -161,6 +163,7 @@ export interface MetricsWidget extends Widget {
     datasetId: string;
     oneMetricPerRow: boolean;
     datasetType?: DatasetType;
+    significantDigitLabels: boolean;
     s3Key: {
       raw: string;
       json: string;

--- a/frontend/src/services/TickFormatter.ts
+++ b/frontend/src/services/TickFormatter.ts
@@ -6,6 +6,25 @@ const THOUSANDS_LABEL = "K";
 const MILLIONS_LABEL = "M";
 const BILLIONS_LABEL = "B";
 
+function format(
+  tick: any,
+  largestTick: number,
+  significantDigitLabels: boolean
+): string {
+  switch (typeof tick) {
+    case "string":
+      return formatString(tick);
+    case "number":
+      return formatNumber(tick, largestTick, significantDigitLabels);
+    default:
+      return tick;
+  }
+}
+
+function formatString(tick: string) {
+  return tick.toLocaleString();
+}
+
 function formatNumber(
   num: number,
   largestTick: number,
@@ -38,7 +57,7 @@ function formatNumber(
 }
 
 const TickFormatter = {
-  formatNumber,
+  format,
 };
 
 export default TickFormatter;

--- a/frontend/src/services/UtilsService.ts
+++ b/frontend/src/services/UtilsService.ts
@@ -62,6 +62,22 @@ function getLargestHeader(headers: Array<string>, data?: Array<any>) {
 }
 
 /**
+ * Calculate the YAxis margin needed. This is important after we started
+ * showing the ticks numbers as locale strings and commas or periods are being
+ * added. Margin: Count the commas or periods in the largestTick to locale string,
+ * and multiply by pixelsByCharacter.
+ */
+function calculateYAxisMargin(
+  largestTick: number,
+  significantDigitLabels: boolean
+): number {
+  const pixelsByCharacter = significantDigitLabels ? 2 : 8;
+  const tickLocaleString: string = largestTick.toLocaleString();
+  const numberOfCommas: number = tickLocaleString.match(/,|\./g)?.length || 0;
+  return numberOfCommas * pixelsByCharacter;
+}
+
+/**
  * Given a dashboard, it returns the URL path of the screen
  * where the user should be redirected: /dashboard/edit/{id},
  * /dashboard/{id}, etc. This depends on the dashboard state.
@@ -89,6 +105,7 @@ const UtilsService = {
   timeout,
   getLargestHeader,
   getDashboardUrlPath,
+  calculateYAxisMargin,
 };
 
 export default UtilsService;

--- a/frontend/src/services/__tests__/TickFormatter.test.ts
+++ b/frontend/src/services/__tests__/TickFormatter.test.ts
@@ -1,53 +1,53 @@
 import TickFormatter from "../TickFormatter";
 
+describe("format handles ticks of type string", () => {
+  it("returns the value in locale string", () => {
+    const largestTick = 500;
+    const tick = "2020/04/11";
+    expect(TickFormatter.format(tick, largestTick, true)).toEqual("2020/04/11");
+  });
+});
+
 describe("formatNumber with significantDigitLabels enabled", () => {
   it("does not add significant digit label when largestTick is < 1000", () => {
     const largestTick = 500;
-    expect(TickFormatter.formatNumber(100, largestTick, true)).toEqual("100");
-    expect(TickFormatter.formatNumber(0.5, largestTick, true)).toEqual("0.5");
+    expect(TickFormatter.format(100, largestTick, true)).toEqual("100");
+    expect(TickFormatter.format(0.5, largestTick, true)).toEqual("0.5");
   });
 
   it("adds K when largestTick is greater than 1K", () => {
     const largestTick = 1500;
-    expect(TickFormatter.formatNumber(100, largestTick, true)).toEqual("0.1K");
-    expect(TickFormatter.formatNumber(1800, largestTick, true)).toEqual("1.8K");
-    expect(TickFormatter.formatNumber(2000, largestTick, true)).toEqual("2K");
-    expect(TickFormatter.formatNumber(999999, largestTick, true)).toEqual(
-      "999.999K"
-    );
+    expect(TickFormatter.format(100, largestTick, true)).toEqual("0.1K");
+    expect(TickFormatter.format(1800, largestTick, true)).toEqual("1.8K");
+    expect(TickFormatter.format(2000, largestTick, true)).toEqual("2K");
+    expect(TickFormatter.format(999999, largestTick, true)).toEqual("999.999K");
   });
 
   it("adds M when largestTick is greater than 1M", () => {
     const largestTick = 1500000;
-    expect(TickFormatter.formatNumber(1500000, largestTick, true)).toEqual(
-      "1.5M"
-    );
+    expect(TickFormatter.format(1500000, largestTick, true)).toEqual("1.5M");
   });
 
   it("adds B when largestTick is greater than 1B", () => {
     const largestTick = 1000000000;
-    expect(TickFormatter.formatNumber(1000000000, largestTick, true)).toEqual(
-      "1B"
-    );
+    expect(TickFormatter.format(1000000000, largestTick, true)).toEqual("1B");
   });
 
   it("handles negative values by taking the absolute value", () => {
     const largestTick = -1500;
-    expect(TickFormatter.formatNumber(1000, largestTick, true)).toEqual("1K");
-    expect(TickFormatter.formatNumber(-1000, largestTick, true)).toEqual("-1K");
+    expect(TickFormatter.format(1000, largestTick, true)).toEqual("1K");
+    expect(TickFormatter.format(-1000, largestTick, true)).toEqual("-1K");
   });
 
   it("does not add label when value is zero", () => {
     const largestTick = 1000;
-    expect(TickFormatter.formatNumber(0, largestTick, true)).toEqual("0");
+    expect(TickFormatter.format(0, largestTick, true)).toEqual("0");
   });
 });
 
 describe("formatNumber with significantDigitLabels disabled", () => {
   it("returns number in locale string", () => {
     const largestTick = 25000;
-    expect(TickFormatter.formatNumber(25000, largestTick, false)).toEqual(
-      "25,000"
-    );
+    expect(TickFormatter.format(25000, largestTick, false)).toEqual("25,000");
   });
 });


### PR DESCRIPTION
## Description

Added significant digit labels to LineChart, ColumnChart, BarChart and PartToWhole widgets. Refactored the code that calculates the largest tick into its own hook to avoid repeating it on every component. 

## Testing

You can test on my personal environment by enabling/disabling Significant Digit Labels, or checking this dashboard that has significant digit labels enabled (K, M, etc). https://fdingler.badger.wwps.aws.dev/admin/dashboard/266f1ccf-9e8a-400b-9f5b-3865d40cf0ff

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
