### PR TITLE
GTT-1523: Added spacing to Actions drop-down on mobile preview

### DIFF
--- a/frontend/src/components/BarChartWidget.tsx
+++ b/frontend/src/components/BarChartWidget.tsx
@@ -237,10 +237,12 @@ const BarChartWidget = (props: Props) => {
         />
       </div>
       {props.summaryBelow && (
-        <MarkdownRender
-          source={props.summary}
-          className="usa-prose margin-top-1 margin-bottom-0 chartSummaryBelow"
-        />
+        <div style={showMobilePreview ? { clear: "left" } : {}}>
+          <MarkdownRender
+            source={props.summary}
+            className="usa-prose margin-top-1 margin-bottom-0 chartSummaryBelow"
+          />
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/ColumnChartWidget.tsx
+++ b/frontend/src/components/ColumnChartWidget.tsx
@@ -248,10 +248,12 @@ const ColumnChartWidget = (props: Props) => {
         />
       </div>
       {props.summaryBelow && (
-        <MarkdownRender
-          source={props.summary}
-          className="usa-prose margin-top-1 margin-bottom-0 chartSummaryBelow"
-        />
+        <div style={showMobilePreview ? { clear: "left" } : {}}>
+          <MarkdownRender
+            source={props.summary}
+            className="usa-prose margin-top-1 margin-bottom-0 chartSummaryBelow"
+          />
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/DonutChartWidget.tsx
+++ b/frontend/src/components/DonutChartWidget.tsx
@@ -349,10 +349,12 @@ const DonutChartWidget = (props: Props) => {
         />
       </div>
       {props.summaryBelow && (
-        <MarkdownRender
-          source={props.summary}
-          className="usa-prose margin-top-1 margin-bottom-0 chartSummaryBelow"
-        />
+        <div style={showMobilePreview ? { clear: "left" } : {}}>
+          <MarkdownRender
+            source={props.summary}
+            className="usa-prose margin-top-1 margin-bottom-0 chartSummaryBelow"
+          />
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/LineChartWidget.tsx
+++ b/frontend/src/components/LineChartWidget.tsx
@@ -220,10 +220,12 @@ const LineChartWidget = (props: Props) => {
         />
       </div>
       {props.summaryBelow && (
-        <MarkdownRender
-          source={props.summary}
-          className="usa-prose margin-top-1 margin-bottom-0 chartSummaryBelow"
-        />
+        <div style={showMobilePreview ? { clear: "left" } : {}}>
+          <MarkdownRender
+            source={props.summary}
+            className="usa-prose margin-top-1 margin-bottom-0 chartSummaryBelow"
+          />
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/PartWholeChartWidget.tsx
+++ b/frontend/src/components/PartWholeChartWidget.tsx
@@ -228,10 +228,12 @@ const PartWholeChartWidget = (props: Props) => {
         <DataTable rows={data || []} columns={parts} fileName={props.title} />
       </div>
       {props.summaryBelow && (
-        <MarkdownRender
-          source={props.summary}
-          className="usa-prose margin-top-1 margin-bottom-0 chartSummaryBelow"
-        />
+        <div style={showMobilePreview ? { clear: "left" } : {}}>
+          <MarkdownRender
+            source={props.summary}
+            className="usa-prose margin-top-1 margin-bottom-0 chartSummaryBelow"
+          />
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/PieChartWidget.tsx
+++ b/frontend/src/components/PieChartWidget.tsx
@@ -317,10 +317,12 @@ const PieChartWidget = (props: Props) => {
         />
       </div>
       {props.summaryBelow && (
-        <MarkdownRender
-          source={props.summary}
-          className="usa-prose margin-top-1 margin-bottom-0 chartSummaryBelow"
-        />
+        <div style={showMobilePreview ? { clear: "left" } : {}}>
+          <MarkdownRender
+            source={props.summary}
+            className="usa-prose margin-top-1 margin-bottom-0 chartSummaryBelow"
+          />
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Description

Previously for charts inside mobile preview, Actions drop-down would show up on the same row as summary when users choose to display summary below charts. Now Actions drop-down would show up above summary.

## Testing

Passed unit tests and integration tests.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
