### PR TITLE
GTT-1040 Add significant digit labels to metrics widget

### DIFF
--- a/frontend/src/components/MetricsCardGroup.tsx
+++ b/frontend/src/components/MetricsCardGroup.tsx
@@ -2,11 +2,13 @@ import React from "react";
 import { Metric } from "../models";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowUp, faArrowDown } from "@fortawesome/free-solid-svg-icons";
+import TickFormatter from "../services/TickFormatter";
 import dayjs from "dayjs";
 
 interface Props {
   metrics: Array<Metric>;
   metricPerRow: number;
+  significantDigitLabels: boolean;
 }
 
 function MetricsCardGroup(props: Props) {
@@ -23,7 +25,12 @@ function MetricsCardGroup(props: Props) {
     }
     rows.push(row);
   }
-  return props.metrics.length ? (
+
+  if (!props.metrics.length) {
+    return null;
+  }
+
+  return (
     <div className="grid-col">
       {rows.map((row, i) => {
         return (
@@ -47,11 +54,15 @@ function MetricsCardGroup(props: Props) {
                         title={metric.value ? metric.value.toString() : ""}
                       >
                         <h1 className="margin-0 text-no-wrap overflow-hidden text-overflow-ellipsis">
-                          {metric.value}
+                          {TickFormatter.format(
+                            Number(metric.value),
+                            Number(metric.value),
+                            props.significantDigitLabels
+                          )}
                         </h1>
                       </div>
                       <div className="flex-2">
-                        {metric.changeOverTime ? (
+                        {metric.changeOverTime && (
                           <div className="margin-top-05">
                             <FontAwesomeIcon
                               size="xs"
@@ -64,8 +75,6 @@ function MetricsCardGroup(props: Props) {
                             />
                             {metric.changeOverTime.substring(1)}
                           </div>
-                        ) : (
-                          ""
                         )}
                       </div>
                       <div className="flex-2">
@@ -90,7 +99,7 @@ function MetricsCardGroup(props: Props) {
         );
       })}
     </div>
-  ) : null;
+  );
 }
 
 export default MetricsCardGroup;

--- a/frontend/src/components/MetricsWidget.tsx
+++ b/frontend/src/components/MetricsWidget.tsx
@@ -6,17 +6,25 @@ type Props = {
   title: string;
   metrics: Array<Metric>;
   metricPerRow: number;
+  significantDigitLabels: boolean;
 };
 
-const MetricsWidget = (props: Props) => {
-  const { title, metrics, metricPerRow } = props;
-
+const MetricsWidget = ({
+  title,
+  metrics,
+  metricPerRow,
+  significantDigitLabels,
+}: Props) => {
   return (
     <div>
       <h2 className="margin-top-4">{title}</h2>
       {metrics.length ? (
         <div>
-          <MetricsCardGroup metrics={metrics} metricPerRow={metricPerRow} />
+          <MetricsCardGroup
+            metrics={metrics}
+            metricPerRow={metricPerRow}
+            significantDigitLabels={significantDigitLabels}
+          />
         </div>
       ) : (
         ""

--- a/frontend/src/components/WidgetRender.tsx
+++ b/frontend/src/components/WidgetRender.tsx
@@ -74,6 +74,7 @@ function WidgetWithDataset({ widget }: Props) {
           title={metricsWidget.showTitle ? metricsWidget.content.title : ""}
           metrics={json}
           metricPerRow={metricsWidget.content.oneMetricPerRow ? 1 : 3}
+          significantDigitLabels={metricsWidget.content.significantDigitLabels}
         />
       );
     default:

--- a/frontend/src/components/__tests__/MetricsWidget.test.tsx
+++ b/frontend/src/components/__tests__/MetricsWidget.test.tsx
@@ -5,7 +5,12 @@ import MetricsWidget from "../MetricsWidget";
 
 test("renders the title and summary of the metrics preview component", async () => {
   const { getByText } = render(
-    <MetricsWidget title="test title" metrics={[]} metricPerRow={3} />,
+    <MetricsWidget
+      title="test title"
+      metrics={[]}
+      metricPerRow={3}
+      significantDigitLabels={true}
+    />,
     { wrapper: MemoryRouter }
   );
   expect(getByText("test title")).toBeInTheDocument();
@@ -17,6 +22,7 @@ test("metrics preview should match snapshot", async () => {
       title="test title"
       metrics={[{ title: "test title", value: 1 }]}
       metricPerRow={3}
+      significantDigitLabels={true}
     />,
     { wrapper: MemoryRouter }
   );

--- a/frontend/src/containers/EditMetrics.tsx
+++ b/frontend/src/containers/EditMetrics.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useHistory, useParams } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import {
   Metric,
   LocationState,
@@ -23,6 +24,7 @@ interface FormValues {
   title: string;
   showTitle: boolean;
   oneMetricPerRow: boolean;
+  significantDigitLabels: boolean;
 }
 
 interface PathParams {
@@ -31,6 +33,7 @@ interface PathParams {
 }
 
 function EditMetrics() {
+  const { t } = useTranslation();
   const history = useHistory<LocationState>();
   const { state } = history.location;
   const { dashboardId, widgetId } = useParams<PathParams>();
@@ -39,22 +42,20 @@ function EditMetrics() {
     register,
     errors,
     handleSubmit,
-    getValues,
     reset,
+    watch,
   } = useForm<FormValues>();
+
   const [fileLoading, setFileLoading] = useState(false);
   const [editingWidget, setEditingWidget] = useState(false);
   const { widget, currentJson } = useWidget(dashboardId, widgetId);
-
-  const [title, setTitle] = useState("");
-  const [showTitle, setShowTitle] = useState(false);
-  const [oneMetricPerRow, setOneMetricPerRow] = useState(false);
   const [metrics, setMetrics] = useState<Array<Metric>>([]);
-  const {
-    fullPreview,
-    fullPreviewToggle,
-    fullPreviewButton,
-  } = useFullPreview();
+  const { fullPreview, fullPreviewButton } = useFullPreview();
+
+  const title = watch("title");
+  const showTitle = watch("showTitle");
+  const oneMetricPerRow = watch("oneMetricPerRow");
+  const significantDigitLabels = watch("significantDigitLabels");
 
   useEffect(() => {
     if (widget && currentJson) {
@@ -62,22 +63,29 @@ function EditMetrics() {
         state && state.metricTitle !== undefined
           ? state.metricTitle
           : widget.content.title;
+
       const showTitle =
         state && state.showTitle !== undefined
           ? state.showTitle
           : widget.showTitle;
+
       const oneMetricPerRow =
         state && state.oneMetricPerRow !== undefined
           ? state.oneMetricPerRow
           : widget.content.oneMetricPerRow;
+
+      const significantDigitLabels =
+        state && state.significantDigitLabels !== undefined
+          ? state.significantDigitLabels
+          : widget.content.significantDigitLabels;
+
       reset({
         title,
         showTitle,
         oneMetricPerRow,
+        significantDigitLabels,
       });
-      setTitle(title);
-      setShowTitle(showTitle);
-      setOneMetricPerRow(oneMetricPerRow);
+
       setMetrics(
         state && state.metrics
           ? [...state.metrics]
@@ -125,6 +133,7 @@ function EditMetrics() {
           s3Key: newDataset.s3Key,
           oneMetricPerRow: values.oneMetricPerRow,
           datasetType: DatasetType.CreateNew,
+          significantDigitLabels: values.significantDigitLabels,
         },
         widget.updatedAt
       );
@@ -192,13 +201,6 @@ function EditMetrics() {
     setMetrics(widgets);
   };
 
-  const onFormChange = () => {
-    const { title, showTitle, oneMetricPerRow } = getValues();
-    setTitle(title);
-    setShowTitle(showTitle);
-    setOneMetricPerRow(oneMetricPerRow);
-  };
-
   const crumbs = [
     {
       label: "Dashboards",
@@ -238,7 +240,6 @@ function EditMetrics() {
           <div className="grid-col-6" hidden={fullPreview}>
             <form
               className="usa-form usa-form--large"
-              onChange={onFormChange}
               onSubmit={handleSubmit(onSubmit)}
             >
               <fieldset className="usa-fieldset">
@@ -267,6 +268,27 @@ function EditMetrics() {
                     htmlFor="display-title"
                   >
                     Show title on dashboard
+                  </label>
+                </div>
+
+                <label className="usa-label text-bold">
+                  {t("MetricsOptionsLabel")}
+                </label>
+                <div className="usa-hint">{t("MetricsOptionsDescription")}</div>
+                <div className="usa-checkbox">
+                  <input
+                    className="usa-checkbox__input"
+                    id="significantDigitLabels"
+                    type="checkbox"
+                    name="significantDigitLabels"
+                    defaultChecked={false}
+                    ref={register()}
+                  />
+                  <label
+                    className="usa-checkbox__label"
+                    htmlFor="significantDigitLabels"
+                  >
+                    {t("SignificantDigitLabels")}
                   </label>
                 </div>
 
@@ -308,6 +330,7 @@ function EditMetrics() {
               title={showTitle ? title : ""}
               metrics={metrics}
               metricPerRow={oneMetricPerRow ? 1 : 3}
+              significantDigitLabels={significantDigitLabels}
             />
           </div>
         </div>

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -103,5 +103,7 @@
   "ChartOptionsLabel": "Chart Options",
   "ChartOptionsDescription": "Format your chart",
   "TableOptionsLabel": "Table Options",
-  "TableOptionsDescription": "Format your table"
+  "TableOptionsDescription": "Format your table",
+  "MetricsOptionsLabel": "Metrics Options",
+  "MetricsOptionsDescription": "Format your metrics"
 }

--- a/frontend/src/models/index.tsx
+++ b/frontend/src/models/index.tsx
@@ -262,6 +262,7 @@ export type LocationState = {
   position?: number;
   showTitle?: boolean;
   oneMetricPerRow?: boolean;
+  significantDigitLabels?: boolean;
   metricTitle?: string;
   origin?: string;
   json?: Array<any>;


### PR DESCRIPTION
## Description

Added support for significant digit labels to the Metrics widgets. 

## Testing

You can test in my personal environment by verifying that the Metrics content items display the significant digit labels `K`, `M` and `B`. https://fdingler.badger.wwps.aws.dev/admin/dashboard/266f1ccf-9e8a-400b-9f5b-3865d40cf0ff 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
