### PR TITLE
GTT-1498: Change version to 1.0.5.  Instruct user to get code from mainline, and not a particular tag, as unstable changes are now in mainline-dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ reported the issue. Please try to include as much information as you can. Detail
 
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the _mainline_ branch.
+1. You are working against the latest source on the _mainline-dev_ branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 

--- a/README.md
+++ b/README.md
@@ -33,15 +33,17 @@ PDoA comes with pre-built code to provision an instance in your AWS account. You
 
 | Region               | Launch                                                                                                                                                                                                                                                                                                                             |
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Install in us-east-1 | [![Install in us-east-1](docs/images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/quickcreate?templateURL=https://performance-dashboard-on-aws-solution-releases-us-west-2.s3.us-west-2.amazonaws.com/performance-dashboard-on-aws/v1.0.4/performance-dashboard-on-aws.template) |
+| Install in us-east-1 | [![Install in us-east-1](docs/images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/quickcreate?templateURL=https://performance-dashboard-on-aws-solution-releases-us-west-2.s3.us-west-2.amazonaws.com/performance-dashboard-on-aws/v1.0.5/performance-dashboard-on-aws.template) |
 
 ### Clone this repository
 
-The mainline branch of this repository develops rapidly. If you want to obtain the latest stable copy of the code, clone this repository using the tag of the most recent release, which currently is 1.0.4.
+If you want to obtain the latest stable copy of the code, clone this repository using the command below.
 
 ```
-$ git clone -b 1.0.4 https://github.com/awslabs/performance-dashboard-on-aws.git
+$ git clone https://github.com/awslabs/performance-dashboard-on-aws.git
 ```
+
+If you would like to contribute to the project, see the [contributing guidelines](CONTRIBUTING.md).
 
 ## Security
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "performance-dashboard-backend",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "performance-dashboard-backend",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Performance Dashboard on AWS Backend",
   "scripts": {
     "test": "LOG_LEVEL=SILENT jest --coverage --watchAll",

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "performance-dashboard-cdk",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "performance-dashboard-cdk",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Performance Dashboard on AWS CDK",
   "bin": {
     "cdk": "bin/main.js"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -25,7 +25,7 @@ If you're not familiar with deploying resources on AWS using CFT, start by revie
 
 | Region                | Launch                                                                                                                                                                                                                                                                                                                        |
 | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| US East (N. Virginia) | [![Install in us-east-1](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/quickcreate?templateURL=https://performance-dashboard-on-aws-solution-releases-us-west-2.s3.us-west-2.amazonaws.com/performance-dashboard-on-aws/v1.0.4/performance-dashboard-on-aws.template) |
+| US East (N. Virginia) | [![Install in us-east-1](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/quickcreate?templateURL=https://performance-dashboard-on-aws-solution-releases-us-west-2.s3.us-west-2.amazonaws.com/performance-dashboard-on-aws/v1.0.5/performance-dashboard-on-aws.template) |
 
 You will be directed to the CloudFormation console on your browser. Enter the stack name such as "MyCorp-PerfDash", and enter the email of the user who will initially administer PDoA in the "adminEmail" field, then press the "Next" button. Accept the default values on the next page, and press the Next button. Finally, check on the two "Capabilities" checkboxes at the bottom of the page. Press the "Create Stack" button. It will take about 25 minutes for the compute, storage, and database resources on AWS to be provisioned.
 
@@ -41,10 +41,10 @@ If you prefer to deploy PDoA in a region other than US East (N. Virginia), you m
 
 | Region                                          | Launch                                                                                                                                                                                                                                                                                                                                                  |
 | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Install this first in US East (N. Virginia)** | [![Install this first](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/quickcreate?templateURL=https://performance-dashboard-on-aws-solution-releases-us-west-2.s3.us-west-2.amazonaws.com/performance-dashboard-on-aws/v1.0.4/LambdaEdge.template)                                               |
-| Install PDoA in South America (São Paulo)       | [![Install in non US East (N. Virginia) region](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home?region=sa-east-1#/stacks/quickcreate?templateURL=https://performance-dashboard-on-aws-solution-releases-us-west-2.s3.us-west-2.amazonaws.com/performance-dashboard-on-aws/v1.0.4/performance-dashboard-on-aws.template)    |
-| Install PDoA in Canada (Central)                | [![Install in non US East (N. Virginia) region](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home?region=ca-central-1#/stacks/quickcreate?templateURL=https://performance-dashboard-on-aws-solution-releases-us-west-2.s3.us-west-2.amazonaws.com/performance-dashboard-on-aws/v1.0.4/performance-dashboard-on-aws.template) |
-| Install PDoA in Europe (London)                 | [![Install in non US East (N. Virginia) region](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home?region=eu-west-2#/stacks/quickcreate?templateURL=https://performance-dashboard-on-aws-solution-releases-us-west-2.s3.us-west-2.amazonaws.com/performance-dashboard-on-aws/v1.0.4/performance-dashboard-on-aws.template)    |
+| **Install this first in US East (N. Virginia)** | [![Install this first](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/quickcreate?templateURL=https://performance-dashboard-on-aws-solution-releases-us-west-2.s3.us-west-2.amazonaws.com/performance-dashboard-on-aws/v1.0.5/LambdaEdge.template)                                               |
+| Install PDoA in South America (São Paulo)       | [![Install in non US East (N. Virginia) region](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home?region=sa-east-1#/stacks/quickcreate?templateURL=https://performance-dashboard-on-aws-solution-releases-us-west-2.s3.us-west-2.amazonaws.com/performance-dashboard-on-aws/v1.0.5/performance-dashboard-on-aws.template)    |
+| Install PDoA in Canada (Central)                | [![Install in non US East (N. Virginia) region](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home?region=ca-central-1#/stacks/quickcreate?templateURL=https://performance-dashboard-on-aws-solution-releases-us-west-2.s3.us-west-2.amazonaws.com/performance-dashboard-on-aws/v1.0.5/performance-dashboard-on-aws.template) |
+| Install PDoA in Europe (London)                 | [![Install in non US East (N. Virginia) region](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home?region=eu-west-2#/stacks/quickcreate?templateURL=https://performance-dashboard-on-aws-solution-releases-us-west-2.s3.us-west-2.amazonaws.com/performance-dashboard-on-aws/v1.0.5/performance-dashboard-on-aws.template)    |
 
 ## Deploying with AWS Cloud Development Kit (CDK)
 
@@ -62,10 +62,10 @@ The following instructions assume that you have local AWS credentials in `~/.aws
 
 ### 1. Clone this repository
 
-The mainline branch of this repository develops rapidly. If you want to obtain the latest stable copy of the code, clone this repository using the tag of the most recent release, which currently is 1.0.4.
+Clone this repository to obtain the latest stable copy of the code:
 
 ```bash
-git clone -b 1.0.4 https://github.com/awslabs/performance-dashboard-on-aws.git
+git clone -b https://github.com/awslabs/performance-dashboard-on-aws.git
 cd performance-dashboard-on-aws
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -65,7 +65,7 @@ The following instructions assume that you have local AWS credentials in `~/.aws
 Clone this repository to obtain the latest stable copy of the code:
 
 ```bash
-git clone -b https://github.com/awslabs/performance-dashboard-on-aws.git
+git clone https://github.com/awslabs/performance-dashboard-on-aws.git
 cd performance-dashboard-on-aws
 ```
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "performance-dashboard-frontend",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "performance-dashboard-frontend",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "description": "Performance Dashboard on AWS Frontend",
   "dependencies": {


### PR DESCRIPTION
## Description

* ran release.sh to bump to version 1.0.5
* Update docs to instruct users to clone from mainline, as unstable code is now committed to mainline-dev during a sprint

## Testing

* ran unit tests
* deployed to AWS, and verified version 1.0.5 shows up in UI
* Ran integration tests

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
