### PR TITLE
GTT-1565: Use name when download a file inside a section tab

### DIFF
--- a/frontend/src/components/BarChartWidget.tsx
+++ b/frontend/src/components/BarChartWidget.tsx
@@ -21,6 +21,7 @@ import { ColumnDataType, CurrencyDataType, NumberDataType } from "../models";
 
 type Props = {
   title: string;
+  downloadTitle: string;
   summary: string;
   bars: Array<string>;
   data?: Array<any>;
@@ -320,7 +321,7 @@ const BarChartWidget = (props: Props) => {
           rows={data || []}
           columns={bars}
           columnsMetadata={props.columnsMetadata}
-          fileName={props.title}
+          fileName={props.downloadTitle}
         />
       </div>
       {props.summaryBelow && (

--- a/frontend/src/components/ChartWidget.tsx
+++ b/frontend/src/components/ChartWidget.tsx
@@ -61,6 +61,7 @@ function ChartWidgetComponent(props: Props) {
           title={
             !props.hideTitle && props.widget.showTitle ? content.title : ""
           }
+          downloadTitle={content.title}
           summary={content.summary}
           summaryBelow={content.summaryBelow}
           lines={keys}
@@ -78,6 +79,7 @@ function ChartWidgetComponent(props: Props) {
           title={
             !props.hideTitle && props.widget.showTitle ? content.title : ""
           }
+          downloadTitle={content.title}
           summary={content.summary}
           summaryBelow={content.summaryBelow}
           columns={keys}
@@ -97,6 +99,7 @@ function ChartWidgetComponent(props: Props) {
           title={
             !props.hideTitle && props.widget.showTitle ? content.title : ""
           }
+          downloadTitle={content.title}
           summary={content.summary}
           summaryBelow={content.summaryBelow}
           bars={keys}
@@ -115,6 +118,7 @@ function ChartWidgetComponent(props: Props) {
           title={
             !props.hideTitle && props.widget.showTitle ? content.title : ""
           }
+          downloadTitle={content.title}
           summary={content.summary}
           summaryBelow={content.summaryBelow}
           parts={keys}
@@ -131,6 +135,7 @@ function ChartWidgetComponent(props: Props) {
           title={
             !props.hideTitle && props.widget.showTitle ? content.title : ""
           }
+          downloadTitle={content.title}
           summary={content.summary}
           summaryBelow={content.summaryBelow}
           parts={keys}
@@ -149,6 +154,7 @@ function ChartWidgetComponent(props: Props) {
           title={
             !props.hideTitle && props.widget.showTitle ? content.title : ""
           }
+          downloadTitle={content.title}
           summary={content.summary}
           summaryBelow={content.summaryBelow}
           parts={keys}

--- a/frontend/src/components/ColumnChartWidget.tsx
+++ b/frontend/src/components/ColumnChartWidget.tsx
@@ -21,6 +21,7 @@ import { ColumnDataType, CurrencyDataType, NumberDataType } from "../models";
 
 type Props = {
   title: string;
+  downloadTitle: string;
   summary: string;
   columns: Array<string>;
   data?: Array<any>;
@@ -331,7 +332,7 @@ const ColumnChartWidget = (props: Props) => {
           rows={data || []}
           columns={columns}
           columnsMetadata={props.columnsMetadata}
-          fileName={props.title}
+          fileName={props.downloadTitle}
         />
       </div>
       {props.summaryBelow && (

--- a/frontend/src/components/DonutChartWidget.tsx
+++ b/frontend/src/components/DonutChartWidget.tsx
@@ -16,6 +16,7 @@ import { ColumnMetadata, NumberDataType } from "../models";
 
 type Props = {
   title: string;
+  downloadTitle: string;
   summary: string;
   parts: Array<string>;
   data?: Array<object>;
@@ -365,7 +366,7 @@ const DonutChartWidget = (props: Props) => {
         <DataTable
           rows={data || []}
           columns={parts}
-          fileName={props.title}
+          fileName={props.downloadTitle}
           columnsMetadata={props.columnsMetadata}
         />
       </div>

--- a/frontend/src/components/LineChartWidget.tsx
+++ b/frontend/src/components/LineChartWidget.tsx
@@ -20,6 +20,7 @@ import { ColumnDataType } from "../models";
 
 type Props = {
   title: string;
+  downloadTitle: string;
   summary: string;
   lines: Array<string>;
   data?: Array<any>;
@@ -220,7 +221,7 @@ const LineChartWidget = (props: Props) => {
           rows={data || []}
           columns={lines}
           columnsMetadata={props.columnsMetadata}
-          fileName={props.title}
+          fileName={props.downloadTitle}
         />
       </div>
       {props.summaryBelow && (

--- a/frontend/src/components/PartWholeChartWidget.tsx
+++ b/frontend/src/components/PartWholeChartWidget.tsx
@@ -15,6 +15,7 @@ import DataTable from "./DataTable";
 
 type Props = {
   title: string;
+  downloadTitle: string;
   summary: string;
   parts: Array<string>;
   data?: Array<object>;
@@ -242,7 +243,7 @@ const PartWholeChartWidget = (props: Props) => {
         <DataTable
           rows={data || []}
           columns={parts}
-          fileName={props.title}
+          fileName={props.downloadTitle}
           columnsMetadata={props.columnsMetadata}
         />
       </div>

--- a/frontend/src/components/PieChartWidget.tsx
+++ b/frontend/src/components/PieChartWidget.tsx
@@ -15,6 +15,7 @@ import { ColumnMetadata, NumberDataType } from "../models";
 
 type Props = {
   title: string;
+  downloadTitle: string;
   summary: string;
   parts: Array<string>;
   data?: Array<object>;
@@ -331,7 +332,7 @@ const PieChartWidget = (props: Props) => {
         <DataTable
           rows={data || []}
           columns={parts}
-          fileName={props.title}
+          fileName={props.downloadTitle}
           columnsMetadata={props.columnsMetadata}
         />
       </div>

--- a/frontend/src/components/VisualizeChart.tsx
+++ b/frontend/src/components/VisualizeChart.tsx
@@ -405,6 +405,7 @@ function VisualizeChart(props: Props) {
               {props.chartType === ChartType.LineChart && (
                 <LineChartWidget
                   title={props.showTitle ? props.title : ""}
+                  downloadTitle={props.title}
                   summary={props.summary}
                   lines={
                     props.json.length
@@ -423,6 +424,7 @@ function VisualizeChart(props: Props) {
               {props.chartType === ChartType.ColumnChart && (
                 <ColumnChartWidget
                   title={props.showTitle ? props.title : ""}
+                  downloadTitle={props.title}
                   summary={props.summary}
                   columns={
                     props.json.length
@@ -443,6 +445,7 @@ function VisualizeChart(props: Props) {
               {props.chartType === ChartType.BarChart && (
                 <BarChartWidget
                   title={props.showTitle ? props.title : ""}
+                  downloadTitle={props.title}
                   summary={props.summary}
                   bars={
                     props.json.length
@@ -460,6 +463,7 @@ function VisualizeChart(props: Props) {
               {props.chartType === ChartType.PartWholeChart && (
                 <PartWholeChartWidget
                   title={props.showTitle ? props.title : ""}
+                  downloadTitle={props.title}
                   summary={props.summary}
                   parts={
                     props.json.length
@@ -475,6 +479,7 @@ function VisualizeChart(props: Props) {
               {props.chartType === ChartType.PieChart && (
                 <PieChartWidget
                   title={props.showTitle ? props.title : ""}
+                  downloadTitle={props.title}
                   summary={props.summary}
                   parts={
                     props.json.length
@@ -493,6 +498,7 @@ function VisualizeChart(props: Props) {
               {props.chartType === ChartType.DonutChart && (
                 <DonutChartWidget
                   title={props.showTitle ? props.title : ""}
+                  downloadTitle={props.title}
                   summary={props.summary}
                   parts={
                     props.json.length

--- a/frontend/src/components/__tests__/BarChartWidget.test.tsx
+++ b/frontend/src/components/__tests__/BarChartWidget.test.tsx
@@ -7,6 +7,7 @@ test("renders the chart title", async () => {
   render(
     <BarChartWidget
       title="test title"
+      downloadTitle="test title"
       summary="test summary"
       bars={["test"]}
       data={[{ col: "column name", test: 1 }]}
@@ -23,6 +24,7 @@ test("renders chart summary above the chart", async () => {
   render(
     <BarChartWidget
       title="test title"
+      downloadTitle="test title"
       summary="test summary"
       bars={["test"]}
       data={[{ col: "column name", test: 1 }]}
@@ -42,6 +44,7 @@ test("renders chart summary below the chart", async () => {
   render(
     <BarChartWidget
       title="test title"
+      downloadTitle="test title"
       summary="test summary"
       bars={["test"]}
       data={[{ col: "column name", test: 1 }]}

--- a/frontend/src/components/__tests__/ColumnChartWidget.test.tsx
+++ b/frontend/src/components/__tests__/ColumnChartWidget.test.tsx
@@ -7,6 +7,7 @@ test("renders the chart title", async () => {
   render(
     <ColumnChartWidget
       title="test title"
+      downloadTitle="test title"
       summary="test summary"
       columns={["test"]}
       data={[{ test: 1 }]}
@@ -23,6 +24,7 @@ test("renders chart summary above the chart", async () => {
   render(
     <ColumnChartWidget
       title="test title"
+      downloadTitle="test title"
       summary="test summary"
       columns={["test"]}
       data={[{ test: 1 }]}
@@ -42,6 +44,7 @@ test("renders chart summary below the chart", async () => {
   render(
     <ColumnChartWidget
       title="test title"
+      downloadTitle="test title"
       summary="test summary"
       columns={["test"]}
       data={[{ test: 1 }]}

--- a/frontend/src/components/__tests__/DonutChartWidget.test.tsx
+++ b/frontend/src/components/__tests__/DonutChartWidget.test.tsx
@@ -7,6 +7,7 @@ test("renders the chart title", async () => {
   render(
     <DonutChartWidget
       title="test title"
+      downloadTitle="test title"
       summary="test summary"
       parts={["test"]}
       summaryBelow={false}
@@ -23,6 +24,7 @@ test("renders the summary above the chart", async () => {
   render(
     <DonutChartWidget
       title="test title"
+      downloadTitle="test title"
       summary="test summary"
       parts={["test"]}
       summaryBelow={false}
@@ -42,6 +44,7 @@ test("renders the summary below the chart", async () => {
   render(
     <DonutChartWidget
       title="test title"
+      downloadTitle="test title"
       summary="test summary"
       parts={["test"]}
       summaryBelow={true}

--- a/frontend/src/components/__tests__/LineChartWidget.test.tsx
+++ b/frontend/src/components/__tests__/LineChartWidget.test.tsx
@@ -7,6 +7,7 @@ test("renders the chart title", async () => {
   render(
     <LineChartWidget
       title="test title"
+      downloadTitle="test title"
       summary="test summary"
       lines={["test"]}
       data={[{ test: 1 }]}
@@ -23,6 +24,7 @@ test("renders chart summary above the chart", async () => {
   render(
     <LineChartWidget
       title="test title"
+      downloadTitle="test title"
       summary="test summary"
       lines={["test"]}
       data={[{ test: 1 }]}
@@ -42,6 +44,7 @@ test("renders chart summary below the chart", async () => {
   render(
     <LineChartWidget
       title="test title"
+      downloadTitle="test title"
       summary="test summary"
       lines={["test"]}
       data={[{ test: 1 }]}

--- a/frontend/src/components/__tests__/PartWholeChartWidget.test.tsx
+++ b/frontend/src/components/__tests__/PartWholeChartWidget.test.tsx
@@ -7,6 +7,7 @@ test("renders the chart title", async () => {
   render(
     <PartWholeChartWidget
       title="test title"
+      downloadTitle="test title"
       summary="test summary"
       parts={["test"]}
       summaryBelow={false}
@@ -23,6 +24,7 @@ test("renders the summary above the chart", async () => {
   render(
     <PartWholeChartWidget
       title="test title"
+      downloadTitle="test title"
       summary="test summary"
       parts={["test"]}
       summaryBelow={false}
@@ -42,6 +44,7 @@ test("renders the summary below the chart", async () => {
   render(
     <PartWholeChartWidget
       title="test title"
+      downloadTitle="test title"
       summary="test summary"
       parts={["test"]}
       summaryBelow={true}

--- a/frontend/src/components/__tests__/PieChartWidget.test.tsx
+++ b/frontend/src/components/__tests__/PieChartWidget.test.tsx
@@ -7,6 +7,7 @@ test("renders the chart title", async () => {
   render(
     <PieChartWidget
       title="test title"
+      downloadTitle="test title"
       summary="test summary"
       parts={["test"]}
       summaryBelow={false}
@@ -23,6 +24,7 @@ test("renders the summary above the chart", async () => {
   render(
     <PieChartWidget
       title="test title"
+      downloadTitle="test title"
       summary="test summary"
       parts={["test"]}
       summaryBelow={false}
@@ -42,6 +44,7 @@ test("renders the summary below the chart", async () => {
   render(
     <PieChartWidget
       title="test title"
+      downloadTitle="test title"
       summary="test summary"
       parts={["test"]}
       summaryBelow={true}

--- a/frontend/src/containers/EditColors.tsx
+++ b/frontend/src/containers/EditColors.tsx
@@ -185,6 +185,7 @@ function EditColors() {
               <div className="grid-col-5">
                 <BarChartWidget
                   title=""
+                  downloadTitle="Edit colors bar sample"
                   summary=""
                   bars={datasetBar.dataset.headers}
                   data={datasetBar.dataset.data}
@@ -199,6 +200,7 @@ function EditColors() {
               <div className="grid-col-7">
                 <ColumnChartWidget
                   title=""
+                  downloadTitle="Edit colors column sample"
                   summary=""
                   columns={datasetColumn.dataset.headers}
                   data={datasetColumn.dataset.data}

--- a/frontend/src/containers/FormattingCSV.tsx
+++ b/frontend/src/containers/FormattingCSV.tsx
@@ -68,6 +68,7 @@ function FormattingCSV() {
       <div>
         <LineChartWidget
           title=""
+          downloadTitle="Line chart sample"
           summary=""
           lines={lineChart.dataset.headers}
           data={lineChart.dataset.data}
@@ -100,6 +101,7 @@ function FormattingCSV() {
       <div>
         <BarChartWidget
           title=""
+          downloadTitle="Bar chart sample"
           summary=""
           bars={bar.dataset.headers}
           data={bar.dataset.data}
@@ -132,6 +134,7 @@ function FormattingCSV() {
       <div>
         <ColumnChartWidget
           title=""
+          downloadTitle="Column chart sample"
           summary=""
           columns={column.dataset.headers}
           data={column.dataset.data}
@@ -164,6 +167,7 @@ function FormattingCSV() {
       <div>
         <PartWholeChartWidget
           title=""
+          downloadTitle="Part-to-whole chart sample"
           summary=""
           parts={partToWhole.dataset.headers}
           data={partToWhole.dataset.data}
@@ -196,6 +200,7 @@ function FormattingCSV() {
       <div>
         <PieChartWidget
           title=""
+          downloadTitle="Pie chart sample"
           summary=""
           parts={pie.dataset.headers}
           data={pie.dataset.data}
@@ -228,6 +233,7 @@ function FormattingCSV() {
       <div>
         <DonutChartWidget
           title=""
+          downloadTitle="Donut chart sample"
           summary=""
           parts={donut.dataset.headers}
           data={donut.dataset.data}
@@ -259,7 +265,7 @@ function FormattingCSV() {
       <hr />
       <div>
         <TableWidget
-          title=""
+          title="Table sample"
           summary=""
           data={table.dataset.data}
           summaryBelow={false}


### PR DESCRIPTION
## Description

Use name when download a file inside a section tab.

## Testing

You can test it here: https://migdizn.badger.wwps.aws.dev/admin/dashboard/6a7412e7-f962-4d76-835d-74a2a92ec219#1255ed82-cc1b-42af-9a1b-290a005bc84f

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
