### PR TITLE
GTT-1390: Add Donut chart new features

### DIFF
--- a/backend/src/lib/factories/__tests__/widget-factory.test.ts
+++ b/backend/src/lib/factories/__tests__/widget-factory.test.ts
@@ -525,6 +525,7 @@ describe("toItem", () => {
         sortByDesc: true,
         significantDigitLabels: true,
         dataLabels: true,
+        showTotal: true,
         columnsMetadata: [
           {
             hidden: false,
@@ -565,6 +566,7 @@ describe("toItem", () => {
       sortByDesc: true,
       significantDigitLabels: true,
       dataLabels: true,
+      showTotal: true,
       columnsMetadata: [
         {
           hidden: false,

--- a/backend/src/lib/factories/widget-factory.ts
+++ b/backend/src/lib/factories/widget-factory.ts
@@ -123,6 +123,10 @@ function fromChartItem(widget: Widget): ChartWidget {
         chartWidget.content.dataLabels !== undefined
           ? chartWidget.content.dataLabels
           : false,
+      showTotal:
+        chartWidget.content.showTotal !== undefined
+          ? chartWidget.content.showTotal
+          : true,
     },
   };
 }
@@ -245,6 +249,10 @@ function createChartWidget(widget: Widget): ChartWidget {
         widget.content.dataLabels !== undefined
           ? widget.content.dataLabels
           : false,
+      showTotal:
+        widget.content.showTotal !== undefined
+          ? widget.content.showTotal
+          : true,
       ...(widget.content.horizontalScroll && {
         horizontalScroll: widget.content.horizontalScroll,
       }),

--- a/backend/src/lib/models/widget.ts
+++ b/backend/src/lib/models/widget.ts
@@ -80,6 +80,7 @@ export interface ChartWidget extends Widget {
     datasetType?: string;
     horizontalScroll?: boolean;
     dataLabels: boolean;
+    showTotal: boolean;
     fileName: string;
     columnsMetadata: ColumnMetadata[];
     sortByColumn?: string;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4278,6 +4278,14 @@
         "csstype": "^2.2.0"
       }
     },
+    "@types/react-csv": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/react-csv/-/react-csv-1.1.2.tgz",
+      "integrity": "sha512-hCtZyXAubxBtn3Oi3I9kNAx2liRTaMtl1eWpO2M98aYkHuoSTbYO8OcZEjyr9aJJ30Xnoxj+uES3G6L6O1qgtg==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-datepicker": {
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/@types/react-datepicker/-/react-datepicker-3.1.8.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "@types/node": "^12.0.0",
     "@types/papaparse": "^5.2.0",
     "@types/react": "^16.9.0",
+    "@types/react-csv": "^1.1.2",
     "@types/react-datepicker": "^3.1.8",
     "@types/react-dom": "^16.9.0",
     "@types/react-modal": "^3.10.6",

--- a/frontend/src/components/ChartWidget.tsx
+++ b/frontend/src/components/ChartWidget.tsx
@@ -132,6 +132,7 @@ function ChartWidgetComponent(props: Props) {
           significantDigitLabels={content.significantDigitLabels}
           hideDataLabels={!content.dataLabels}
           columnsMetadata={content.columnsMetadata}
+          showTotal={content.showTotal}
         />
       );
 

--- a/frontend/src/components/DonutChartWidget.tsx
+++ b/frontend/src/components/DonutChartWidget.tsx
@@ -26,6 +26,7 @@ type Props = {
   };
   columnsMetadata: Array<any>;
   hideDataLabels?: boolean;
+  showTotal?: boolean;
   isPreview?: boolean;
 };
 
@@ -269,12 +270,14 @@ const DonutChartWidget = (props: Props) => {
                   onMouseEnter={() => setPartsHover(part)}
                 />
               ))}
-              <Label
-                className="text-base-darkest text-bold"
-                value={getTotal()}
-                offset={0}
-                position="center"
-              />
+              {props.showTotal && (
+                <Label
+                  className="text-base-darkest text-bold"
+                  value={getTotal()}
+                  offset={0}
+                  position="center"
+                />
+              )}
             </Pie>
             <Tooltip
               itemStyle={{ color: "#1b1b1b" }}

--- a/frontend/src/components/TableWidget.tsx
+++ b/frontend/src/components/TableWidget.tsx
@@ -7,7 +7,6 @@ import UtilsService from "../services/UtilsService";
 import Table from "./Table";
 import Button from "./Button";
 import { CSVLink } from "react-csv";
-import { isPropertySignature } from "typescript";
 import { useTranslation } from "react-i18next";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faDownload } from "@fortawesome/free-solid-svg-icons";

--- a/frontend/src/components/VisualizeChart.tsx
+++ b/frontend/src/components/VisualizeChart.tsx
@@ -48,6 +48,7 @@ interface Props {
   significantDigitLabels: boolean;
   horizontalScroll: boolean;
   dataLabels: boolean;
+  showTotal: boolean;
   columnsMetadata: Array<any>;
   configHeader: JSX.Element;
 }
@@ -156,7 +157,8 @@ function VisualizeChart(props: Props) {
               options={DatasetParsingService.getDatasetSortOptions(
                 props.originalJson,
                 props.headers,
-                t
+                t,
+                props.chartType
               )}
               onChange={handleSortDataChange}
               defaultValue={
@@ -232,6 +234,23 @@ function VisualizeChart(props: Props) {
               />
               <label className="usa-checkbox__label" htmlFor="dataLabels">
                 {t("VisualizeChartComponent.ShowDataLabels")}
+              </label>
+            </div>
+
+            <div
+              className="usa-checkbox"
+              hidden={props.chartType !== ChartType.DonutChart}
+            >
+              <input
+                className="usa-checkbox__input"
+                id="showTotal"
+                type="checkbox"
+                name="showTotal"
+                defaultChecked={true}
+                ref={props.register()}
+              />
+              <label className="usa-checkbox__label" htmlFor="showTotal">
+                {t("VisualizeChartComponent.ShowTotal")}
               </label>
             </div>
           </div>
@@ -438,6 +457,7 @@ function VisualizeChart(props: Props) {
                   summaryBelow={props.summaryBelow}
                   significantDigitLabels={props.significantDigitLabels}
                   hideDataLabels={!props.dataLabels}
+                  showTotal={props.showTotal}
                   isPreview={!props.fullPreview}
                   columnsMetadata={props.columnsMetadata}
                 />

--- a/frontend/src/components/__tests__/ChartWidget.test.tsx
+++ b/frontend/src/components/__tests__/ChartWidget.test.tsx
@@ -26,6 +26,7 @@ const chart: ChartWidget = {
     columnsMetadata: [],
     significantDigitLabels: false,
     dataLabels: false,
+    showTotal: true,
   },
 };
 

--- a/frontend/src/components/__tests__/VisualizeChart.test.tsx
+++ b/frontend/src/components/__tests__/VisualizeChart.test.tsx
@@ -68,6 +68,7 @@ test("renders the VisualizeChart component", async () => {
       columnsMetadata={[]}
       configHeader={<></>}
       dataLabels={false}
+      showTotal={true}
     />,
     { wrapper: MemoryRouter }
   );
@@ -137,6 +138,7 @@ test("renders the VisualizeChart component without horizontal scrolling", async 
       columnsMetadata={[]}
       configHeader={<></>}
       dataLabels={false}
+      showTotal={true}
     />,
     { wrapper: MemoryRouter }
   );

--- a/frontend/src/components/__tests__/__snapshots__/VisualizeChart.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/VisualizeChart.test.tsx.snap
@@ -302,6 +302,24 @@ exports[`renders the VisualizeChart component 1`] = `
               Show data labels
             </label>
           </div>
+          <div
+            class="usa-checkbox"
+            hidden=""
+          >
+            <input
+              checked=""
+              class="usa-checkbox__input"
+              id="showTotal"
+              name="showTotal"
+              type="checkbox"
+            />
+            <label
+              class="usa-checkbox__label"
+              for="showTotal"
+            >
+              Show total in chart's center
+            </label>
+          </div>
         </div>
         <div
           class="usa-form-group"
@@ -757,6 +775,24 @@ exports[`renders the VisualizeChart component without horizontal scrolling 1`] =
               for="dataLabels"
             >
               Show data labels
+            </label>
+          </div>
+          <div
+            class="usa-checkbox"
+            hidden=""
+          >
+            <input
+              checked=""
+              class="usa-checkbox__input"
+              id="showTotal"
+              name="showTotal"
+              type="checkbox"
+            />
+            <label
+              class="usa-checkbox__label"
+              for="showTotal"
+            >
+              Show total in chart's center
             </label>
           </div>
         </div>

--- a/frontend/src/containers/AddChart.tsx
+++ b/frontend/src/containers/AddChart.tsx
@@ -40,6 +40,7 @@ interface FormValues {
   horizontalScroll: boolean;
   significantDigitLabels: boolean;
   dataLabels: boolean;
+  showTotal: boolean;
   sortData: string;
 }
 
@@ -107,6 +108,7 @@ function AddChart() {
   const showTitle = watch("showTitle");
   const horizontalScroll = watch("horizontalScroll");
   const dataLabels = watch("dataLabels");
+  const showTotal = watch("showTotal");
   const significantDigitLabels = watch("significantDigitLabels");
 
   const initializeColumnsMetadata = () => {
@@ -180,6 +182,9 @@ function AddChart() {
             values.chartType === ChartType.PieChart ||
             values.chartType === ChartType.DonutChart) && {
             dataLabels: values.dataLabels,
+          }),
+          ...(values.chartType === ChartType.DonutChart && {
+            showTotal: values.showTotal,
           }),
           datasetType: datasetType,
           datasetId: newDataset
@@ -494,6 +499,7 @@ function AddChart() {
                 significantDigitLabels={significantDigitLabels}
                 horizontalScroll={horizontalScroll}
                 dataLabels={dataLabels}
+                showTotal={showTotal}
                 columnsMetadata={ColumnsMetadataService.getColumnsMetadata(
                   hiddenColumns,
                   dataTypes,

--- a/frontend/src/containers/EditChart.tsx
+++ b/frontend/src/containers/EditChart.tsx
@@ -45,6 +45,7 @@ interface FormValues {
   sortData: string;
   horizontalScroll: boolean;
   dataLabels: boolean;
+  showTotal: boolean;
   significantDigitLabels: boolean;
 }
 
@@ -111,6 +112,7 @@ function EditChart() {
   const chartType = watch("chartType");
   const horizontalScroll = watch("horizontalScroll");
   const dataLabels = watch("dataLabels");
+  const showTotal = watch("showTotal");
   const significantDigitLabels = watch("significantDigitLabels");
 
   const [displayedJson, setDisplayedJson] = useState<any[]>([]);
@@ -156,6 +158,7 @@ function EditChart() {
       const chartType = widget.content.chartType;
       const horizontalScroll = widget.content.horizontalScroll;
       const dataLabels = widget.content.dataLabels;
+      const showTotal = widget.content.showTotal;
 
       reset({
         title,
@@ -170,6 +173,7 @@ function EditChart() {
         chartType,
         horizontalScroll,
         dataLabels,
+        showTotal,
         significantDigitLabels: widget.content.significantDigitLabels,
         dynamicDatasets:
           widget.content.datasetType === DatasetType.DynamicDataset
@@ -334,6 +338,9 @@ function EditChart() {
             values.chartType === ChartType.PieChart ||
             values.chartType === ChartType.DonutChart) && {
             dataLabels: values.dataLabels,
+          }),
+          ...(values.chartType === ChartType.DonutChart && {
+            showTotal: values.showTotal,
           }),
           datasetType: displayedDatasetType,
           datasetId: newDataset
@@ -608,6 +615,7 @@ function EditChart() {
                   setSortByDesc={setSortByDesc}
                   horizontalScroll={horizontalScroll}
                   dataLabels={dataLabels}
+                  showTotal={showTotal}
                   significantDigitLabels={significantDigitLabels}
                   columnsMetadata={ColumnsMetadataService.getColumnsMetadata(
                     hiddenColumns,

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -148,6 +148,7 @@
     "ChartTypeError": "Please select a chart type",
     "DisplayHorizontalScroll": "Display with horizontal scroll",
     "ShowDataLabels": "Show data labels",
+    "ShowTotal": "Show total in chart's center",
     "ChartCorrectDisplay": "Does the chart look correct?"
   },
   "ViewDashboardAlertVersionNotesFrom": "Version {{version}} notes from",

--- a/frontend/src/models/index.tsx
+++ b/frontend/src/models/index.tsx
@@ -126,6 +126,7 @@ export interface ChartWidget extends Widget {
     horizontalScroll?: boolean;
     significantDigitLabels: boolean;
     dataLabels: boolean;
+    showTotal: boolean;
   };
 }
 

--- a/frontend/src/services/DatasetParsingService.ts
+++ b/frontend/src/services/DatasetParsingService.ts
@@ -1,3 +1,5 @@
+import { ChartType } from "../models";
+
 /**
  * Create a header row json. The first row of data will be interpreted as
  * field names. Each row of data will be an object of values keyed by field.
@@ -45,25 +47,34 @@ function getFilteredJson(
 function getDatasetSortOptions(
   json: Array<any>,
   headers: Array<string>,
-  t: Function
+  t: Function,
+  chartType?: ChartType
 ): any {
   const sortOptions: any = [{ value: "", label: t("SelectAnOption") }];
 
-  headers.forEach((h) => {
-    const column = [];
-    for (const row of json) {
-      column.push(row[h]);
+  headers.forEach((h, index) => {
+    if (
+      !chartType ||
+      index <= 1 ||
+      chartType === ChartType.LineChart ||
+      chartType === ChartType.BarChart ||
+      chartType === ChartType.ColumnChart
+    ) {
+      const column = [];
+      for (const row of json) {
+        column.push(row[h]);
+      }
+      const isNumberOrDate =
+        column.every((c) => typeof c === "number") ||
+        column.every((c) => !isNaN(Date.parse(c)));
+      const sortTypeAsc = isNumberOrDate ? t("LowToHigh") : t("AZ");
+      const sortTypeDesc = isNumberOrDate ? t("HighToLow") : t("Z-A");
+      sortOptions.push({ value: `${h}###asc`, label: `"${h}" ${sortTypeAsc}` });
+      sortOptions.push({
+        value: `${h}###desc`,
+        label: `"${h}" ${sortTypeDesc}`,
+      });
     }
-    const isNumberOrDate =
-      column.every((c) => typeof c === "number") ||
-      column.every((c) => !isNaN(Date.parse(c)));
-    const sortTypeAsc = isNumberOrDate ? t("LowToHigh") : t("AZ");
-    const sortTypeDesc = isNumberOrDate ? t("HighToLow") : t("Z-A");
-    sortOptions.push({ value: `${h}###asc`, label: `"${h}" ${sortTypeAsc}` });
-    sortOptions.push({
-      value: `${h}###desc`,
-      label: `"${h}" ${sortTypeDesc}`,
-    });
   });
 
   return sortOptions;


### PR DESCRIPTION
## Description

- Add show/hide option for donut chart total
- Donut/Pie/P-T-W charts need to show only relevant sorting options

## Testing

You can test it here: https://migdizn.badger.wwps.aws.dev/admin/dashboard/22b36013-843f-4b69-8ade-d8d06fd4159e/edit-chart/e9842d10-809e-4340-a8a1-71feb0554e6c

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
