### PR TITLE
Add back button to ChooseData component

### DIFF
--- a/frontend/src/components/ChooseData.tsx
+++ b/frontend/src/components/ChooseData.tsx
@@ -14,6 +14,7 @@ interface Props {
   datasetType: DatasetType | undefined;
   register: Function;
   onCancel: Function;
+  backStep: Function;
   advanceStep: Function;
   fileLoading: boolean;
   csvErrors: Array<object> | undefined;
@@ -248,6 +249,9 @@ function ChooseData(props: Props) {
       <br />
       <br />
       <hr />
+      <Button variant="outline" type="button" onClick={props.backStep}>
+        {t("BackButton")}
+      </Button>
       <Button
         type="button"
         onClick={props.advanceStep}

--- a/frontend/src/components/__tests__/ChooseData.test.tsx
+++ b/frontend/src/components/__tests__/ChooseData.test.tsx
@@ -23,6 +23,7 @@ test("renders the ChooseData component", async () => {
       datasetType={DatasetType.DynamicDataset}
       onFileProcessed={() => {}}
       handleChange={() => {}}
+      backStep={() => {}}
       advanceStep={() => {}}
       fileLoading={false}
       browseDatasets={() => {}}

--- a/frontend/src/components/__tests__/__snapshots__/ChooseData.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/ChooseData.test.tsx.snap
@@ -649,6 +649,12 @@ exports[`renders the ChooseData component 1`] = `
   <br />
   <hr />
   <button
+    class="usa-button usa-button--outline"
+    type="button"
+  >
+    Back
+  </button>
+  <button
     class="usa-button usa-button--base"
     type="button"
   >

--- a/frontend/src/containers/AddChart.tsx
+++ b/frontend/src/containers/AddChart.tsx
@@ -260,6 +260,10 @@ function AddChart() {
     setStep(step - 1);
   };
 
+  const goBack = () => {
+    history.push(`/admin/dashboard/${dashboardId}/add-content`);
+  };
+
   const browseDatasets = () => {
     history.push({
       pathname: `/admin/dashboard/${dashboardId}/choose-static-dataset`,
@@ -433,6 +437,7 @@ function AddChart() {
                   datasetType={datasetType}
                   onFileProcessed={onFileProcessed}
                   handleChange={handleChange}
+                  backStep={goBack}
                   advanceStep={advanceStep}
                   fileLoading={fileLoading}
                   browseDatasets={browseDatasets}

--- a/frontend/src/containers/AddTable.tsx
+++ b/frontend/src/containers/AddTable.tsx
@@ -217,6 +217,10 @@ function AddTable() {
     setStep(step - 1);
   };
 
+  const goBack = () => {
+    history.push(`/admin/dashboard/${dashboardId}/add-content`);
+  };
+
   const selectDynamicDataset = async (selectedDataset: Dataset) => {
     setDatasetLoading(true);
 
@@ -357,6 +361,7 @@ function AddTable() {
                 datasetType={datasetType}
                 onFileProcessed={onFileProcessed}
                 handleChange={handleChange}
+                backStep={goBack}
                 advanceStep={advanceStep}
                 fileLoading={fileLoading}
                 browseDatasets={browseDatasets}

--- a/frontend/src/containers/EditChart.tsx
+++ b/frontend/src/containers/EditChart.tsx
@@ -478,6 +478,10 @@ function EditChart() {
     setStep(step - 1);
   };
 
+  const goBack = () => {
+    history.push(`/admin/dashboard/${dashboardId}/add-content`);
+  };
+
   const browseDatasets = () => {
     history.push({
       pathname: `/admin/dashboard/${dashboardId}/choose-static-dataset`,
@@ -609,6 +613,7 @@ function EditChart() {
                     datasetType={displayedDatasetType}
                     onFileProcessed={onFileProcessed}
                     handleChange={handleChange}
+                    backStep={goBack}
                     advanceStep={advanceStep}
                     fileLoading={fileLoading}
                     browseDatasets={browseDatasets}

--- a/frontend/src/containers/EditTable.tsx
+++ b/frontend/src/containers/EditTable.tsx
@@ -401,6 +401,10 @@ function EditTable() {
     setStep(step - 1);
   };
 
+  const goBack = () => {
+    history.push(`/admin/dashboard/${dashboardId}/add-content`);
+  };
+
   const browseDatasets = () => {
     history.push({
       pathname: `/admin/dashboard/${dashboardId}/choose-static-dataset`,
@@ -526,6 +530,7 @@ function EditTable() {
                     datasetType={displayedDatasetType}
                     onFileProcessed={onFileProcessed}
                     handleChange={handleChange}
+                    backStep={goBack}
                     advanceStep={advanceStep}
                     fileLoading={fileLoading}
                     browseDatasets={browseDatasets}


### PR DESCRIPTION
## Description

Add back button for ChooseData component.

## Testing

Describe how you tested your changes and/or give instructions to the reviewers on how they can verify them.
 
1- Go to https://d8deswpe5z99x.cloudfront.net/admin
2- Create/edit a dashboard
3- Create/edit table or chart content
4- Verify that Back button is available in the Choose Data page
5- Verify that it takes you to the content type selector.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
