### PR TITLE
[BUG] Ensure logo file gets stored in the proper bucket

### DIFF
--- a/cdk/lib/envconfig/index.ts
+++ b/cdk/lib/envconfig/index.ts
@@ -45,6 +45,7 @@ function getConfigContent(): string {
     userPoolId: process.env.USER_POOL_ID,
     appClientId: process.env.APP_CLIENT_ID,
     datasetsBucket: process.env.DATASETS_BUCKET,
+    contentBucket: process.env.CONTENT_BUCKET,
     identityPoolId: process.env.IDENTITY_POOL_ID,
     contactEmail: process.env.CONTACT_EMAIL,
     brandName: process.env.BRAND_NAME,


### PR DESCRIPTION
## Description

Currently the EnvConfig lambda has an environment variable for the content bucket, but it is not used by the lambda function to actually include the contentBucket in the env.js file.

This is causing the current code to search and store the logo in the datasets bucket, since the content bucket cannot be resolved to an actual bucket (since its missing from the env.js).

## Testing

We modified the env.js file locally, and uploaded a new file, and ensure the logo was stored in the proper place.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
