### PR TITLE
fix: Users were always redirected to access denied

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -250,7 +250,6 @@ const routes: Array<AppRoute> = [
   {
     path: "/403/access-denied",
     component: AccessDenied,
-    public: true,
   },
   {
     path: "/:friendlyURL",

--- a/frontend/src/hooks/__mocks__/index.tsx
+++ b/frontend/src/hooks/__mocks__/index.tsx
@@ -454,6 +454,7 @@ export function useCurrentAuthenticatedUser() {
     isAdmin: roles.isAdmin,
     isEditor: roles.isEditor,
     isPublisher: roles.isPublisher,
+    hasRole: true,
   };
 }
 

--- a/frontend/src/hooks/user-hooks.ts
+++ b/frontend/src/hooks/user-hooks.ts
@@ -9,11 +9,13 @@ type CurrentUserHook = {
   isEditor: boolean;
   isPublisher: boolean;
   isFederatedId: boolean;
+  hasRole: boolean;
 };
 
 export function useCurrentAuthenticatedUser(): CurrentUserHook {
   const [username, setUser] = useState<string>("");
   const [federated, setFederated] = useState(false);
+  const [hasRole, setHasRole] = useState(true);
   const [roles, setRoles] = useState<{
     isAdmin: boolean;
     isEditor: boolean;
@@ -46,6 +48,8 @@ export function useCurrentAuthenticatedUser(): CurrentUserHook {
         isEditor: userRoles.includes(UserRoles.Editor),
         isPublisher: userRoles.includes(UserRoles.Publisher),
       });
+    } else {
+      setHasRole(false);
     }
   }, []);
 
@@ -59,6 +63,7 @@ export function useCurrentAuthenticatedUser(): CurrentUserHook {
     isFederatedId: federated,
     isEditor: roles.isEditor,
     isPublisher: roles.isPublisher,
+    hasRole,
   };
 }
 

--- a/frontend/src/layouts/Admin.tsx
+++ b/frontend/src/layouts/Admin.tsx
@@ -18,6 +18,7 @@ function AdminLayout(props: LayoutProps) {
     isAdmin,
     isFederatedId,
     isEditor,
+    hasRole,
   } = useCurrentAuthenticatedUser();
   const { settings } = useSettings();
 
@@ -109,13 +110,8 @@ function AdminLayout(props: LayoutProps) {
         </div>
       </Header>
       <main className="padding-y-3">
-        {isAdmin || isEditor ? (
-          <>
-            <div className="grid-container">{props.children}</div>
-          </>
-        ) : (
-          <Redirect to="/403/access-denied" />
-        )}
+        {!hasRole && <Redirect to="/403/access-denied" />}
+        <div className="grid-container">{props.children}</div>
       </main>
       <Footer />
     </>


### PR DESCRIPTION
## Description

Bug fix: Added a new variable to the response of the `useCurrentAuthUser` hook that will tell us wether the user has a role assigned or not. Originally I was redirecting the user to the Access Denied screen by looking at the `isAdmin` or `isEditor` variables, but that was a mistake because those variables are always initialized to false, causing the redirect to always happen. 

## Testing

Tested in my personal environment and verified that users with a role can use the Admin UI. Also verified users without a role are redirected to the Access Denied screen.  

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
