### PR TITLE
GTT-1518: [Bug] Mobile preview checkbox not on same row as buttons in Portuguese

### DIFF
--- a/frontend/src/containers/ViewDashboardAdmin.tsx
+++ b/frontend/src/containers/ViewDashboardAdmin.tsx
@@ -142,6 +142,10 @@ function ViewDashboardAdmin() {
     );
   }
 
+  const isDraftOrPublishPending =
+    dashboard.state === DashboardState.Draft ||
+    dashboard.state === DashboardState.PublishPending;
+
   return (
     <>
       <Breadcrumbs
@@ -245,7 +249,11 @@ function ViewDashboardAdmin() {
               : "2"
           }`}
         >
-          <div className="grid-col text-left flex-row flex-align-center display-flex">
+          <div
+            className={`${
+              isDraftOrPublishPending ? "grid-col-3" : "grid-col"
+            } text-left flex-row flex-align-center display-flex`}
+          >
             <ul className="usa-button-group">
               <li className="usa-button-group__item">
                 <span
@@ -279,7 +287,11 @@ function ViewDashboardAdmin() {
               </li>
             </ul>
           </div>
-          <div className="grid-col text-right">
+          <div
+            className={`${
+              isDraftOrPublishPending ? "grid-col-9" : "grid-col"
+            } text-right`}
+          >
             {dashboard.state === DashboardState.Published && (
               <>
                 <Button


### PR DESCRIPTION
## Description

Mobile preview checkbox now shows up on the same row as the other two buttons on desktop fullscreen view.

## Testing

Passed all unit tests and integration tests. You can check it out below:
Draft: https://d1p86h8o9mi768.cloudfront.net/admin/dashboard/14227ccf-e538-49e0-9be1-13bfbb15b11e
Pending publish: https://d1p86h8o9mi768.cloudfront.net/admin/dashboard/a24a7de6-6a47-45d9-8245-0c85b56c91e7

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
