### PR TITLE
fix: Part-to-whole is broken on very small screens

### DIFF
--- a/frontend/src/components/PartWholeChartWidget.tsx
+++ b/frontend/src/components/PartWholeChartWidget.tsx
@@ -116,6 +116,7 @@ const PartWholeChartWidget = (props: Props) => {
     const minHeight = 250;
     const minHeightMobile = 300;
     const maxHeight = 500;
+    const pixelsByPart = 28;
 
     if (!data || !data.length) {
       return minHeight;
@@ -127,7 +128,9 @@ const PartWholeChartWidget = (props: Props) => {
         return minHeightMobile;
       } else {
         // For every part in the chart, add 20 pixels
-        return minHeightMobile + Math.min(maxHeight, data.length * 20);
+        return (
+          minHeightMobile + Math.min(maxHeight, data.length * pixelsByPart)
+        );
       }
     }
 

--- a/frontend/src/components/PartWholeChartWidget.tsx
+++ b/frontend/src/components/PartWholeChartWidget.tsx
@@ -8,7 +8,7 @@ import {
   ResponsiveContainer,
   CartesianGrid,
 } from "recharts";
-import { useColors } from "../hooks";
+import { useColors, useWindowSize } from "../hooks";
 import TickFormatter from "../services/TickFormatter";
 import MarkdownRender from "./MarkdownRender";
 
@@ -29,6 +29,7 @@ const PartWholeChartWidget = (props: Props) => {
   const [partsHover, setPartsHover] = useState(null);
   const [hiddenParts, setHiddenParts] = useState<Array<string>>([]);
   const [xAxisLargestValue, setXAxisLargestValue] = useState(0);
+  const windowSize = useWindowSize();
 
   const partWholeData = useRef<Array<object>>([]);
   const partWholeParts = useRef<Array<string>>([]);
@@ -111,6 +112,28 @@ const PartWholeChartWidget = (props: Props) => {
     );
   };
 
+  const calculateChartHeight = (): number => {
+    const minHeight = 250;
+    const minHeightMobile = 300;
+    const maxHeight = 500;
+
+    if (!data || !data.length) {
+      return minHeight;
+    }
+
+    // Handle very small screens where width is less than 300 pixels
+    if (windowSize.width <= 300) {
+      if (data.length < 5) {
+        return minHeightMobile;
+      } else {
+        // For every part in the chart, add 20 pixels
+        return minHeightMobile + Math.min(maxHeight, data.length * 20);
+      }
+    }
+
+    return data.length < 15 ? minHeight : maxHeight;
+  };
+
   return (
     <div>
       <h2 className={`margin-bottom-${props.summaryBelow ? "4" : "1"}`}>
@@ -123,10 +146,7 @@ const PartWholeChartWidget = (props: Props) => {
         />
       )}
       {partWholeData.current.length && (
-        <ResponsiveContainer
-          width="100%"
-          height={data && data.length > 15 ? 600 : 250}
-        >
+        <ResponsiveContainer width="100%" height={calculateChartHeight()}>
           <BarChart
             className="part-to-whole-chart"
             data={partWholeData.current}

--- a/frontend/src/hooks/__mocks__/index.tsx
+++ b/frontend/src/hooks/__mocks__/index.tsx
@@ -545,3 +545,12 @@ export function useTableMetadata() {
     largestTickByColumn,
   };
 }
+
+export function useWindowSize() {
+  const [size] = useState({
+    width: 1024,
+    height: 768,
+  });
+
+  return size;
+}

--- a/frontend/src/hooks/chart-hooks.ts
+++ b/frontend/src/hooks/chart-hooks.ts
@@ -65,3 +65,29 @@ export function useXAxisMetadata(
     xAxisLargestValue,
   };
 }
+
+type UseWindowSizeHook = {
+  width: number;
+  height: number;
+};
+
+export function useWindowSize(): UseWindowSizeHook {
+  const [size, setSize] = useState({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  });
+
+  React.useEffect(() => {
+    function handleResize() {
+      setSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    }
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return size;
+}

--- a/frontend/src/hooks/index.tsx
+++ b/frontend/src/hooks/index.tsx
@@ -17,7 +17,11 @@ import { useImage } from "./image-hooks";
 import { useLogo } from "./logo-hooks";
 import { useDatasets } from "./dataset-hooks";
 import { useFullPreview } from "./dashboard-preview-hooks";
-import { useYAxisMetadata, useXAxisMetadata } from "./chart-hooks";
+import {
+  useYAxisMetadata,
+  useXAxisMetadata,
+  useWindowSize,
+} from "./chart-hooks";
 import { useTableMetadata } from "./table-hooks";
 
 /**
@@ -57,4 +61,5 @@ export {
   useYAxisMetadata,
   useXAxisMetadata,
   useTableMetadata,
+  useWindowSize,
 };


### PR DESCRIPTION
## Description

Making the height of the `Part to whole chart` be dynamic depending on the amount of parts in the chart and depending on the screen size. I wrote a hook to get the window width and heights as it gets resized. 

Waiting for Jason and Andrew to confirm that they are okay with this fix. 

## Testing

Verified that all part-to-whole charts in this dashboard are displayed correctly in a smartphone: https://fdingler.badger.wwps.aws.dev/homenick-and-sons . 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
