### PR TITLE
small quality of life changes

### DIFF
--- a/e2e-tests/cypress/integration/settings.spec.ts
+++ b/e2e-tests/cypress/integration/settings.spec.ts
@@ -46,6 +46,8 @@ describe("Admin user", () => {
     topicAreaListingPage.waitUntilTopicAreasTableLoads();
 
     topicAreaListingPage.verifyTopicAreaLabel(newName, newNames);
+    
+    cy.reload();
 
     // Customize topic area label to old name
     cy.get("@oldName").then((oldName) => {
@@ -80,6 +82,8 @@ describe("Admin user", () => {
     topicAreaListingPage = createTopicAreaPage.submit();
     topicAreaListingPage.waitUntilTopicAreasTableLoads();
 
+    cy.reload();
+
     cy.contains(`"${topicAreaName}" topic area successfully created`);
     topicAreaListingPage.verifyTopicArea(topicAreaName);
 
@@ -93,6 +97,8 @@ describe("Admin user", () => {
 
     topicAreaListingPage = editTopicAreaPage.submit();
     topicAreaListingPage.waitUntilTopicAreasTableLoads();
+
+    cy.reload();
 
     cy.contains(`${newTopicAreaName} was successfully edited.`);
     topicAreaListingPage.verifyTopicArea(newTopicAreaName);
@@ -276,6 +282,8 @@ describe("Admin user", () => {
     cy.contains("Date and time format successfully edited.");
     dateTimeFormatPage.verifyFormat(newDateFormat, newTimeFormat);
 
+    cy.reload();
+    
     // Change to US date and time format and verify
     cy.get("@oldDateFormat").then((oldDateFormat) => {
       cy.get("@oldTimeFormat").then((oldTimeFormat) => {

--- a/e2e-tests/cypress/pages/CreateTopicArea.ts
+++ b/e2e-tests/cypress/pages/CreateTopicArea.ts
@@ -2,7 +2,7 @@ import TopicAreaListingPage from "./TopicAreaListing";
 
 class CreateTopicAreaPage {
   createTopicArea(topicAreaName: string) {
-    cy.findByLabelText("Topic Area name").type(topicAreaName);
+    cy.get("[data-testid='CreateTopicAreaForm'] input").type(topicAreaName);
   }
 
   submit(): TopicAreaListingPage {

--- a/e2e-tests/cypress/pages/DateTimeFormat.ts
+++ b/e2e-tests/cypress/pages/DateTimeFormat.ts
@@ -3,7 +3,7 @@ class DateTimeFormatPage {
     // Capture the http request
     cy.intercept({
       method: "GET",
-      url: "/prod/settings",
+      pathname: "/prod/settings",
     }).as("settingsRequest");
 
     // Direct user to edit date and time format page

--- a/e2e-tests/cypress/pages/EditTopicArea.ts
+++ b/e2e-tests/cypress/pages/EditTopicArea.ts
@@ -2,7 +2,7 @@ import TopicAreaListingPage from "./TopicAreaListing";
 
 class EditTopicAreaPage {
   editTopicArea(newName: string) {
-    cy.findByLabelText("Topic Area name").clear().type(newName);
+    cy.get("[data-testid='EditTopicAreaForm'] input").clear().type(newName);
   }
 
   submit(): TopicAreaListingPage {

--- a/e2e-tests/cypress/pages/PublishedSite.ts
+++ b/e2e-tests/cypress/pages/PublishedSite.ts
@@ -91,7 +91,7 @@ class PublishedSitePage {
   }
 
   verifyHeadlineAndDescription(headline: string, description: string) {
-    cy.get("div.Markdown.undefined").eq(2).contains(headline);
+    cy.get("[data-testid='published-site-headline'] .Markdown").contains(headline);
     cy.get("div.Markdown.undefined").eq(3).contains(description);
 
     cy.intercept({

--- a/e2e-tests/cypress/pages/Settings.ts
+++ b/e2e-tests/cypress/pages/Settings.ts
@@ -35,7 +35,7 @@ class SettingsPage {
     }).as("settingsRequest");
 
     // Direct user to Publishing guidance settings page
-    cy.get("a").contains("Topic Areas").click();
+    cy.get("a.usa-current[href='/admin/settings/topicarea']").click();
     cy.wait(["@settingsRequest", "@listTopicAreasRequest"]);
 
     return new TopicAreaListingPage();

--- a/e2e-tests/cypress/pages/TopicAreaListing.ts
+++ b/e2e-tests/cypress/pages/TopicAreaListing.ts
@@ -10,13 +10,13 @@ class TopicAreaListingPage {
   }
 
   goToEditTopicAreaLabel(): EditTopicAreaLabelPage {
-    cy.get("button").contains("Edit").click();
+    cy.get("[data-testid='edittopicarealabel']",).click();
     cy.contains("Edit topic area name");
     return new EditTopicAreaLabelPage();
   }
 
   goToCreateTopicArea(): CreateTopicAreaPage {
-    cy.get("button").contains("Create new topic area").click();
+    cy.get("[data-testid='createtopicarea']").click();
     cy.get("h1").contains("Create new topic area");
     return new CreateTopicAreaPage();
   }
@@ -54,7 +54,7 @@ class TopicAreaListingPage {
     // Capture the http requests
     cy.intercept({
       method: "DELETE",
-      url: "/prod/topicarea",
+      url: new RegExp('/prod/topicarea/'),
     }).as("deleteTopicAreaRequest");
 
     cy.intercept({

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16553,9 +16553,9 @@
       "integrity": "sha512-gbIXrYrENNQ/e4JoyK8LNfJXYYDaccu/7uT8izOq/0vWUKEdRFwCFvP1aLZWZnuE5tAaaFOlFdjynMh9PiC/dQ=="
     },
     "react-horizontal-scrolling-menu": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/react-horizontal-scrolling-menu/-/react-horizontal-scrolling-menu-2.0.9.tgz",
-      "integrity": "sha512-RF/D8X9ap1VNaXqB0WbBhbbmGE2RXuVho0DtnGpbxHV9Zi4mh+6emeLbzXCOYuWD5rXglr+mtN9PoCm2hH7Lvw=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-horizontal-scrolling-menu/-/react-horizontal-scrolling-menu-2.1.1.tgz",
+      "integrity": "sha512-D2CWWP3o1yo1LQ1Ya5J+IGPJiWoyaV2EPgNwpIjeURp7yidnYAzS7oUL8rsNOHiMGtcjb4awQXadat5Z2IyUfw=="
     },
     "react-i18next": {
       "version": "11.10.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,7 +41,7 @@
     "react-excel-renderer": "^1.1.0",
     "react-helmet": "^6.1.0",
     "react-hook-form": "^6.3.1",
-    "react-horizontal-scrolling-menu": "^2.0.9",
+    "react-horizontal-scrolling-menu": "^2.1.1",
     "react-i18next": "^11.10.0",
     "react-markdown": "^5.0.3",
     "react-modal": "^3.11.2",

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from "react";
+import { isPropertySignature } from "typescript";
 import "./Button.css";
 
 type Variant =
@@ -14,6 +15,7 @@ interface Props {
   onClick?: Function;
   variant?: Variant;
   className?: string;
+  testid?: string;
   disabled?: boolean;
   type?: "submit" | "reset" | "button";
   ariaLabel?: string;
@@ -50,6 +52,7 @@ const Button = React.forwardRef<HTMLButtonElement, Props>((props, ref) => {
 
   const button = (
     <button
+      data-testid={props.testid}
       aria-label={props.ariaLabel}
       className={`usa-button${variantClassName}${additionalClasses}`}
       disabled={props.disabled}

--- a/frontend/src/containers/EditTopicArea.tsx
+++ b/frontend/src/containers/EditTopicArea.tsx
@@ -84,6 +84,7 @@ function EditTopicArea() {
           <form
             onSubmit={handleSubmit(onSubmit)}
             className="usa-form usa-form--large"
+            data-testid="EditTopicAreaForm"
           >
             <TextField
               id="name"

--- a/frontend/src/containers/PublishedSiteSettings.tsx
+++ b/frontend/src/containers/PublishedSiteSettings.tsx
@@ -149,7 +149,7 @@ function PublishedSiteSettings() {
       ) : (
         <div className="grid-row margin-top-0-important">
           <div className="grid-col flex-9">
-            <div className="published-site font-sans-lg">
+            <div className="published-site font-sans-lg" data-testid="published-site-headline">
               <MarkdownRender source={homepage.title} />
             </div>
             <div className="grid-col flex-9">

--- a/frontend/src/containers/PublishedSiteSettings.tsx
+++ b/frontend/src/containers/PublishedSiteSettings.tsx
@@ -149,7 +149,10 @@ function PublishedSiteSettings() {
       ) : (
         <div className="grid-row margin-top-0-important">
           <div className="grid-col flex-9">
-            <div className="published-site font-sans-lg" data-testid="published-site-headline">
+            <div
+              className="published-site font-sans-lg"
+              data-testid="published-site-headline"
+            >
               <MarkdownRender source={homepage.title} />
             </div>
             <div className="grid-col flex-9">

--- a/frontend/src/containers/TopicareaListing.tsx
+++ b/frontend/src/containers/TopicareaListing.tsx
@@ -158,11 +158,10 @@ function TopicareaListing(props: Props) {
             </Button>
           </span>
           <span>
-            <Button 
-            testid={"createtopicarea"}
-            onClick={createTopicArea}>{`${t(
-              "CreateNew"
-            )} ${settings.topicAreaLabels.singular.toLowerCase()}`}
+            <Button testid={"createtopicarea"} onClick={createTopicArea}>
+              {`${t(
+                "CreateNew"
+              )} ${settings.topicAreaLabels.singular.toLowerCase()}`}
             </Button>
           </span>
         </div>

--- a/frontend/src/containers/TopicareaListing.tsx
+++ b/frontend/src/containers/TopicareaListing.tsx
@@ -158,9 +158,12 @@ function TopicareaListing(props: Props) {
             </Button>
           </span>
           <span>
-            <Button onClick={createTopicArea}>{`${t(
+            <Button 
+            testid={"createtopicarea"}
+            onClick={createTopicArea}>{`${t(
               "CreateNew"
-            )} ${settings.topicAreaLabels.singular.toLowerCase()}`}</Button>
+            )} ${settings.topicAreaLabels.singular.toLowerCase()}`}
+            </Button>
           </span>
         </div>
       </div>

--- a/frontend/src/containers/TopicareaSettings.tsx
+++ b/frontend/src/containers/TopicareaSettings.tsx
@@ -42,6 +42,7 @@ function TopicareaSettings() {
             </div>
             <div className="grid-col flex-3 text-right">
               <Button
+                testid={"edittopicarealabel"}
                 className="margin-top-2"
                 variant="outline"
                 onClick={onTopicAreaLabelEdit}

--- a/frontend/src/containers/__tests__/__snapshots__/PublishedSiteSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/PublishedSiteSettings.test.tsx.snap
@@ -314,6 +314,7 @@ exports[`published site settings should match snapshot 1`] = `
             >
               <div
                 class="published-site font-sans-lg"
+                data-testid="published-site-headline"
               >
                 <div
                   class="Markdown undefined"

--- a/frontend/src/containers/__tests__/__snapshots__/TopicareaSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/TopicareaSettings.test.tsx.snap
@@ -185,6 +185,7 @@ exports[`topic area settings should match snapshot 1`] = `
             >
               <button
                 class="usa-button usa-button--outline margin-top-2"
+                data-testid="edittopicarealabel"
               >
                 Edit
               </button>
@@ -316,6 +317,7 @@ exports[`topic area settings should match snapshot 1`] = `
               <span>
                 <button
                   class="usa-button usa-button--base"
+                  data-testid="createtopicarea"
                 >
                   Create new ministry
                 </button>


### PR DESCRIPTION
## Description

The list of changes here to fix all of the e2e tests are not comprehensive. My changes were to investigate general failures in the test.

cy.intercept

```
    cy.intercept({
      method: "DELETE",
      url: new RegExp('/prod/topicarea/'),
    }).as("deleteTopicAreaRequest");
```
The documentation vs the intellisense makes this a bit confusing coupled with implementation route with values in route vs parameters. The general safe bet to make this check more durable would be using `url: new Regex()` to capture the requests.

In several places I added `cy.reload();` during testing I found that a lot of selectors would work the first time but then a DOM disconnected error was occurring. The fix posted on SO and on Cypress FAQ is to not cache selected elements. In this case the selected elements were not cached. I have to assume that `cy.get()` was internally caches or interacting with shadow DOM. Calling reload resolved the issue. 

A couple of places I added data-testid attribute, to fix some selector issues. This was already used in a few places and a recommended practice by Cypress to make selectors a bit more durable.

## Testing

Ran e2e tests to verify changes worked consistently.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
