### PR TITLE
GTT-1081 Add support for data table on every chart widget

### DIFF
--- a/frontend/src/components/BarChartWidget.tsx
+++ b/frontend/src/components/BarChartWidget.tsx
@@ -16,6 +16,7 @@ import { useColors, useXAxisMetadata } from "../hooks";
 import UtilsService from "../services/UtilsService";
 import TickFormatter from "../services/TickFormatter";
 import MarkdownRender from "./MarkdownRender";
+import DataTable from "./DataTable";
 
 type Props = {
   title: string;
@@ -163,8 +164,8 @@ const BarChartWidget = (props: Props) => {
               <Legend
                 verticalAlign="top"
                 onClick={toggleBars}
-                onMouseLeave={(e) => setBarsHover(null)}
-                onMouseEnter={(e) => setBarsHover(e.dataKey)}
+                onMouseLeave={() => setBarsHover(null)}
+                onMouseEnter={(e: any) => setBarsHover(e.dataKey)}
               />
             )}
             {props.bars.length &&
@@ -205,6 +206,11 @@ const BarChartWidget = (props: Props) => {
           className="usa-prose margin-top-1 margin-bottom-0 chartSummaryBelow"
         />
       )}
+      <DataTable
+        rows={data || []}
+        columns={bars}
+        columnsMetadata={props.columnsMetadata}
+      />
     </div>
   );
 };

--- a/frontend/src/components/ColumnChartWidget.tsx
+++ b/frontend/src/components/ColumnChartWidget.tsx
@@ -16,6 +16,7 @@ import { useColors, useYAxisMetadata } from "../hooks";
 import UtilsService from "../services/UtilsService";
 import TickFormatter from "../services/TickFormatter";
 import MarkdownRender from "./MarkdownRender";
+import DataTable from "./DataTable";
 
 type Props = {
   title: string;
@@ -178,8 +179,8 @@ const ColumnChartWidget = (props: Props) => {
               <Legend
                 verticalAlign="top"
                 onClick={toggleColumns}
-                onMouseLeave={(e) => setColumnsHover(null)}
-                onMouseEnter={(e) => setColumnsHover(e.dataKey)}
+                onMouseLeave={() => setColumnsHover(null)}
+                onMouseEnter={(e: any) => setColumnsHover(e.dataKey)}
               />
             )}
             {props.columns.length &&
@@ -220,6 +221,11 @@ const ColumnChartWidget = (props: Props) => {
           className="usa-prose margin-top-1 margin-bottom-0 chartSummaryBelow"
         />
       )}
+      <DataTable
+        rows={data || []}
+        columns={columns}
+        columnsMetadata={props.columnsMetadata}
+      />
     </div>
   );
 };

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -1,0 +1,84 @@
+import React, { useState, useMemo } from "react";
+import { ColumnMetadata } from "../models";
+import { useTranslation } from "react-i18next";
+import UtilsService from "../services/UtilsService";
+import TickFormatter from "../services/TickFormatter";
+import Button from "./Button";
+import Table from "./Table";
+
+interface Props {
+  rows: any[];
+  columns: string[];
+  columnsMetadata?: ColumnMetadata[];
+}
+
+function DataTable({ rows, columns, columnsMetadata }: Props) {
+  const { t } = useTranslation();
+  const [showDataTable, setShowDataTable] = useState(false);
+
+  const tableRows = useMemo(() => rows, [rows]);
+  const tableColumns = useMemo(
+    () =>
+      columns.map((header) => {
+        return {
+          Header: header,
+          id: header,
+          accessor: header,
+          minWidth: 150,
+          Cell: (props: any) => {
+            const row = props.row.original;
+
+            // Check if there is metadata for this column
+            let columnMetadata;
+            if (columnsMetadata) {
+              columnMetadata = columnsMetadata.find(
+                (cm) => cm.columnName === header
+              );
+            }
+
+            return !UtilsService.isCellEmpty(row[header])
+              ? TickFormatter.format(row[header], 0, false, columnMetadata)
+              : "-";
+          },
+        };
+      }),
+    [columns, columnsMetadata]
+  );
+
+  return (
+    <>
+      <div className="text-right">
+        {!showDataTable && (
+          <Button
+            type="button"
+            variant="unstyled"
+            onClick={() => setShowDataTable(true)}
+            className="margin-top-1"
+          >
+            {t("ShowDataTableButton")}
+          </Button>
+        )}
+        {showDataTable && (
+          <Button
+            type="button"
+            variant="unstyled"
+            onClick={() => setShowDataTable(false)}
+            className="margin-top-1"
+          >
+            {t("HideDataTableButton")}
+          </Button>
+        )}
+      </div>
+      {showDataTable && (
+        <Table
+          selection="none"
+          rows={tableRows}
+          disablePagination={true}
+          columns={tableColumns}
+        />
+      )}
+    </>
+  );
+}
+
+export default DataTable;

--- a/frontend/src/components/LineChartWidget.tsx
+++ b/frontend/src/components/LineChartWidget.tsx
@@ -15,6 +15,7 @@ import { useColors, useYAxisMetadata } from "../hooks";
 import UtilsService from "../services/UtilsService";
 import TickFormatter from "../services/TickFormatter";
 import MarkdownRender from "./MarkdownRender";
+import DataTable from "./DataTable";
 
 type Props = {
   title: string;
@@ -177,8 +178,8 @@ const LineChartWidget = (props: Props) => {
             <Legend
               verticalAlign="top"
               onClick={toggleLines}
-              onMouseLeave={(e) => setLinesHover(null)}
-              onMouseEnter={(e) => setLinesHover(e.dataKey)}
+              onMouseLeave={() => setLinesHover(null)}
+              onMouseEnter={(e: any) => setLinesHover(e.dataKey)}
             />
             {props.lines.length &&
               props.lines.slice(1).map((line, index) => {
@@ -204,6 +205,11 @@ const LineChartWidget = (props: Props) => {
           className="usa-prose margin-top-1 margin-bottom-0 chartSummaryBelow"
         />
       )}
+      <DataTable
+        rows={data || []}
+        columns={lines}
+        columnsMetadata={props.columnsMetadata}
+      />
     </div>
   );
 };

--- a/frontend/src/components/PartWholeChartWidget.tsx
+++ b/frontend/src/components/PartWholeChartWidget.tsx
@@ -11,6 +11,7 @@ import {
 import { useColors, useWindowSize } from "../hooks";
 import TickFormatter from "../services/TickFormatter";
 import MarkdownRender from "./MarkdownRender";
+import DataTable from "./DataTable";
 
 type Props = {
   title: string;
@@ -200,8 +201,8 @@ const PartWholeChartWidget = (props: Props) => {
                 width: "100%",
               }}
               onClick={toggleParts}
-              onMouseLeave={(e) => setPartsHover(null)}
-              onMouseEnter={(e) => setPartsHover(e.dataKey)}
+              onMouseLeave={() => setPartsHover(null)}
+              onMouseEnter={(e: any) => setPartsHover(e.dataKey)}
             />
             {partWholeParts.current.map((part, index) => {
               return (
@@ -228,6 +229,7 @@ const PartWholeChartWidget = (props: Props) => {
           className="usa-prose margin-top-1 margin-bottom-0 chartSummaryBelow"
         />
       )}
+      <DataTable rows={data || []} columns={parts} />
     </div>
   );
 };

--- a/frontend/src/components/__tests__/DataTable.test.tsx
+++ b/frontend/src/components/__tests__/DataTable.test.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import {
+  ColumnDataType,
+  ColumnMetadata,
+  CurrencyDataType,
+  NumberDataType,
+} from "../../models";
+import { render, fireEvent, screen } from "@testing-library/react";
+import DataTable from "../DataTable";
+
+const columns = ["year", "sales", "revenue"];
+const rows = [
+  {
+    year: 2015,
+    sales: 10000,
+    revenue: 34,
+  },
+  {
+    year: 2016,
+    sales: 45000,
+    revenue: 74,
+  },
+  {
+    year: 2017,
+    sales: 56000,
+    revenue: 23,
+  },
+];
+
+const columnsMetadata: ColumnMetadata[] = [
+  {
+    columnName: "year",
+    dataType: ColumnDataType.Text,
+    hidden: false,
+  },
+  {
+    columnName: "sales",
+    dataType: ColumnDataType.Number,
+    numberType: NumberDataType.Currency,
+    currencyType: CurrencyDataType["Dollar $"],
+    hidden: false,
+  },
+  {
+    columnName: "revenue",
+    dataType: ColumnDataType.Number,
+    numberType: NumberDataType.Percentage,
+    hidden: false,
+  },
+];
+
+beforeEach(() => {
+  render(
+    <DataTable
+      rows={rows}
+      columns={columns}
+      columnsMetadata={columnsMetadata}
+    />
+  );
+});
+
+test("table should be hidden by default", async () => {
+  expect(screen.queryByRole("table")).not.toBeInTheDocument();
+});
+
+test("shows and hides table when button is clicked", async () => {
+  const showTableBtn = screen.getByRole("button", { name: "Show data table" });
+  fireEvent.click(showTableBtn);
+  expect(screen.getByRole("table")).toBeInTheDocument();
+
+  const hideTableBtn = screen.getByRole("button", { name: "Hide data table" });
+  fireEvent.click(hideTableBtn);
+  expect(screen.queryByRole("table")).not.toBeInTheDocument();
+});
+
+test("displays a table with values properly formatted", async () => {
+  const showTableBtn = screen.getByRole("button", { name: "Show data table" });
+  fireEvent.click(showTableBtn);
+
+  // Years should be formatted as text as per ColumnMetadata, without comma separators
+  expect(screen.getByText("2015")).toBeInTheDocument();
+  expect(screen.getByText("2016")).toBeInTheDocument();
+  expect(screen.getByText("2017")).toBeInTheDocument();
+
+  // Sales column should be formatted as currency
+  expect(screen.getByText("$10,000.00")).toBeInTheDocument();
+  expect(screen.getByText("$45,000.00")).toBeInTheDocument();
+  expect(screen.getByText("$56,000.00")).toBeInTheDocument();
+
+  // Revenue column should be formatted as percentage
+  expect(screen.getByText("34%")).toBeInTheDocument();
+  expect(screen.getByText("74%")).toBeInTheDocument();
+  expect(screen.getByText("23%")).toBeInTheDocument();
+});

--- a/frontend/src/components/__tests__/__snapshots__/VisualizeChart.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/VisualizeChart.test.tsx.snap
@@ -393,6 +393,16 @@ exports[`renders the VisualizeChart component 1`] = `
             id="title"
             style="width: 100%; height: 300px;"
           />
+          <div
+            class="text-right"
+          >
+            <button
+              class="usa-button usa-button--unstyled margin-top-1"
+              type="button"
+            >
+              Show data table
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -793,6 +803,16 @@ exports[`renders the VisualizeChart component without horizontal scrolling 1`] =
             id="title"
             style="width: 100%; height: 300px;"
           />
+          <div
+            class="text-right"
+          >
+            <button
+              class="usa-button usa-button--unstyled margin-top-1"
+              type="button"
+            >
+              Show data table
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -215,5 +215,7 @@
     "RequestAccessButton": "Request access",
     "CardTitle": "Request access to create dashboards",
     "Message": "You don't have access. Request access from the admin(s) and you will receive an email when your access is granted."
-  }
+  },
+  "ShowDataTableButton": "Show data table",
+  "HideDataTableButton": "Hide data table"
 }


### PR DESCRIPTION
## Description

Added the ability to visualize data on Charts as Table. I created a <DataTable> component that is used across all chart widgets. 

## Testing

Check this dashboard https://fdingler.badger.wwps.aws.dev/homenick-and-sons and look at the `Show data table` link on every chart. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
