### PR TITLE
GTT-1483: Improved mobile display of pie/donut chart

### DIFF
--- a/frontend/src/components/DonutChartWidget.tsx
+++ b/frontend/src/components/DonutChartWidget.tsx
@@ -8,7 +8,7 @@ import {
   Tooltip,
   Label,
 } from "recharts";
-import { useColors } from "../hooks";
+import { useColors, useWindowSize } from "../hooks";
 import TickFormatter from "../services/TickFormatter";
 import MarkdownRender from "./MarkdownRender";
 import DataTable from "./DataTable";
@@ -218,6 +218,33 @@ const DonutChartWidget = (props: Props) => {
     );
   };
 
+  const windowSize = useWindowSize();
+  const smallScreenPixels = 800;
+
+  const calculateChartHeight = (): number => {
+    const baseHeight = 300;
+    const pixelsByPart = 60;
+    const pixelsByPartInPreview = 50;
+    const labelsPerRow = 4;
+    const labelsPerRowInPreview = 2;
+
+    if (!data || !data.length) {
+      return baseHeight;
+    }
+
+    let additional;
+    if (windowSize.width <= smallScreenPixels || showMobilePreview) {
+      additional = data.length * pixelsByPart;
+    } else if (props.isPreview) {
+      additional =
+        (Math.floor(data.length / labelsPerRowInPreview) + 1) *
+        pixelsByPartInPreview;
+    } else {
+      additional = (Math.floor(data.length / labelsPerRow) + 1) * pixelsByPart;
+    }
+    return baseHeight + additional;
+  };
+
   return (
     <div>
       <h2 className={`margin-bottom-${props.summaryBelow ? "4" : "1"}`}>
@@ -230,7 +257,7 @@ const DonutChartWidget = (props: Props) => {
         />
       )}
       {donutData.current.length && (
-        <ResponsiveContainer width="100%" height={420}>
+        <ResponsiveContainer width="100%" height={calculateChartHeight()}>
           <PieChart>
             <Legend
               verticalAlign="top"
@@ -244,6 +271,11 @@ const DonutChartWidget = (props: Props) => {
               onClick={toggleParts}
               onMouseLeave={() => setPartsHover(null)}
               onMouseEnter={(e: any) => setPartsHover(e.value)}
+              layout={
+                windowSize.width <= smallScreenPixels || showMobilePreview
+                  ? "vertical"
+                  : undefined
+              }
             />
             <Pie
               data={donutData.current.map((d: any) => {
@@ -253,7 +285,13 @@ const DonutChartWidget = (props: Props) => {
               })}
               dataKey="value"
               nameKey="name"
-              cx={props.isPreview ? "50%" : "28%"}
+              cx={
+                props.isPreview ||
+                windowSize.width <= smallScreenPixels ||
+                showMobilePreview
+                  ? "50%"
+                  : "28%"
+              }
               cy="50%"
               outerRadius={120}
               innerRadius={80}

--- a/frontend/src/components/PieChartWidget.tsx
+++ b/frontend/src/components/PieChartWidget.tsx
@@ -7,7 +7,7 @@ import {
   Legend,
   Tooltip,
 } from "recharts";
-import { useColors } from "../hooks";
+import { useColors, useWindowSize } from "../hooks";
 import TickFormatter from "../services/TickFormatter";
 import MarkdownRender from "./MarkdownRender";
 import DataTable from "./DataTable";
@@ -195,6 +195,27 @@ const PieChartWidget = (props: Props) => {
     );
   };
 
+  const windowSize = useWindowSize();
+  const smallScreenPixels = 800;
+
+  const calculateChartHeight = (): number => {
+    const baseHeight = 240;
+    const pixelsByPart = 60;
+    const labelsPerRow = 3;
+
+    if (!data || !data.length) {
+      return baseHeight;
+    }
+
+    let additional;
+    if (windowSize.width <= smallScreenPixels || showMobilePreview) {
+      additional = data.length * pixelsByPart;
+    } else {
+      additional = (Math.floor(data.length / labelsPerRow) + 1) * pixelsByPart;
+    }
+    return baseHeight + additional;
+  };
+
   return (
     <div>
       <h2 className={`margin-bottom-${props.summaryBelow ? "4" : "1"}`}>
@@ -207,7 +228,7 @@ const PieChartWidget = (props: Props) => {
         />
       )}
       {pieData.current.length && (
-        <ResponsiveContainer width="100%" height={420}>
+        <ResponsiveContainer width="100%" height={calculateChartHeight()}>
           <PieChart>
             <Legend
               verticalAlign="top"
@@ -230,7 +251,13 @@ const PieChartWidget = (props: Props) => {
               })}
               dataKey="value"
               nameKey="name"
-              cx={props.isPreview ? "50%" : "28%"}
+              cx={
+                props.isPreview ||
+                showMobilePreview ||
+                windowSize.width <= smallScreenPixels
+                  ? "50%"
+                  : "28%"
+              }
               cy="50%"
               outerRadius={120}
               label={renderCustomizedLabel}

--- a/frontend/src/components/PieChartWidget.tsx
+++ b/frontend/src/components/PieChartWidget.tsx
@@ -201,9 +201,11 @@ const PieChartWidget = (props: Props) => {
   const smallScreenPixels = 800;
 
   const calculateChartHeight = (): number => {
-    const baseHeight = 240;
+    const baseHeight = 300;
     const pixelsByPart = 60;
-    const labelsPerRow = 3;
+    const pixelsByPartInPreview = 50;
+    const labelsPerRow = 4;
+    const labelsPerRowInPreview = 2;
 
     if (!data || !data.length) {
       return baseHeight;
@@ -212,6 +214,10 @@ const PieChartWidget = (props: Props) => {
     let additional;
     if (windowSize.width <= smallScreenPixels || showMobilePreview) {
       additional = data.length * pixelsByPart;
+    } else if (props.isPreview) {
+      additional =
+        (Math.floor(data.length / labelsPerRowInPreview) + 1) *
+        pixelsByPartInPreview;
     } else {
       additional = (Math.floor(data.length / labelsPerRow) + 1) * pixelsByPart;
     }

--- a/frontend/src/components/PieChartWidget.tsx
+++ b/frontend/src/components/PieChartWidget.tsx
@@ -176,6 +176,8 @@ const PieChartWidget = (props: Props) => {
         <span className="margin-left-05 font-sans-md text-bottom">
           {value.toLocaleString()}
         </span>
+        <div>{"\n"}</div>
+
         <div className="margin-left-4 margin-bottom-1 text-base-darkest text-bold">
           {value && value !== "null" ? (
             TickFormatter.format(
@@ -242,6 +244,11 @@ const PieChartWidget = (props: Props) => {
               onClick={toggleParts}
               onMouseLeave={() => setPartsHover(null)}
               onMouseEnter={(e: any) => setPartsHover(e.value)}
+              layout={
+                windowSize.width <= smallScreenPixels || showMobilePreview
+                  ? "vertical"
+                  : undefined
+              }
             />
             <Pie
               data={pieData.current.map((d: any) => {
@@ -253,8 +260,8 @@ const PieChartWidget = (props: Props) => {
               nameKey="name"
               cx={
                 props.isPreview ||
-                showMobilePreview ||
-                windowSize.width <= smallScreenPixels
+                windowSize.width <= smallScreenPixels ||
+                showMobilePreview
                   ? "50%"
                   : "28%"
               }

--- a/frontend/src/components/PieChartWidget.tsx
+++ b/frontend/src/components/PieChartWidget.tsx
@@ -176,8 +176,6 @@ const PieChartWidget = (props: Props) => {
         <span className="margin-left-05 font-sans-md text-bottom">
           {value.toLocaleString()}
         </span>
-        <div>{"\n"}</div>
-
         <div className="margin-left-4 margin-bottom-1 text-base-darkest text-bold">
           {value && value !== "null" ? (
             TickFormatter.format(


### PR DESCRIPTION
## Description

- Pie/donut charts are centered horizontally on mobile device and inside mobile preview so they are not cut off
- Pie/donut charts don't overlap with legend.

## Testing

Passed all unit tests and integration tests. You can test it out here: https://d1p86h8o9mi768.cloudfront.net/admin/dashboard/edit/36e206f5-ffa6-4b21-b8b9-f214f6909e6a

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
