### PR TITLE
GTT-1491: Dashboards page headers should appear to be clickable

### DIFF
--- a/frontend/src/components/Tab.tsx
+++ b/frontend/src/components/Tab.tsx
@@ -21,7 +21,7 @@ function Tab(props: Props) {
   }
 
   return (
-    <li className={className} onClick={onClick}>
+    <li className={className} onClick={onClick} style={{ cursor: "pointer" }}>
       {props.label}
     </li>
   );

--- a/frontend/src/components/__tests__/__snapshots__/Tab.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/Tab.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`renders the Tab component 1`] = `
 <div>
   <li
     class="display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md bg-white border-base-dark border-x-0 border-top-0 border-bottom-05"
+    style="cursor: pointer;"
   >
     Tab 1
   </li>
@@ -14,6 +15,7 @@ exports[`renders the Tab component with default tab 2 selected 1`] = `
 <div>
   <li
     class="display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md"
+    style="cursor: pointer;"
   >
     Tab 1
   </li>

--- a/frontend/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -10,11 +10,13 @@ exports[`renders the Tabs component 1`] = `
     >
       <li
         class="display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md bg-white border-base-dark border-x-0 border-top-0 border-bottom-05"
+        style="cursor: pointer;"
       >
         Tab 1
       </li>
       <li
         class="display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md"
+        style="cursor: pointer;"
       >
         Tab 2
       </li>
@@ -38,11 +40,13 @@ exports[`renders the Tabs component with default tab 2 selected 1`] = `
     >
       <li
         class="display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md"
+        style="cursor: pointer;"
       >
         Tab 1
       </li>
       <li
         class="display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md bg-white border-base-dark border-x-0 border-top-0 border-bottom-05"
+        style="cursor: pointer;"
       >
         Tab 2
       </li>


### PR DESCRIPTION
## Description

When hovering the cursor over Dashboards page headers, the cursor will become a pointer.

## Testing

Updated unit tests. Passed all unit tests and integration tests. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
