### PR TITLE
GTT-1177 : Address AppSec findings

### DIFF
--- a/backend/src/lambda/api.ts
+++ b/backend/src/lambda/api.ts
@@ -4,6 +4,25 @@ import api from "../lib/api";
 
 const server = serverlessExpress.createServer(api);
 
+function logRequest(event: APIGatewayProxyEvent, context: Context) {
+  // Don't log sensitive data such as API body and authorization headers
+  let eventToLog = { ...event };
+  if (eventToLog) {
+    if (eventToLog.resource.includes("ingestapi")) {
+      eventToLog = { ...eventToLog, body: null };
+    }
+    if (eventToLog.headers?.Authorization) {
+      eventToLog.headers.Authorization = "<Redacted>";
+    }
+    if (eventToLog.multiValueHeaders?.Authorization) {
+      eventToLog.multiValueHeaders.Authorization = ["<Redacted>"];
+    }
+  }
+
+  console.log("Event=", JSON.stringify(eventToLog));
+  console.log("Context=", JSON.stringify(context));
+}
+
 /**
  * Lambda entry handler for HTTP requests
  * coming from API Gateway.
@@ -11,13 +30,7 @@ const server = serverlessExpress.createServer(api);
  * @param event
  */
 export const handler = (event: APIGatewayProxyEvent, context: Context) => {
-  let eventToLog = { ...event };
-  if (eventToLog && eventToLog.resource.includes("ingestapi")) {
-    eventToLog = { ...eventToLog, body: null };
-  }
-
-  console.log("Event=", JSON.stringify(eventToLog));
-  console.log("Context=", JSON.stringify(context));
+  logRequest(event, context);
 
   return serverlessExpress.proxy(server, event, context);
 };

--- a/backend/src/lib/controllers/user-ctrl.ts
+++ b/backend/src/lib/controllers/user-ctrl.ts
@@ -50,7 +50,10 @@ async function addUsers(req: Request, res: Response) {
     );
     return res.send();
   } catch (error) {
-    res.status(500).send(error);
+    logger.error(error);
+    if (error.code === "UsernameExistsException")
+      res.status(400).send("Invalid input");
+    else res.status(400).send(error);
   }
 }
 

--- a/backend/src/lib/controllers/user-ctrl.ts
+++ b/backend/src/lib/controllers/user-ctrl.ts
@@ -50,10 +50,9 @@ async function addUsers(req: Request, res: Response) {
     );
     return res.send();
   } catch (error) {
+    // Don't return error which may reveal that user already exists
     logger.error(error);
-    if (error.code === "UsernameExistsException")
-      res.status(400).send("Invalid input");
-    else res.status(400).send(error);
+    res.status(400).send("Bad Request");
   }
 }
 
@@ -124,7 +123,9 @@ async function changeRole(req: Request, res: Response) {
     await repo.changeRole(usernames, role);
     return res.send();
   } catch (error) {
-    res.status(500).send(error);
+    // Don't return error which may reveal that user doesn't exists
+    logger.error(error);
+    res.status(400).send("Bad Request");
   }
 }
 


### PR DESCRIPTION
## Description

- Redact sensitive information when logging API requests
- Don't return HTTP 500 error indicating UsernameExistsException in POST /user call

## Testing

Verified CloudWatch logs for API calls made by the front end, and also calls to  /ingestapi, don't contain the Authorization token

Verified that a call to POST /user to create a duplicate user doesn't return a 500 error that reveals the user already exists

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
