### PR TITLE
GTT-1532: Added E2E tests as a new GitHub workflow

### DIFF
--- a/.github/workflows/mainline-dev-e2e-tests.yml
+++ b/.github/workflows/mainline-dev-e2e-tests.yml
@@ -3,9 +3,11 @@
 name: E2E Tests
 
 on:
-  # Run e2e tests at midnight UTC time every day
+  # Run E2E check daily (16:42 UTC) or manually since scheduled checks
+  # are not guaranteed to run on time or run at all
   schedule:
-    - cron: " 0 0 * * * "
+    - cron: "42 16 * * *"
+  workflow_dispatch:
 
 jobs:
   tests:
@@ -33,4 +35,4 @@ jobs:
           export CYPRESS_defaultCommandTimeout=20000
           export CYPRESS_username=${{secrets.E2E_TEST_USERNAME}}
           export CYPRESS_password=${{secrets.E2E_TEST_PASSWORD}}
-          ./node_modules/.bin/cypress run  --config-file false
+          ./node_modules/.bin/cypress run  --config-file false --config video=false

--- a/.github/workflows/mainline-dev-e2e-tests.yml
+++ b/.github/workflows/mainline-dev-e2e-tests.yml
@@ -1,0 +1,36 @@
+# Workflow that runs end-to-end (E2E) tests every day against Gamma
+
+name: E2E Tests
+
+on:
+  # Run e2e tests at midnight UTC time every day
+  schedule:
+    - cron: " 0 0 * * * "
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: mainline-dev
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - run: |
+          cd e2e-tests
+          npm install
+          export CYPRESS_baseUrl=https://gamma.badger.wwps.aws.dev/
+          export CYPRESS_defaultCommandTimeout=20000
+          export CYPRESS_username=${{secrets.E2E_TEST_USERNAME}}
+          export CYPRESS_password=${{secrets.E2E_TEST_PASSWORD}}
+          ./node_modules/.bin/cypress run  --config-file false

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -18,17 +18,19 @@ Create a file `cypress.json` in the root of this directory with the following st
   "env": {
     "username": "foo",
     "password": "bar"
-  }
+  },
+  "defaultCommandTimeout": 8000
 }
 ```
 
 Replace the values in the JSON file according to your specific installation of PDoA. This file is ignored by git because it contains sensitive information. The following table describes what each field in the JSON file is used for:
 
-| JSON Field | Description                                                         |
-| ---------- | ------------------------------------------------------------------- |
-| baseUrl    | The URL of the UI where PDoA is deployed. Likely the CloudFront URL |
-| username   | Valid Cognito username used for tests                               |
-| password   | Password for the Cognito test user                                  |
+| JSON Field            | Description                                                         |
+| --------------------- | ------------------------------------------------------------------- |
+| baseUrl               | The URL of the UI where PDoA is deployed. Likely the CloudFront URL |
+| username              | Valid Cognito username used for tests                               |
+| password              | Password for the Cognito test user                                  |
+| defaultCommandTimeout | Default timeout in milliseconds for basic Cypress functions         |
 
 ## Run the tests
 

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -19,7 +19,7 @@ Create a file `cypress.json` in the root of this directory with the following st
     "username": "foo",
     "password": "bar"
   },
-  "defaultCommandTimeout": 8000
+  "defaultCommandTimeout": 20000
 }
 ```
 


### PR DESCRIPTION
## Description

- Updated e2e-tests README
- Added e2e tests as a new GitHub workflow that runs daily or manually 

Note: Adding a new GitHub workflow via merging a pull request is buggy sometimes, and the new workflow might not show up under action. If so, I'll need to manually create the workflow using GitHub website GUI.

## Testing

I tested it on a forked badger repo, and it was working properly. You can check it out here: https://github.com/yinxudeng/performance-dashboard-on-aws/actions/workflows/main.yml

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
