### PR TITLE
GTT-1226: Provide specific error messaging for publishing dashboards with same URL

### DIFF
--- a/frontend/src/containers/PublishDashboard.tsx
+++ b/frontend/src/containers/PublishDashboard.tsx
@@ -150,7 +150,10 @@ function PublishDashboard() {
           id: "top-alert",
           alert: {
             type: "error",
-            message: t("PublishWorkflow.FailToPublishError"),
+            message:
+              err.response.status === 409
+                ? t("PublishWorkflow.FailToPublishUrlAlreadyExists")
+                : t("PublishWorkflow.FailToPublishError"),
           },
         });
       }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -400,6 +400,7 @@
     "ConfirmURL": "Confirm URL",
     "ReviewAndPublish": "Review and publish",
     "InfoAlert": "This dashboard is now in the publish pending state and cannot be edited unless returned to draft.",
+    "FailToPublishUrlAlreadyExists": "Failed to publish dashboard. The selected URL is already being used for an existing dashboard. Please change it and try again.",
     "FailToPublishError": "Failed to publish dashboard. Please try again.",
     "FailToReturnToDraftError": "Failed to return dashboard to draft. Please try again.",
     "FailToSaveReleaseNotesError": "Failed to save release notes, please try again.",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -400,6 +400,7 @@
     "ConfirmURL": "Confirmar URL",
     "ReviewAndPublish": "Revisar y publicar",
     "InfoAlert": "Este panel se encuentra ahora en estado de publicación pendiente y no se puede editar a menos que vuelva a estar en el estado de borrador.",
+    "FailToPublishUrlAlreadyExists": "No se pudo publicar el panel. La URL seleccionada ya se está utilizando para un panel existente. Cámbiela e inténtelo de nuevo.",
     "FailToPublishError": "No se pudo publicar el panel. Inténtelo de nuevo.",
     "FailToReturnToDraftError": "No se pudo devolver el panel al estado de borrador. Inténtelo de nuevo.",
     "FailToSaveReleaseNotesError": "No se pudieron guardar las notas de la versión; inténtelo de nuevo.",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -400,6 +400,7 @@
     "ConfirmURL": "Confirmar URL",
     "ReviewAndPublish": "Revisar e publicar",
     "InfoAlert": "Este painel agora está no estado pendente de publicação e só poderá ser editado se for retornado ao estado de rascunho.",
+    "FailToPublishUrlAlreadyExists": "Falha ao publicar o painel. O URL selecionado já está sendo usado para um painel existente. Por favor, mude e tente novamente.",
     "FailToPublishError": "Falha ao publicar o painel. Tente novamente.",
     "FailToReturnToDraftError": "Falha ao retornar o painel ao estado de rascunho. Tente novamente.",
     "FailToSaveReleaseNotesError": "Falha ao salvar as notas de release. Tente novamente.",


### PR DESCRIPTION
## Description

Provide specific error messaging for publishing dashboards with same URL

## Testing

Tested it locally

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
