### PR TITLE
GTT-1127 Fixed metrics display on mobile

### DIFF
--- a/frontend/src/components/MetricsCardGroup.tsx
+++ b/frontend/src/components/MetricsCardGroup.tsx
@@ -44,9 +44,9 @@ function MetricsCardGroup(props: Props) {
                     className={`grid-col-${12 / props.metricPerRow} padding-05`}
                     key={j}
                   >
-                    <div className="display-flex flex-column border-base-lightest border-2px height-card padding-1">
+                    <div className="display-flex flex-column border-base-lightest border-2px height-card padding-1 overflow-x-auto">
                       <div className="flex-5">
-                        <p className="text-base-darkest text-bold margin-0">
+                        <p className="text-base-darkest text-bold margin-0 text-no-wrap">
                           {metric.title}
                         </p>
                       </div>
@@ -55,7 +55,7 @@ function MetricsCardGroup(props: Props) {
                         data-position="bottom"
                         title={metric.value ? metric.value.toString() : ""}
                       >
-                        <h1 className="margin-0 text-no-wrap overflow-hidden text-overflow-ellipsis">
+                        <h1 className="margin-0 text-no-wrap">
                           {TickFormatter.format(
                             Number(metric.value),
                             Number(metric.value),

--- a/frontend/src/components/WidgetRender.tsx
+++ b/frontend/src/components/WidgetRender.tsx
@@ -73,7 +73,11 @@ function WidgetWithDataset({ widget }: Props) {
         <MetricsWidgetComponent
           title={metricsWidget.showTitle ? metricsWidget.content.title : ""}
           metrics={json}
-          metricPerRow={metricsWidget.content.oneMetricPerRow ? 1 : 3}
+          metricPerRow={
+            metricsWidget.content.oneMetricPerRow || window.innerWidth < 640
+              ? 1
+              : 3
+          }
           significantDigitLabels={metricsWidget.content.significantDigitLabels}
         />
       );

--- a/frontend/src/components/__tests__/__snapshots__/MetricsWidget.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/MetricsWidget.test.tsx.snap
@@ -22,13 +22,13 @@ exports[`metrics preview should match snapshot 1`] = `
               class="grid-col-4 padding-05"
             >
               <div
-                class="display-flex flex-column border-base-lightest border-2px height-card padding-1"
+                class="display-flex flex-column border-base-lightest border-2px height-card padding-1 overflow-x-auto"
               >
                 <div
                   class="flex-5"
                 >
                   <p
-                    class="text-base-darkest text-bold margin-0"
+                    class="text-base-darkest text-bold margin-0 text-no-wrap"
                   >
                     test title
                   </p>
@@ -39,7 +39,7 @@ exports[`metrics preview should match snapshot 1`] = `
                   title="1"
                 >
                   <h1
-                    class="margin-0 text-no-wrap overflow-hidden text-overflow-ellipsis"
+                    class="margin-0 text-no-wrap"
                   >
                     1
                   </h1>


### PR DESCRIPTION
## Description

Metrics will always display one per row on mobile. Long numbers offer a horizontal scroll instead of partially displaying with an ellipsis at the end.

## Testing

Tested locally and updated snapshot.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
