### PR TITLE
GTT-1421 : Increase memory size of lambda used by CDK BucketDeployment

### DIFF
--- a/cdk/lib/frontend-stack.ts
+++ b/cdk/lib/frontend-stack.ts
@@ -107,11 +107,11 @@ export class FrontendStack extends cdk.Stack {
      */
     const frontendDeploy = new s3Deploy.BucketDeployment(
       this,
-      "DeployFrontend",
+      "Deploy-Frontend",
       {
         sources: [s3Deploy.Source.asset("../frontend/build")],
         destinationBucket: this.frontendBucket,
-        memoryLimit: 512,
+        memoryLimit: 4096,
         prune: false,
         distribution,
       }


### PR DESCRIPTION
## Description

We use the CDK BucketDeployment construct to load Reactjs assets to S3.  Behind the scene, it's implemented by a Lambda.  We've been experiencing timeout with that Lambda, which causes the deployment to Gamma to timeout.  We found that the root cause is this CDK [defect](https://github.com/aws/aws-cdk/issues/4058).  The recommendation is to increase the memory size used by BucketDeployment.  In increasing the Lambda memory, we encountered this [issue](https://github.com/aws/aws-cdk/issues/7128).  The suggested workaround is to rename the construct, which we did.

## Testing

Deployed the changes from my laptop to my Isengard account successfully.  Made a manual update of the BucketDeployment Lambda memory on Gamma and verified that the timeout problem did not occur

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
