### PR TITLE
Fix: Change 'duplicated' to 'copied' when copying a widget

### DIFF
--- a/frontend/src/components/WidgetList.tsx
+++ b/frontend/src/components/WidgetList.tsx
@@ -226,7 +226,7 @@ function WidgetList(props: Props) {
                         variant="unstyled"
                         className="margin-left-2 text-base-dark hover:text-base-darker active:text-base-darkest"
                         onClick={() => onDuplicate(widget)}
-                        ariaLabel={t("DuplicateContent", {
+                        ariaLabel={t("CopyContent", {
                           name: widget.name,
                         })}
                       >

--- a/frontend/src/containers/EditDashboard.tsx
+++ b/frontend/src/containers/EditDashboard.tsx
@@ -83,7 +83,7 @@ function EditDashboard() {
             widget.widgetType === WidgetType.Chart
               ? widget.content.chartType
               : widget.widgetType
-          )} '${widget.name}' ${t("DashboardWasDuplicated")}`,
+          )} '${widget.name}' ${t("DashboardWasCopied")}`,
         },
       });
 

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -781,7 +781,7 @@
   "Admin": "Admin",
   "Editor": "Editor",
   "GlobalUser": "user",
-  "DashboardWasDuplicated": "was successfully duplicated.",
+  "DashboardWasCopied": "was successfully copied.",
   "Copy": "Copy",
-  "DuplicateContent": "Duplicate {{name}}"
+  "CopyContent": "Copy {{name}}"
 }


### PR DESCRIPTION
## Description

Change 'duplicated' to 'copied' when copying a widget.

## Testing

Tested it locally.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
