### PR TITLE
GTT-1197: Suppress false cfn_nag warnings.  Enable backup for Dynamodb tables

### DIFF
--- a/cdk/lib/constructs/api.ts
+++ b/cdk/lib/constructs/api.ts
@@ -73,7 +73,8 @@ export class BackendApi extends cdk.Construct {
         rules_to_suppress: [
           {
             id: "W84",
-            reason: "CloudWatchLogs LogGroup are encrypted by default.  There are no customer requirements to use KMS in this case, and there is a business goal to keep cost low.",
+            reason:
+              "CloudWatchLogs LogGroup are encrypted by default.  There are no customer requirements to use KMS in this case, and there is a business goal to keep cost low.",
           },
         ],
       },

--- a/cdk/lib/constructs/api.ts
+++ b/cdk/lib/constructs/api.ts
@@ -8,6 +8,7 @@ import {
   PolicyDocument,
   PolicyStatement,
 } from "@aws-cdk/aws-iam";
+import { LogGroup } from "@aws-cdk/aws-logs";
 
 interface ApiProps {
   apiFunction: lambda.Function;
@@ -64,6 +65,19 @@ export class BackendApi extends cdk.Construct {
     const apigatewayLogGroup = new logs.LogGroup(scope, "ApiAccessLogs", {
       retention: logs.RetentionDays.TEN_YEARS,
     });
+    let logGroup: logs.CfnLogGroup = apigatewayLogGroup.node.findChild(
+      "Resource"
+    ) as logs.CfnLogGroup;
+    logGroup.cfnOptions.metadata = {
+      cfn_nag: {
+        rules_to_suppress: [
+          {
+            id: "W84",
+            reason: "CloudWatchLogs LogGroup are encrypted by default.  There are no customer requirements to use KMS in this case, and there is a business goal to keep cost low.",
+          },
+        ],
+      },
+    };
 
     this.api = new apigateway.RestApi(scope, "ApiGateway", {
       description: "Performance Dashboard backend API",

--- a/cdk/lib/constructs/database.ts
+++ b/cdk/lib/constructs/database.ts
@@ -27,6 +27,7 @@ export class Database extends cdk.Construct {
 
     const mainTable = new dynamodb.Table(scope, "MainTable", {
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      pointInTimeRecovery: true,
       stream: dynamodb.StreamViewType.NEW_AND_OLD_IMAGES,
       partitionKey: {
         name: "pk",
@@ -89,6 +90,7 @@ export class Database extends cdk.Construct {
 
     const auditTrailTable = new dynamodb.Table(scope, "AuditTrail", {
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      pointInTimeRecovery: true,
       partitionKey: {
         name: "pk",
         type: dynamodb.AttributeType.STRING,

--- a/cdk/lib/constructs/function-aspect.ts
+++ b/cdk/lib/constructs/function-aspect.ts
@@ -19,6 +19,7 @@ export class FunctionInvalidWarningSuppressor implements cdk.IAspect {
   /**
    * Suppress cfn_nag Warn W58: Lambda functions require permission to write CloudWatch Logs
    * Suppress cfn_nag Warn W89: Lambda functions should be deployed inside a VPC
+   * Suppress cfn_nag Warn W92: Lambda functions should define ReservedConcurrentExecutions to reserve simultaneous executions
    */
   private cfn_nag_warn(fcn: lambda.CfnFunction) {
     fcn.cfnOptions.metadata = {
@@ -32,6 +33,11 @@ export class FunctionInvalidWarningSuppressor implements cdk.IAspect {
           {
             id: "W89",
             reason: "VPCs are not used for this use case",
+          },
+          {
+            id: "W92",
+            reason:
+              "ReservedConcurrentExecutions are placed on the Lambda serving Admin traffic to guarantee the Admin console is available under load.  The Lambda serving public traffic should not have an upper bound, and our docs advises the customer to adjust the concurrency appropriately.",
           },
         ],
       },

--- a/cdk/lib/constructs/function-aspect.ts
+++ b/cdk/lib/constructs/function-aspect.ts
@@ -31,8 +31,7 @@ export class FunctionInvalidWarningSuppressor implements cdk.IAspect {
           },
           {
             id: "W89",
-            reason:
-              "VPCs are not used for this use case",
+            reason: "VPCs are not used for this use case",
           },
         ],
       },

--- a/cdk/lib/constructs/function-aspect.ts
+++ b/cdk/lib/constructs/function-aspect.ts
@@ -16,8 +16,11 @@ export class FunctionInvalidWarningSuppressor implements cdk.IAspect {
     "Backend.Functions.DynamoDBStreamProcessor.Resource",
   ];
 
-  // Suppress cfn_nag Warn W58: Lambda functions require permission to write CloudWatch Logs
-  private cfn_nag_warn_w58(fcn: lambda.CfnFunction) {
+  /**
+   * Suppress cfn_nag Warn W58: Lambda functions require permission to write CloudWatch Logs
+   * Suppress cfn_nag Warn W89: Lambda functions should be deployed inside a VPC
+   */
+  private cfn_nag_warn(fcn: lambda.CfnFunction) {
     fcn.cfnOptions.metadata = {
       cfn_nag: {
         rules_to_suppress: [
@@ -25,6 +28,11 @@ export class FunctionInvalidWarningSuppressor implements cdk.IAspect {
             id: "W58",
             reason:
               "Function has AWSLambdaBasicExecutionRole which provides write permissions to CloudWatch Logs",
+          },
+          {
+            id: "W89",
+            reason:
+              "VPCs are not used for this use case",
           },
         ],
       },
@@ -40,11 +48,11 @@ export class FunctionInvalidWarningSuppressor implements cdk.IAspect {
       const cfnFcn: lambda.CfnFunction = node.node.findChild(
         "Resource"
       ) as lambda.CfnFunction;
-      this.cfn_nag_warn_w58(cfnFcn);
+      this.cfn_nag_warn(cfnFcn);
     } else if (node instanceof lambda.CfnFunction) {
       for (let fcn of this.function_to_suppress) {
         if (node.logicalId.includes(fcn)) {
-          this.cfn_nag_warn_w58(node);
+          this.cfn_nag_warn(node);
         }
       }
     }

--- a/cdk/lib/constructs/lambdas.ts
+++ b/cdk/lib/constructs/lambdas.ts
@@ -79,6 +79,7 @@ export class LambdaFunctions extends cdk.Construct {
         tracing: lambda.Tracing.ACTIVE,
         memorySize: 256,
         timeout: cdk.Duration.seconds(10),
+        reservedConcurrentExecutions: 10,
         logRetention: logs.RetentionDays.TEN_YEARS,
         environment: {
           AUDIT_TRAIL_TABLE: props.auditTrailTable.tableName,

--- a/cdk/lib/frontend-stack.ts
+++ b/cdk/lib/frontend-stack.ts
@@ -146,6 +146,7 @@ export class FrontendStack extends cdk.Stack {
       timeout: cdk.Duration.seconds(60),
       memorySize: 128,
       logRetention: logs.RetentionDays.TEN_YEARS,
+      reservedConcurrentExecutions: 1,
       environment: {
         FRONTEND_BUCKET: this.frontendBucket.bucketName,
         REGION: cdk.Stack.of(this).region,


### PR DESCRIPTION
## Description

As part of integrating with the Solutions CI pipeline, we have to resolve the [cfn_nag](https://github.com/stelligent/cfn_nag) warnings encountered.

- W78: DynamoDB table should have backup enabled, should be set using PointInTimeRecoveryEnabled.  This was fixed
- W89: Lambda functions should be deployed inside a VPC.  This false warning was suppressed, we're not using VPCs
- W84 loudWatchLogs LogGroup should specify a KMS Key Id to encrypt the log data.  This false warning was suppressed, LogGroup are encrypted by default
- W92 Lambda functions should define ReservedConcurrentExecutions to reserve simultaneous executions.  We set the reserved concurrent executions for the dynamodb streaming Lambda to 10

## Testing

Installed to Zeta and tested

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
