### PR TITLE
GTT-1419: Added options to preview a dashboard's mobile display

### DIFF
--- a/frontend/src/components/BarChartWidget.tsx
+++ b/frontend/src/components/BarChartWidget.tsx
@@ -33,6 +33,7 @@ type Props = {
   };
   columnsMetadata: Array<any>;
   hideDataLabels?: boolean;
+  showMobilePreview?: boolean;
 };
 
 const BarChartWidget = (props: Props) => {
@@ -66,7 +67,7 @@ const BarChartWidget = (props: Props) => {
     [barsHover]
   );
 
-  const { data, bars } = props;
+  const { data, bars, showMobilePreview } = props;
   const yAxisType = useCallback(() => {
     let columnMetadata;
     if (props.columnsMetadata && bars.length) {
@@ -213,12 +214,14 @@ const BarChartWidget = (props: Props) => {
           </BarChart>
         </ResponsiveContainer>
       )}
-      <DataTable
-        rows={data || []}
-        columns={bars}
-        columnsMetadata={props.columnsMetadata}
-        fileName={props.title}
-      />
+      <div style={showMobilePreview ? { float: "left" } : {}}>
+        <DataTable
+          rows={data || []}
+          columns={bars}
+          columnsMetadata={props.columnsMetadata}
+          fileName={props.title}
+        />
+      </div>
       {props.summaryBelow && (
         <MarkdownRender
           source={props.summary}

--- a/frontend/src/components/ChartWidget.tsx
+++ b/frontend/src/components/ChartWidget.tsx
@@ -11,10 +11,12 @@ import DonutChartWidget from "./DonutChartWidget";
 
 interface Props {
   widget: ChartWidget;
+  showMobilePreview?: boolean;
 }
 
 function ChartWidgetComponent(props: Props) {
   const { content } = props.widget;
+  const showMobilePreview = props.showMobilePreview;
   const { json } = useJsonDataset(content.s3Key.json);
   const [filteredJson, setFilteredJson] = useState<Array<any>>([]);
 
@@ -104,6 +106,7 @@ function ChartWidgetComponent(props: Props) {
           parts={keys}
           data={filteredJson}
           significantDigitLabels={content.significantDigitLabels}
+          showMobilePreview={showMobilePreview}
         />
       );
 

--- a/frontend/src/components/ChartWidget.tsx
+++ b/frontend/src/components/ChartWidget.tsx
@@ -65,6 +65,7 @@ function ChartWidgetComponent(props: Props) {
           horizontalScroll={content.horizontalScroll}
           significantDigitLabels={content.significantDigitLabels}
           columnsMetadata={content.columnsMetadata}
+          showMobilePreview={showMobilePreview}
         />
       );
 
@@ -80,6 +81,7 @@ function ChartWidgetComponent(props: Props) {
           significantDigitLabels={content.significantDigitLabels}
           columnsMetadata={content.columnsMetadata}
           hideDataLabels={!content.dataLabels}
+          showMobilePreview={showMobilePreview}
         />
       );
 
@@ -94,6 +96,7 @@ function ChartWidgetComponent(props: Props) {
           significantDigitLabels={content.significantDigitLabels}
           columnsMetadata={content.columnsMetadata}
           hideDataLabels={!content.dataLabels}
+          showMobilePreview={showMobilePreview}
         />
       );
 
@@ -121,6 +124,7 @@ function ChartWidgetComponent(props: Props) {
           significantDigitLabels={content.significantDigitLabels}
           hideDataLabels={!content.dataLabels}
           columnsMetadata={content.columnsMetadata}
+          showMobilePreview={showMobilePreview}
         />
       );
 
@@ -136,6 +140,7 @@ function ChartWidgetComponent(props: Props) {
           hideDataLabels={!content.dataLabels}
           columnsMetadata={content.columnsMetadata}
           showTotal={content.showTotal}
+          showMobilePreview={showMobilePreview}
         />
       );
 

--- a/frontend/src/components/ColumnChartWidget.tsx
+++ b/frontend/src/components/ColumnChartWidget.tsx
@@ -36,6 +36,7 @@ type Props = {
     secondary: string | undefined;
   };
   columnsMetadata: Array<any>;
+  showMobilePreview?: boolean;
 };
 
 const ColumnChartWidget = (props: Props) => {
@@ -70,7 +71,7 @@ const ColumnChartWidget = (props: Props) => {
     [columnsHover]
   );
 
-  const { data, columns } = props;
+  const { data, columns, showMobilePreview } = props;
   const xAxisType = useCallback(() => {
     let columnMetadata;
     if (props.columnsMetadata && columns.length) {
@@ -227,12 +228,14 @@ const ColumnChartWidget = (props: Props) => {
           </BarChart>
         </ResponsiveContainer>
       )}
-      <DataTable
-        rows={data || []}
-        columns={columns}
-        columnsMetadata={props.columnsMetadata}
-        fileName={props.title}
-      />
+      <div style={showMobilePreview ? { float: "left" } : {}}>
+        <DataTable
+          rows={data || []}
+          columns={columns}
+          columnsMetadata={props.columnsMetadata}
+          fileName={props.title}
+        />
+      </div>
       {props.summaryBelow && (
         <MarkdownRender
           source={props.summary}

--- a/frontend/src/components/DonutChartWidget.tsx
+++ b/frontend/src/components/DonutChartWidget.tsx
@@ -28,6 +28,7 @@ type Props = {
   hideDataLabels?: boolean;
   showTotal?: boolean;
   isPreview?: boolean;
+  showMobilePreview?: boolean;
 };
 
 const DonutChartWidget = (props: Props) => {
@@ -39,7 +40,7 @@ const DonutChartWidget = (props: Props) => {
   const donutParts = useRef<Array<string>>([]);
   let total = useRef<number>(0);
 
-  const { data, parts } = props;
+  const { data, parts, showMobilePreview } = props;
   useMemo(() => {
     if (data && data.length) {
       let donut = {};
@@ -301,12 +302,14 @@ const DonutChartWidget = (props: Props) => {
           </PieChart>
         </ResponsiveContainer>
       )}
-      <DataTable
-        rows={data || []}
-        columns={parts}
-        fileName={props.title}
-        columnsMetadata={props.columnsMetadata}
-      />
+      <div style={showMobilePreview ? { float: "left" } : {}}>
+        <DataTable
+          rows={data || []}
+          columns={parts}
+          fileName={props.title}
+          columnsMetadata={props.columnsMetadata}
+        />
+      </div>
       {props.summaryBelow && (
         <MarkdownRender
           source={props.summary}

--- a/frontend/src/components/LineChartWidget.tsx
+++ b/frontend/src/components/LineChartWidget.tsx
@@ -33,6 +33,7 @@ type Props = {
     secondary: string | undefined;
   };
   columnsMetadata: Array<any>;
+  showMobilePreview?: boolean;
 };
 
 const LineChartWidget = (props: Props) => {
@@ -67,7 +68,7 @@ const LineChartWidget = (props: Props) => {
     [linesHover]
   );
 
-  const { data, lines } = props;
+  const { data, lines, showMobilePreview } = props;
   const xAxisType = useCallback(() => {
     let columnMetadata;
     if (props.columnsMetadata && lines.length) {
@@ -210,12 +211,14 @@ const LineChartWidget = (props: Props) => {
           </LineChart>
         </ResponsiveContainer>
       )}
-      <DataTable
-        rows={data || []}
-        columns={lines}
-        columnsMetadata={props.columnsMetadata}
-        fileName={props.title}
-      />
+      <div style={showMobilePreview ? { float: "left" } : {}}>
+        <DataTable
+          rows={data || []}
+          columns={lines}
+          columnsMetadata={props.columnsMetadata}
+          fileName={props.title}
+        />
+      </div>
       {props.summaryBelow && (
         <MarkdownRender
           source={props.summary}

--- a/frontend/src/components/PartWholeChartWidget.tsx
+++ b/frontend/src/components/PartWholeChartWidget.tsx
@@ -224,7 +224,9 @@ const PartWholeChartWidget = (props: Props) => {
           </BarChart>
         </ResponsiveContainer>
       )}
-      <DataTable rows={data || []} columns={parts} fileName={props.title} />
+      <div style={showMobilePreview ? { float: "left" } : {}}>
+        <DataTable rows={data || []} columns={parts} fileName={props.title} />
+      </div>
       {props.summaryBelow && (
         <MarkdownRender
           source={props.summary}

--- a/frontend/src/components/PartWholeChartWidget.tsx
+++ b/frontend/src/components/PartWholeChartWidget.tsx
@@ -24,6 +24,7 @@ type Props = {
     primary: string | undefined;
     secondary: string | undefined;
   };
+  showMobilePreview?: boolean;
 };
 
 const PartWholeChartWidget = (props: Props) => {
@@ -36,7 +37,7 @@ const PartWholeChartWidget = (props: Props) => {
   const partWholeParts = useRef<Array<string>>([]);
   let total = useRef<number>(0);
 
-  const { data, parts } = props;
+  const { data, parts, showMobilePreview } = props;
   useMemo(() => {
     if (data && data.length) {
       let bar = {};
@@ -125,7 +126,7 @@ const PartWholeChartWidget = (props: Props) => {
     }
 
     // Handle very small screens where width is less than 300 pixels
-    if (windowSize.width <= smallScreenPixels) {
+    if (windowSize.width <= smallScreenPixels || showMobilePreview) {
       if (data.length < 5) {
         return minHeightMobile;
       } else {

--- a/frontend/src/components/PieChartWidget.tsx
+++ b/frontend/src/components/PieChartWidget.tsx
@@ -26,6 +26,7 @@ type Props = {
   columnsMetadata: Array<any>;
   hideDataLabels?: boolean;
   isPreview?: boolean;
+  showMobilePreview?: boolean;
 };
 
 const PieChartWidget = (props: Props) => {
@@ -37,7 +38,7 @@ const PieChartWidget = (props: Props) => {
   const pieParts = useRef<Array<string>>([]);
   let total = useRef<number>(0);
 
-  const { data, parts } = props;
+  const { data, parts, showMobilePreview } = props;
   useMemo(() => {
     if (data && data.length) {
       let pie = {};
@@ -269,12 +270,14 @@ const PieChartWidget = (props: Props) => {
           </PieChart>
         </ResponsiveContainer>
       )}
-      <DataTable
-        rows={data || []}
-        columns={parts}
-        fileName={props.title}
-        columnsMetadata={props.columnsMetadata}
-      />
+      <div style={showMobilePreview ? { float: "left" } : {}}>
+        <DataTable
+          rows={data || []}
+          columns={parts}
+          fileName={props.title}
+          columnsMetadata={props.columnsMetadata}
+        />
+      </div>
       {props.summaryBelow && (
         <MarkdownRender
           source={props.summary}

--- a/frontend/src/components/TableWidget.tsx
+++ b/frontend/src/components/TableWidget.tsx
@@ -129,16 +129,20 @@ const TableWidget = ({
         />
       )}
       <div className="text-right margin-bottom-1">
-        <FontAwesomeIcon
-          icon={faDownload}
-          className="margin-right-1"
-          size="sm"
-        />
-        <Button type="button" variant="unstyled" className="margin-right-05">
-          <CSVLink className="text-base" data={rows} filename={title}>
-            {t("DownloadCSV")}
-          </CSVLink>
-        </Button>
+        <div style={{ display: "inline-flex" }}>
+          <FontAwesomeIcon
+            icon={faDownload}
+            className="margin-right-1"
+            size="sm"
+          />
+        </div>
+        <div style={{ display: "inline-flex" }}>
+          <Button type="button" variant="unstyled" className="margin-right-05">
+            <CSVLink className="text-base" data={rows} filename={title}>
+              {t("DownloadCSV")}
+            </CSVLink>
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/TableWidget.tsx
+++ b/frontend/src/components/TableWidget.tsx
@@ -20,6 +20,7 @@ type Props = {
   sortByColumn?: string;
   sortByDesc?: boolean;
   significantDigitLabels: boolean;
+  showMobilePreview?: boolean;
 };
 
 const TableWidget = ({
@@ -31,6 +32,7 @@ const TableWidget = ({
   sortByDesc,
   sortByColumn,
   significantDigitLabels,
+  showMobilePreview,
 }: Props) => {
   const { largestTickByColumn } = useTableMetadata(data);
   const [filteredJson, setFilteredJson] = useState<any[]>([]);
@@ -128,7 +130,13 @@ const TableWidget = ({
           className="usa-prose margin-top-3 margin-bottom-0 tableSummaryBelow"
         />
       )}
-      <div className="text-right margin-bottom-1">
+      <div
+        className={
+          showMobilePreview
+            ? "text-left margin-bottom-1"
+            : "text-right margin-bottom-1"
+        }
+      >
         <div style={{ display: "inline-flex" }}>
           <FontAwesomeIcon
             icon={faDownload}

--- a/frontend/src/components/TableWidget.tsx
+++ b/frontend/src/components/TableWidget.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from "react";
 import { ColumnMetadata } from "../models";
-import { useTableMetadata } from "../hooks";
+import { useTableMetadata, useWindowSize } from "../hooks";
 import MarkdownRender from "./MarkdownRender";
 import TickFormatter from "../services/TickFormatter";
 import UtilsService from "../services/UtilsService";
@@ -37,6 +37,7 @@ const TableWidget = ({
   const { largestTickByColumn } = useTableMetadata(data);
   const [filteredJson, setFilteredJson] = useState<any[]>([]);
   const { t } = useTranslation();
+  const window = useWindowSize();
 
   useMemo(() => {
     let headers =
@@ -132,7 +133,7 @@ const TableWidget = ({
       )}
       <div
         className={
-          showMobilePreview
+          showMobilePreview || window.width < 450
             ? "text-left margin-bottom-1"
             : "text-right margin-bottom-1"
         }

--- a/frontend/src/components/TableWidget.tsx
+++ b/frontend/src/components/TableWidget.tsx
@@ -102,6 +102,8 @@ const TableWidget = ({
     filteredJson,
   ]);
 
+  const maxMobileViewportWidth = 450;
+
   if (!filteredJson || filteredJson.length === 0) {
     return null;
   }
@@ -133,7 +135,7 @@ const TableWidget = ({
       )}
       <div
         className={
-          showMobilePreview || window.width < 450
+          showMobilePreview || window.width < maxMobileViewportWidth
             ? "text-left margin-bottom-1"
             : "text-right margin-bottom-1"
         }

--- a/frontend/src/components/WidgetRender.tsx
+++ b/frontend/src/components/WidgetRender.tsx
@@ -16,14 +16,20 @@ import MetricsWidgetComponent from "../components/MetricsWidget";
 
 interface Props {
   widget: Widget;
+  showMobilePreview?: boolean;
 }
 
-function WidgetRender({ widget }: Props) {
+function WidgetRender({ widget, showMobilePreview }: Props) {
   switch (widget.widgetType) {
     case WidgetType.Text:
       return <TextWidget widget={widget} />;
     case WidgetType.Chart:
-      return <ChartWidgetComponent widget={widget as ChartWidget} />;
+      return (
+        <ChartWidgetComponent
+          widget={widget as ChartWidget}
+          showMobilePreview={showMobilePreview}
+        />
+      );
     case WidgetType.Table:
     case WidgetType.Metrics:
       return <WidgetWithDataset widget={widget} />;

--- a/frontend/src/components/WidgetRender.tsx
+++ b/frontend/src/components/WidgetRender.tsx
@@ -32,7 +32,12 @@ function WidgetRender({ widget, showMobilePreview }: Props) {
       );
     case WidgetType.Table:
     case WidgetType.Metrics:
-      return <WidgetWithDataset widget={widget} />;
+      return (
+        <WidgetWithDataset
+          widget={widget}
+          showMobilePreview={showMobilePreview}
+        />
+      );
     case WidgetType.Image:
       return <WidgetWithImage widget={widget as ImageWidget} />;
     default:
@@ -56,7 +61,7 @@ function WidgetWithImage({ widget }: Props) {
   );
 }
 
-function WidgetWithDataset({ widget }: Props) {
+function WidgetWithDataset({ widget, showMobilePreview }: Props) {
   const { json } = useWidgetDataset(widget);
   switch (widget.widgetType) {
     case WidgetType.Table:
@@ -71,6 +76,7 @@ function WidgetWithDataset({ widget }: Props) {
           sortByColumn={tableWidget.content.sortByColumn}
           sortByDesc={tableWidget.content.sortByDesc}
           significantDigitLabels={tableWidget.content.significantDigitLabels}
+          showMobilePreview={showMobilePreview}
         />
       );
     case WidgetType.Metrics:

--- a/frontend/src/components/WidgetRender.tsx
+++ b/frontend/src/components/WidgetRender.tsx
@@ -86,7 +86,9 @@ function WidgetWithDataset({ widget, showMobilePreview }: Props) {
           title={metricsWidget.showTitle ? metricsWidget.content.title : ""}
           metrics={json}
           metricPerRow={
-            metricsWidget.content.oneMetricPerRow || window.innerWidth < 640
+            metricsWidget.content.oneMetricPerRow ||
+            window.innerWidth < 640 ||
+            showMobilePreview
               ? 1
               : 3
           }

--- a/frontend/src/components/__tests__/__snapshots__/TableWidget.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/TableWidget.test.tsx.snap
@@ -192,37 +192,45 @@ exports[`table preview should match snapshot 1`] = `
     <div
       class="text-right margin-bottom-1"
     >
-      <svg
-        aria-hidden="true"
-        class="svg-inline--fa fa-download fa-w-16 fa-sm margin-right-1"
-        data-icon="download"
-        data-prefix="fas"
-        focusable="false"
-        role="img"
-        viewBox="0 0 512 512"
-        xmlns="http://www.w3.org/2000/svg"
+      <div
+        style="display: inline-flex;"
       >
-        <path
-          d="M216 0h80c13.3 0 24 10.7 24 24v168h87.7c17.8 0 26.7 21.5 14.1 34.1L269.7 378.3c-7.5 7.5-19.8 7.5-27.3 0L90.1 226.1c-12.6-12.6-3.7-34.1 14.1-34.1H192V24c0-13.3 10.7-24 24-24zm296 376v112c0 13.3-10.7 24-24 24H24c-13.3 0-24-10.7-24-24V376c0-13.3 10.7-24 24-24h146.7l49 49c20.1 20.1 52.5 20.1 72.6 0l49-49H488c13.3 0 24 10.7 24 24zm-124 88c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20zm64 0c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20z"
-          fill="currentColor"
-        />
-      </svg>
-      <button
-        class="usa-button usa-button--unstyled margin-right-05"
-        type="button"
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-download fa-w-16 fa-sm margin-right-1"
+          data-icon="download"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M216 0h80c13.3 0 24 10.7 24 24v168h87.7c17.8 0 26.7 21.5 14.1 34.1L269.7 378.3c-7.5 7.5-19.8 7.5-27.3 0L90.1 226.1c-12.6-12.6-3.7-34.1 14.1-34.1H192V24c0-13.3 10.7-24 24-24zm296 376v112c0 13.3-10.7 24-24 24H24c-13.3 0-24-10.7-24-24V376c0-13.3 10.7-24 24-24h146.7l49 49c20.1 20.1 52.5 20.1 72.6 0l49-49H488c13.3 0 24 10.7 24 24zm-124 88c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20zm64 0c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20z"
+            fill="currentColor"
+          />
+        </svg>
+      </div>
+      <div
+        style="display: inline-flex;"
       >
-        <a
-          class="text-base"
-          download="test title"
-          href="data:text/csv;charset=utf-8,﻿\\"id\\",\\"name\\",\\"updatedAt\\"
+        <button
+          class="usa-button usa-button--unstyled margin-right-05"
+          type="button"
+        >
+          <a
+            class="text-base"
+            download="test title"
+            href="data:text/csv;charset=utf-8,﻿\\"id\\",\\"name\\",\\"updatedAt\\"
 \\"1\\",\\"Banana\\",\\"2021-11-11\\"
 \\"2\\",\\"Chocolate\\",\\"2020-11-11\\"
 \\"3\\",\\"Vanilla\\",\\"2019-11-11\\""
-          target="_self"
-        >
-          Download
-        </a>
-      </button>
+            target="_self"
+          >
+            Download
+          </a>
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/frontend/src/components/__tests__/__snapshots__/VisualizeChart.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/VisualizeChart.test.tsx.snap
@@ -440,34 +440,36 @@ exports[`renders the VisualizeChart component 1`] = `
             id="title"
             style="width: 100%; height: 300px;"
           />
-          <div
-            class="text-right"
-          >
-            <button
-              aria-controls="menu--1"
-              aria-haspopup="true"
-              class="usa-button usa-button--unstyled text-base"
-              data-reach-menu-button=""
-              id="menu-button--menu--1"
-              type="button"
+          <div>
+            <div
+              class="text-right"
             >
-              Actions
-              <svg
-                aria-hidden="true"
-                class="svg-inline--fa fa-caret-down fa-w-10 margin-left-1"
-                data-icon="caret-down"
-                data-prefix="fas"
-                focusable="false"
-                role="img"
-                viewBox="0 0 320 512"
-                xmlns="http://www.w3.org/2000/svg"
+              <button
+                aria-controls="menu--1"
+                aria-haspopup="true"
+                class="usa-button usa-button--unstyled text-base"
+                data-reach-menu-button=""
+                id="menu-button--menu--1"
+                type="button"
               >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
+                Actions
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-caret-down fa-w-10 margin-left-1"
+                  data-icon="caret-down"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 320 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -915,34 +917,36 @@ exports[`renders the VisualizeChart component without horizontal scrolling 1`] =
             id="title"
             style="width: 100%; height: 300px;"
           />
-          <div
-            class="text-right"
-          >
-            <button
-              aria-controls="menu--7"
-              aria-haspopup="true"
-              class="usa-button usa-button--unstyled text-base"
-              data-reach-menu-button=""
-              id="menu-button--menu--7"
-              type="button"
+          <div>
+            <div
+              class="text-right"
             >
-              Actions
-              <svg
-                aria-hidden="true"
-                class="svg-inline--fa fa-caret-down fa-w-10 margin-left-1"
-                data-icon="caret-down"
-                data-prefix="fas"
-                focusable="false"
-                role="img"
-                viewBox="0 0 320 512"
-                xmlns="http://www.w3.org/2000/svg"
+              <button
+                aria-controls="menu--7"
+                aria-haspopup="true"
+                class="usa-button usa-button--unstyled text-base"
+                data-reach-menu-button=""
+                id="menu-button--menu--7"
+                type="button"
               >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
+                Actions
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-caret-down fa-w-10 margin-left-1"
+                  data-icon="caret-down"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 320 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/__tests__/__snapshots__/VisualizeTable.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/VisualizeTable.test.tsx.snap
@@ -421,37 +421,45 @@ exports[`renders the VisualizeTable component 1`] = `
           <div
             class="text-right margin-bottom-1"
           >
-            <svg
-              aria-hidden="true"
-              class="svg-inline--fa fa-download fa-w-16 fa-sm margin-right-1"
-              data-icon="download"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              viewBox="0 0 512 512"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              style="display: inline-flex;"
             >
-              <path
-                d="M216 0h80c13.3 0 24 10.7 24 24v168h87.7c17.8 0 26.7 21.5 14.1 34.1L269.7 378.3c-7.5 7.5-19.8 7.5-27.3 0L90.1 226.1c-12.6-12.6-3.7-34.1 14.1-34.1H192V24c0-13.3 10.7-24 24-24zm296 376v112c0 13.3-10.7 24-24 24H24c-13.3 0-24-10.7-24-24V376c0-13.3 10.7-24 24-24h146.7l49 49c20.1 20.1 52.5 20.1 72.6 0l49-49H488c13.3 0 24 10.7 24 24zm-124 88c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20zm64 0c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20z"
-                fill="currentColor"
-              />
-            </svg>
-            <button
-              class="usa-button usa-button--unstyled margin-right-05"
-              type="button"
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-download fa-w-16 fa-sm margin-right-1"
+                data-icon="download"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 512 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M216 0h80c13.3 0 24 10.7 24 24v168h87.7c17.8 0 26.7 21.5 14.1 34.1L269.7 378.3c-7.5 7.5-19.8 7.5-27.3 0L90.1 226.1c-12.6-12.6-3.7-34.1 14.1-34.1H192V24c0-13.3 10.7-24 24-24zm296 376v112c0 13.3-10.7 24-24 24H24c-13.3 0-24-10.7-24-24V376c0-13.3 10.7-24 24-24h146.7l49 49c20.1 20.1 52.5 20.1 72.6 0l49-49H488c13.3 0 24 10.7 24 24zm-124 88c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20zm64 0c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+            <div
+              style="display: inline-flex;"
             >
-              <a
-                class="text-base"
-                download=""
-                href="data:text/csv;charset=utf-8,﻿\\"id\\",\\"name\\",\\"updatedAt\\"
+              <button
+                class="usa-button usa-button--unstyled margin-right-05"
+                type="button"
+              >
+                <a
+                  class="text-base"
+                  download=""
+                  href="data:text/csv;charset=utf-8,﻿\\"id\\",\\"name\\",\\"updatedAt\\"
 \\"1\\",\\"Banana\\",\\"2021-11-11\\"
 \\"2\\",\\"Chocolate\\",\\"2020-11-11\\"
 \\"3\\",\\"Vanilla\\",\\"2019-11-11\\""
-                target="_self"
-              >
-                Download
-              </a>
-            </button>
+                  target="_self"
+                >
+                  Download
+                </a>
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/containers/ViewDashboardAdmin.tsx
+++ b/frontend/src/containers/ViewDashboardAdmin.tsx
@@ -380,7 +380,7 @@ function ViewDashboardAdmin() {
         style={
           showMobilePreview
             ? {
-                width: `${Math.min(windowSize.width, mobilePreviewWidth)}px`,
+                width: `${mobilePreviewWidth}px`,
                 margin: "auto",
               }
             : {}

--- a/frontend/src/containers/ViewDashboardAdmin.tsx
+++ b/frontend/src/containers/ViewDashboardAdmin.tsx
@@ -4,7 +4,7 @@ import Link from "../components/Link";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCopy } from "@fortawesome/free-solid-svg-icons";
 import { useTranslation } from "react-i18next";
-import { useDashboard, useDashboardVersions } from "../hooks";
+import { useDashboard, useDashboardVersions, useWindowSize } from "../hooks";
 import { Dashboard, DashboardState, LocationState } from "../models";
 import BackendService from "../services/BackendService";
 import WidgetRender from "../components/WidgetRender";
@@ -33,8 +33,11 @@ function ViewDashboardAdmin() {
   const [isOpenPublishModal, setIsOpenPublishModal] = useState(false);
   const [showVersionNotes, setShowVersionNotes] = useState(false);
   const [showMobilePreview, setShowMobilePreview] = useState(false);
+  const windowSize = useWindowSize();
 
   const { t } = useTranslation();
+
+  const mobilePreviewWidth = 400;
 
   const draftOrPublishPending = versions.find(
     (v) =>
@@ -372,7 +375,7 @@ function ViewDashboardAdmin() {
         style={
           showMobilePreview
             ? {
-                width: `${Math.min(window.screen.width, 400)}px`,
+                width: `${Math.min(windowSize.width, mobilePreviewWidth)}px`,
                 margin: "auto",
               }
             : {}

--- a/frontend/src/containers/ViewDashboardAdmin.tsx
+++ b/frontend/src/containers/ViewDashboardAdmin.tsx
@@ -32,6 +32,7 @@ function ViewDashboardAdmin() {
   const [isOpenRepublishModal, setIsOpenRepublishModal] = useState(false);
   const [isOpenPublishModal, setIsOpenPublishModal] = useState(false);
   const [showVersionNotes, setShowVersionNotes] = useState(false);
+  const [showMobilePreview, setShowMobilePreview] = useState(false);
 
   const { t } = useTranslation();
 
@@ -316,6 +317,24 @@ function ViewDashboardAdmin() {
             {(dashboard.state === DashboardState.Draft ||
               dashboard.state === DashboardState.PublishPending) && (
               <>
+                <span className="usa-checkbox" style={{ marginRight: "8px" }}>
+                  <input
+                    className="usa-checkbox__input"
+                    id="display-mobile-view"
+                    type="checkbox"
+                    name="showMobileView"
+                    defaultChecked={false}
+                    onChange={() => {
+                      setShowMobilePreview(!showMobilePreview);
+                    }}
+                  />
+                  <label
+                    className="usa-checkbox__label"
+                    htmlFor="display-mobile-view"
+                  >
+                    {t("MobilePreview")}
+                  </label>
+                </span>
                 <Button
                   variant="outline"
                   type="button"
@@ -349,29 +368,40 @@ function ViewDashboardAdmin() {
         )}
       </PrimaryActionBar>
 
-      {loading ? (
-        <Spinner
-          className="text-center margin-top-9"
-          label={t("LoadingSpinnerLabel")}
-        />
-      ) : (
-        <>
-          <DashboardHeader
-            name={dashboard?.name}
-            topicAreaName={dashboard?.topicAreaName}
-            description={dashboard?.description}
-            lastUpdated={dashboard?.updatedAt}
+      <div
+        style={
+          showMobilePreview
+            ? {
+                width: `${Math.min(window.screen.width, 400)}px`,
+                margin: "auto",
+              }
+            : {}
+        }
+      >
+        {loading ? (
+          <Spinner
+            className="text-center margin-top-9"
+            label={t("LoadingSpinnerLabel")}
           />
-          <hr />
-          {dashboard?.widgets.map((widget, index) => {
-            return (
-              <div className="margin-top-6 usa-prose" key={index}>
-                <WidgetRender widget={widget} />
-              </div>
-            );
-          })}
-        </>
-      )}
+        ) : (
+          <>
+            <DashboardHeader
+              name={dashboard?.name}
+              topicAreaName={dashboard?.topicAreaName}
+              description={dashboard?.description}
+              lastUpdated={dashboard?.updatedAt}
+            />
+            <hr />
+            {dashboard?.widgets.map((widget, index) => {
+              return (
+                <div className="margin-top-6 usa-prose" key={index}>
+                  <WidgetRender widget={widget} />
+                </div>
+              );
+            })}
+          </>
+        )}
+      </div>
     </>
   );
 }

--- a/frontend/src/containers/ViewDashboardAdmin.tsx
+++ b/frontend/src/containers/ViewDashboardAdmin.tsx
@@ -395,7 +395,10 @@ function ViewDashboardAdmin() {
             {dashboard?.widgets.map((widget, index) => {
               return (
                 <div className="margin-top-6 usa-prose" key={index}>
-                  <WidgetRender widget={widget} />
+                  <WidgetRender
+                    widget={widget}
+                    showMobilePreview={showMobilePreview}
+                  />
                 </div>
               );
             })}

--- a/frontend/src/containers/ViewDashboardAdmin.tsx
+++ b/frontend/src/containers/ViewDashboardAdmin.tsx
@@ -38,6 +38,7 @@ function ViewDashboardAdmin() {
   const { t } = useTranslation();
 
   const mobilePreviewWidth = 400;
+  const maxMobileViewportWidth = 450;
 
   const draftOrPublishPending = versions.find(
     (v) =>
@@ -320,7 +321,11 @@ function ViewDashboardAdmin() {
             {(dashboard.state === DashboardState.Draft ||
               dashboard.state === DashboardState.PublishPending) && (
               <>
-                <span className="usa-checkbox" style={{ marginRight: "8px" }}>
+                <span
+                  className="usa-checkbox"
+                  style={{ marginRight: "8px" }}
+                  hidden={windowSize.width < maxMobileViewportWidth}
+                >
                   <input
                     className="usa-checkbox__input"
                     id="display-mobile-view"

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -817,5 +817,6 @@
   "DashboardWasCopied": "was successfully copied.",
   "Copy": "Copy",
   "CopyContent": "Copy {{name}}",
-  "DownloadCSV": "Download"
+  "DownloadCSV": "Download",
+  "MobilePreview": "Mobile preview"
 }


### PR DESCRIPTION
## Description

- Added a checkbox to preview dashboards' mobile display
- An error message showed up in developer tools console when unchecking mobile preview for part-to-whole chart, and this will be fixed in future sprints.

## Testing

Updated existing unit tests. Passed all unit tests and integration tests. You can see a demo here: https://d1p86h8o9mi768.cloudfront.net/admin/dashboard/de5baf37-ffde-44b6-84cb-37c53adfafe1

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
