### PR TITLE
GTT-1495: display column chart more spread out on mobile device/small screen

### DIFF
--- a/frontend/src/components/ColumnChartWidget.tsx
+++ b/frontend/src/components/ColumnChartWidget.tsx
@@ -12,7 +12,7 @@ import {
   CartesianGrid,
   Tooltip,
 } from "recharts";
-import { useColors, useYAxisMetadata } from "../hooks";
+import { useColors, useYAxisMetadata, useWindowSize } from "../hooks";
 import UtilsService from "../services/UtilsService";
 import TickFormatter from "../services/TickFormatter";
 import MarkdownRender from "./MarkdownRender";
@@ -59,7 +59,6 @@ const ColumnChartWidget = (props: Props) => {
   const pixelsByCharacter = 8;
   const previewWidth = 480;
   const fullWidth = 960;
-  const padding = props.isPreview ? 60 : 120;
 
   const getOpacity = useCallback(
     (dataKey) => {
@@ -71,7 +70,19 @@ const ColumnChartWidget = (props: Props) => {
     [columnsHover]
   );
 
+  const windowSize = useWindowSize();
+  const smallScreenPixels = 800;
+
   const { data, columns, showMobilePreview } = props;
+  let padding;
+  if (showMobilePreview || windowSize.width < smallScreenPixels) {
+    padding = 20;
+  } else if (props.isPreview) {
+    padding = 60;
+  } else {
+    padding = 120;
+  }
+
   const xAxisType = useCallback(() => {
     let columnMetadata;
     if (props.columnsMetadata && columns.length) {


### PR DESCRIPTION
## Description

Display column chart more spread out on mobile device and small screen. 

## Testing

Passed all unit tests and integration tests. You can check it out here: https://d1p86h8o9mi768.cloudfront.net/admin/dashboard/2c8827f0-7601-40b7-b726-2d275bfb557a

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
