### PR TITLE
[Bug fix] rollback the change of IAM policy for content s3 bucket

### DIFF
--- a/cdk/lib/constructs/lambdas.ts
+++ b/cdk/lib/constructs/lambdas.ts
@@ -126,10 +126,7 @@ export class LambdaFunctions extends cdk.Construct {
 
     const s3Policy = new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
-      resources: [
-        props.datasetsBucket.arnForObjects("*"),
-        props.contentBucket.arnForObjects("*"),
-      ],
+      resources: [props.datasetsBucket.arnForObjects("*")],
       actions: ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
     });
 


### PR DESCRIPTION
## Description

Roll back the change of IAM policy for content S3 bucket. 

## Testing

N/A

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
