### PR TITLE
changed property used in the url matcher

### DIFF
--- a/e2e-tests/cypress/pages/DashboardListing.ts
+++ b/e2e-tests/cypress/pages/DashboardListing.ts
@@ -33,6 +33,18 @@ class DashboardListingPage {
   }
 
   deleteDashboard(dashboardName: string) {
+
+    //Setup intercepts early
+    cy.intercept({
+      method: "DELETE",
+      pathname: "/prod/dashboard",
+    }).as("deleteDashboardsRequest");
+
+    cy.intercept({
+      method: "GET",
+      pathname: "/prod/dashboard",
+    }).as("listDashboardRequest");
+
     // Search for dashboard by its name
     cy.findByRole("searchbox").type(dashboardName);
     cy.get("form[role='search']").submit();
@@ -46,17 +58,6 @@ class DashboardListingPage {
     // Click delete from the actions dropdown menu
     cy.findByRole("button", { name: "Actions" }).click();
     cy.get("div").contains("Delete").click();
-
-    // Wait for the requests to finish
-    cy.intercept({
-      method: "DELETE",
-      url: "/prod/dashboard",
-    }).as("deleteDashboardsRequest");
-
-    cy.intercept({
-      method: "GET",
-      url: "/prod/dashboard",
-    }).as("listDashboardRequest");
 
     // Accept modal confirmation prompt
     cy.findByRole("button", { name: "Delete" }).click();


### PR DESCRIPTION
## Description

Fixed the failing e2e tests by changing the RouteMatcher to use pathname.

Reading this doc: https://docs.cypress.io/api/commands/intercept#Arguments

`url - Full HTTP request URL` does not match the intelliense docs `If a string is passed, it will be used as a substring match, not an equality match.`

The intercept does not pickup the ajax call correctly. Changing it to path name.

`pathname  -HTTP request path after the hostname, without query parameters` 

works as expected.

## Testing

I ran the e2e tests and the issue was fixed

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
