### PR TITLE
Fix: Add (Copy) to widget name when duplicating

### DIFF
--- a/backend/src/lib/controllers/widget-ctrl.ts
+++ b/backend/src/lib/controllers/widget-ctrl.ts
@@ -128,7 +128,7 @@ async function duplicateWidget(req: Request, res: Response) {
     return;
   }
 
-  const { updatedAt } = req.body;
+  const { updatedAt, copyLabel } = req.body;
 
   if (!updatedAt) {
     res.status(400).send("Missing required field `updatedAt`");
@@ -146,13 +146,18 @@ async function duplicateWidget(req: Request, res: Response) {
   let newWidget;
   try {
     newWidget = WidgetFactory.createWidget({
-      name: `(Copy) ${widget.name}`,
+      name: `(${copyLabel || "Copy"}) ${widget.name}`,
       dashboardId,
       widgetType: widget.widgetType,
       showTitle: widget.showTitle,
       content: widget.content,
     });
     newWidget.updatedAt = widget.updatedAt;
+    if (newWidget.content.title) {
+      newWidget.content.title = `(${copyLabel || "Copy"}) ${
+        newWidget.content.title
+      }`;
+    }
   } catch (err) {
     console.log("Invalid request to create widget", err);
     return res.status(400).send(err.message);

--- a/backend/src/lib/controllers/widget-ctrl.ts
+++ b/backend/src/lib/controllers/widget-ctrl.ts
@@ -146,7 +146,7 @@ async function duplicateWidget(req: Request, res: Response) {
   let newWidget;
   try {
     newWidget = WidgetFactory.createWidget({
-      name: widget.name,
+      name: `(Copy) ${widget.name}`,
       dashboardId,
       widgetType: widget.widgetType,
       showTitle: widget.showTitle,

--- a/frontend/src/containers/EditDashboard.tsx
+++ b/frontend/src/containers/EditDashboard.tsx
@@ -72,7 +72,8 @@ function EditDashboard() {
       await BackendService.duplicateWidget(
         dashboardId,
         widget.id,
-        widget.updatedAt
+        widget.updatedAt,
+        t("Copy")
       );
 
       history.replace(`/admin/dashboard/edit/${dashboardId}`, {

--- a/frontend/src/services/BackendService.ts
+++ b/frontend/src/services/BackendService.ts
@@ -232,7 +232,8 @@ async function editWidget(
 async function duplicateWidget(
   dashboardId: string,
   widgetId: string,
-  updatedAt: Date
+  updatedAt: Date,
+  copyLabel: string
 ) {
   const headers = await authHeaders();
   return await API.post(
@@ -242,6 +243,7 @@ async function duplicateWidget(
       headers,
       body: {
         updatedAt,
+        copyLabel,
       },
     }
   );


### PR DESCRIPTION
## Description

Add (Copy) to widget name when duplicating.

## Testing

Tested it locally.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
