### PR TITLE
GTT-1077 Access denied screen

### DIFF
--- a/backend/src/lib/api/settings-api.ts
+++ b/backend/src/lib/api/settings-api.ts
@@ -9,12 +9,7 @@ import rbac from "./middleware/rbac";
 const router = Router();
 router.use(auth);
 
-router.get(
-  "/",
-  rbac(Role.Admin, Role.Editor),
-  errorHandler(SettingsCtrl.getSettings)
-);
-
+router.get("/", errorHandler(SettingsCtrl.getSettings));
 router.put("/", rbac(Role.Admin), errorHandler(SettingsCtrl.updateSettings));
 
 router.get(

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -58,6 +58,7 @@ import BrandingAndStylingSettings from "./containers/BrandingAndStylingSettings"
 import EditLogo from "./containers/EditLogo";
 import UserStatus from "./containers/UserStatus";
 import ChooseStaticDataset from "./containers/ChooseStaticDataset";
+import AccessDenied from "./containers/AccessDenied";
 
 interface AppRoute {
   path: string;
@@ -245,6 +246,11 @@ const routes: Array<AppRoute> = [
   {
     path: "/admin/users/changerole",
     component: ChangeRole,
+  },
+  {
+    path: "/403/access-denied",
+    component: AccessDenied,
+    public: true,
   },
   {
     path: "/:friendlyURL",

--- a/frontend/src/containers/AccessDenied.tsx
+++ b/frontend/src/containers/AccessDenied.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
+import EnvConfig from "../services/EnvConfig";
+import Button from "../components/Button";
+import CardGroup from "../components/CardGroup";
+
+const { Card, CardFooter, CardBody } = CardGroup;
+
+function AccessDenied() {
+  const { t } = useTranslation();
+
+  const onRequestAccess = () => {
+    window.location.href = "mailto:".concat(EnvConfig.contactEmail);
+  };
+
+  const onViewPublicWebsite = () => {
+    const win = window.open("/", "_blank");
+    if (!!win) {
+      win.focus();
+    }
+  };
+
+  return (
+    <div className="usa-prose">
+      <div className="grid-row">
+        <div className="grid-col-12 tablet:grid-col-8">
+          <h1 className="font-sans-3xl">{t("WelcomeToPDoA")}</h1>
+        </div>
+      </div>
+      <div className="grid-row">
+        <CardGroup>
+          <Card title={t("AccessDeniedScreen.CardTitle")} col={7}>
+            <CardBody>
+              <p>
+                {t("AccessDeniedScreen.Message")}
+                <br />
+                <br />
+              </p>
+            </CardBody>
+            <CardFooter>
+              <Button type="button" variant="base" onClick={onRequestAccess}>
+                {t("AccessDeniedScreen.RequestAccessButton")}
+              </Button>
+            </CardFooter>
+          </Card>
+        </CardGroup>
+      </div>
+      <hr />
+      <div className="grid-row text-center">
+        <div className="grid-col">
+          <p className="font-sans-md">
+            {t("PDoASite")} <br /> {t("WantToViewPublishedSite")}
+          </p>
+          <Button type="button" variant="outline" onClick={onViewPublicWebsite}>
+            {t("ViewPublishedSite")}{" "}
+            <FontAwesomeIcon size="sm" icon={faExternalLinkAlt} />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AccessDenied;

--- a/frontend/src/containers/__tests__/AccessDenied.test.tsx
+++ b/frontend/src/containers/__tests__/AccessDenied.test.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import AccessDenied from "../AccessDenied";
+
+beforeEach(() => {
+  render(<AccessDenied />, { wrapper: MemoryRouter });
+});
+
+test("renders a welcome message", async () => {
+  expect(
+    screen.getByText("Welcome to the Performance Dashboard")
+  ).toBeInTheDocument();
+});
+
+test("renders a request access button", async () => {
+  expect(
+    screen.getByRole("button", { name: "Request access" })
+  ).toBeInTheDocument();
+});

--- a/frontend/src/context/SettingsProvider.tsx
+++ b/frontend/src/context/SettingsProvider.tsx
@@ -22,6 +22,10 @@ const defaultSettings: Settings = {
     plural: "Topic Areas",
   },
   customLogoS3Key: undefined,
+  colors: {
+    primary: "#2491ff",
+    secondary: "#54278f",
+  },
 };
 
 interface SettingsContextProps {

--- a/frontend/src/layouts/Admin.tsx
+++ b/frontend/src/layouts/Admin.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from "react";
-import { Link } from "react-router-dom";
+import { Link, Redirect } from "react-router-dom";
 import Auth from "@aws-amplify/auth";
 import { useSettings, useCurrentAuthenticatedUser } from "../hooks";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -7,8 +7,6 @@ import { faWindowClose } from "@fortawesome/free-solid-svg-icons";
 import Footer from "./Footer";
 import Logo from "../components/Logo";
 import Header from "../components/Header";
-import Alert from "../components/Alert";
-import EnvConfig from "../services/EnvConfig";
 
 interface LayoutProps {
   children: ReactNode;
@@ -116,30 +114,7 @@ function AdminLayout(props: LayoutProps) {
             <div className="grid-container">{props.children}</div>
           </>
         ) : (
-          <>
-            <div className="text-center margin-top-5 grid-container">
-              <Alert
-                type="warning"
-                hideIcon
-                slim
-                message={
-                  <div>
-                    You haven't been granted access. You can{" "}
-                    <a
-                      href={`mailto:${EnvConfig.contactEmail}?subject=Performance Dashboard Assistance - Request Access`}
-                      className="text-base"
-                    >
-                      contact support
-                    </a>{" "}
-                    to request the Editor or Admin role or view{" "}
-                    <a href="/" className="text-base">
-                      published dashboards
-                    </a>
-                  </div>
-                }
-              ></Alert>
-            </div>
-          </>
+          <Redirect to="/403/access-denied" />
         )}
       </main>
       <Footer />

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -207,5 +207,10 @@
     "ChartDescription": "Display data as a visualization, including line, bar, column and part-to-whole charts.",
     "TableDescription": "Display data formatted in rows and columns.",
     "ImageDescription": "Upload an image to display."
+  },
+  "AccessDeniedScreen": {
+    "RequestAccessButton": "Request access",
+    "CardTitle": "Request access to create dashboards",
+    "Message": "You don't have access. Request access from the admin(s) and you will receive an email when your access is granted."
   }
 }


### PR DESCRIPTION
## Description

Created an access denied screen that the user is redirected to in the case where they don't have a role assigned. In order for this to work, I had to change the backend endpoint to fetch settings to avoid requiring a role. Any authenticated user will be able to fetch settings regardless of the role. Settings are necessary to load elements of the website. 

## Testing

Created a user in Cognito manually without assigning a role to it. Verified that logging in with that user takes me to the AccessDenied page. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
