### PR TITLE
GTT-898: Add option to not show all rows of extensive tables

### DIFF
--- a/backend/src/lib/factories/__tests__/widget-factory.test.ts
+++ b/backend/src/lib/factories/__tests__/widget-factory.test.ts
@@ -239,6 +239,7 @@ describe("createTableWidget", () => {
       sortByColumn: "cases",
       sortByDesc: false,
       significantDigitLabels: true,
+      displayWithPages: true,
       columnsMetadata: [
         {
           hidden: false,
@@ -274,6 +275,7 @@ describe("createTableWidget", () => {
     expect(widget.content.sortByColumn).toEqual("cases");
     expect(widget.content.sortByDesc).toBe(false);
     expect(widget.content.significantDigitLabels).toBe(true);
+    expect(widget.content.displayWithPages).toBe(true);
   });
 
   it("throws an error if table title is undefined", () => {
@@ -406,6 +408,7 @@ describe("fromItem", () => {
         sortByColumn: "foo",
         sortByDesc: false,
         significantDigitLabels: true,
+        displayWithPages: true,
         columnsMetadata: [
           {
             columnName: "foo",
@@ -434,6 +437,7 @@ describe("fromItem", () => {
     expect(widget.content.sortByColumn).toEqual("foo");
     expect(widget.content.sortByDesc).toBe(false);
     expect(widget.content.significantDigitLabels).toBe(true);
+    expect(widget.content.displayWithPages).toBe(true);
     expect(widget.content.columnsMetadata).toEqual([
       {
         columnName: "foo",
@@ -607,6 +611,7 @@ describe("toItem", () => {
         sortByColumn: "deaths",
         sortByDesc: true,
         significantDigitLabels: true,
+        displayWithPages: true,
         columnsMetadata: [
           {
             hidden: false,
@@ -645,6 +650,7 @@ describe("toItem", () => {
       sortByColumn: "deaths",
       sortByDesc: true,
       significantDigitLabels: true,
+      displayWithPages: true,
       columnsMetadata: [
         {
           hidden: false,

--- a/backend/src/lib/factories/widget-factory.ts
+++ b/backend/src/lib/factories/widget-factory.ts
@@ -163,6 +163,10 @@ function fromTableItem(widget: Widget): TableWidget {
         tableWidget.content.significantDigitLabels !== undefined
           ? tableWidget.content.significantDigitLabels
           : false,
+      displayWithPages:
+        tableWidget.content.displayWithPages !== undefined
+          ? tableWidget.content.displayWithPages
+          : false,
     },
   };
 }
@@ -333,6 +337,10 @@ function createTableWidget(widget: Widget): TableWidget {
       significantDigitLabels:
         widget.content.significantDigitLabels !== undefined
           ? widget.content.significantDigitLabels
+          : false,
+      displayWithPages:
+        widget.content.displayWithPages !== undefined
+          ? widget.content.displayWithPages
           : false,
     },
   };

--- a/backend/src/lib/models/widget.ts
+++ b/backend/src/lib/models/widget.ts
@@ -110,6 +110,7 @@ export interface TableWidget extends Widget {
     sortByColumn?: string;
     sortByDesc?: boolean;
     significantDigitLabels: boolean;
+    displayWithPages: boolean;
     s3Key: {
       raw: string;
       json: string;

--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -46,11 +46,13 @@ interface Props {
   setSortByColumn?: Function;
   setSortByDesc?: Function;
   reset?: Function;
+  mobileNavigation?: boolean;
 }
 
 function Table(props: Props) {
   const { t } = useTranslation();
   const windowSize = useWindowSize();
+  const isMobile = props.mobileNavigation || windowSize.width <= 600;
   const borderlessClassName = !props.disableBorderless
     ? " usa-table--borderless"
     : "";
@@ -351,12 +353,12 @@ function Table(props: Props) {
       {!props.disablePagination && rows.length ? (
         <div
           className={`${
-            windowSize.width <= 600 ? "grid-col" : "grid-row margin-bottom-05"
+            isMobile ? "grid-col" : "grid-row margin-bottom-05"
           } font-sans-sm`}
         >
           <div
             className={`${
-              windowSize.width <= 600
+              isMobile
                 ? "grid-row margin-bottom-2 margin-left-05"
                 : "grid-col-3 text-left"
             } text-base text-italic`}
@@ -368,37 +370,42 @@ function Table(props: Props) {
           </div>
           <div
             className={`${
-              windowSize.width <= 600
-                ? "margin-left-05"
-                : "grid-col-6 text-center"
+              isMobile ? "margin-left-05" : "grid-col-6 text-center"
             }`}
           >
-            <button
-              type="button"
-              className="margin-right-1"
-              onClick={() => {
-                setCurrentPage("1");
-                gotoPage(0);
-              }}
-              disabled={!canPreviousPage}
-            >
-              <FontAwesomeIcon
-                icon={faAngleDoubleLeft}
-                className="margin-top-2px"
-              />
-            </button>
-            <button
-              type="button"
-              className="margin-right-2"
-              onClick={() => {
-                setCurrentPage(`${pageIndex}`);
-                previousPage();
-              }}
-              disabled={!canPreviousPage}
-            >
-              <FontAwesomeIcon icon={faAngleLeft} className="margin-top-2px" />
-            </button>
-            {windowSize.width <= 600 ? <div className="margin-bottom-1" /> : ""}
+            {!isMobile && (
+              <>
+                <button
+                  type="button"
+                  className="margin-right-1"
+                  onClick={() => {
+                    setCurrentPage("1");
+                    gotoPage(0);
+                  }}
+                  disabled={!canPreviousPage}
+                >
+                  <FontAwesomeIcon
+                    icon={faAngleDoubleLeft}
+                    className="margin-top-2px"
+                  />
+                </button>
+                <button
+                  type="button"
+                  className="margin-right-2"
+                  onClick={() => {
+                    setCurrentPage(`${pageIndex}`);
+                    previousPage();
+                  }}
+                  disabled={!canPreviousPage}
+                >
+                  <FontAwesomeIcon
+                    icon={faAngleLeft}
+                    className="margin-top-2px"
+                  />
+                </button>
+              </>
+            )}
+            {isMobile ? <div className="margin-bottom-1" /> : ""}
             <span className="margin-right-2px">{`${t("Page")} `}</span>
             <span className="margin-right-1">
               <input
@@ -416,7 +423,7 @@ function Table(props: Props) {
             <button
               type="button"
               className={`${
-                windowSize.width <= 600 ? "" : "usa-button "
+                isMobile ? "" : "usa-button "
               }usa-button--unstyled margin-right-2 text-base-darker hover:text-base-darkest active:text-base-darkest`}
               onClick={() => {
                 if (currentPage) {
@@ -433,7 +440,39 @@ function Table(props: Props) {
             >
               {t("Go")}
             </button>
-            {windowSize.width <= 600 ? <div className="margin-top-1" /> : ""}
+            {isMobile ? <div className="margin-top-1" /> : ""}
+            {isMobile && (
+              <>
+                <button
+                  type="button"
+                  className="margin-right-1"
+                  onClick={() => {
+                    setCurrentPage("1");
+                    gotoPage(0);
+                  }}
+                  disabled={!canPreviousPage}
+                >
+                  <FontAwesomeIcon
+                    icon={faAngleDoubleLeft}
+                    className="margin-top-2px"
+                  />
+                </button>
+                <button
+                  type="button"
+                  className="margin-right-2"
+                  onClick={() => {
+                    setCurrentPage(`${pageIndex}`);
+                    previousPage();
+                  }}
+                  disabled={!canPreviousPage}
+                >
+                  <FontAwesomeIcon
+                    icon={faAngleLeft}
+                    className="margin-top-2px"
+                  />
+                </button>
+              </>
+            )}
             <button
               type="button"
               className="margin-right-1"
@@ -461,7 +500,7 @@ function Table(props: Props) {
           </div>
           <div
             className={`${
-              windowSize.width <= 600
+              isMobile
                 ? "grid-row margin-top-2 margin-left-05 margin-bottom-05"
                 : "grid-col-3 text-right"
             }`}

--- a/frontend/src/components/TableWidget.tsx
+++ b/frontend/src/components/TableWidget.tsx
@@ -20,6 +20,7 @@ type Props = {
   sortByColumn?: string;
   sortByDesc?: boolean;
   significantDigitLabels: boolean;
+  displayWithPages: boolean;
   showMobilePreview?: boolean;
 };
 
@@ -32,6 +33,7 @@ const TableWidget = ({
   sortByDesc,
   sortByColumn,
   significantDigitLabels,
+  displayWithPages,
   showMobilePreview,
 }: Props) => {
   const { largestTickByColumn } = useTableMetadata(data);
@@ -124,10 +126,11 @@ const TableWidget = ({
         rows={rows}
         initialSortAscending={sortByDesc !== undefined ? !sortByDesc : true}
         initialSortByField={sortByColumn}
-        disablePagination={true}
+        disablePagination={!displayWithPages && rows.length < 25}
         columns={columns}
         sortByColumn={sortByColumn}
         sortByDesc={sortByDesc}
+        mobileNavigation
       />
       {summaryBelow && (
         <MarkdownRender

--- a/frontend/src/components/VisualizeTable.tsx
+++ b/frontend/src/components/VisualizeTable.tsx
@@ -40,6 +40,7 @@ interface Props {
   summaryBelow: boolean;
   columnsMetadata: Array<any>;
   significantDigitLabels: boolean;
+  displayWithPages: boolean;
   configHeader: JSX.Element;
 }
 
@@ -140,6 +141,19 @@ function VisualizeTable(props: Props) {
                 htmlFor="significantDigitLabels"
               >
                 {t("SignificantDigitLabels")}
+              </label>
+            </div>
+            <div className="usa-checkbox">
+              <input
+                className="usa-checkbox__input"
+                id="displayWithPages"
+                type="checkbox"
+                name="displayWithPages"
+                defaultChecked={false}
+                ref={props.register()}
+              />
+              <label className="usa-checkbox__label" htmlFor="displayWithPages">
+                {t("DisplayWithPages")}
               </label>
             </div>
           </div>
@@ -255,6 +269,7 @@ function VisualizeTable(props: Props) {
                 sortByColumn={props.sortByColumn}
                 sortByDesc={props.sortByDesc}
                 significantDigitLabels={props.significantDigitLabels}
+                displayWithPages={props.displayWithPages}
               />
             </>
           )}

--- a/frontend/src/components/WidgetRender.tsx
+++ b/frontend/src/components/WidgetRender.tsx
@@ -110,6 +110,7 @@ function WidgetWithDataset({ widget, showMobilePreview, hideTitle }: Props) {
           sortByColumn={tableWidget.content.sortByColumn}
           sortByDesc={tableWidget.content.sortByDesc}
           significantDigitLabels={tableWidget.content.significantDigitLabels}
+          displayWithPages={tableWidget.content.displayWithPages}
           showMobilePreview={showMobilePreview}
         />
       );

--- a/frontend/src/components/__tests__/Table.test.tsx
+++ b/frontend/src/components/__tests__/Table.test.tsx
@@ -157,3 +157,16 @@ test("renders a basic table without pagination", async () => {
   );
   expect(container).toMatchSnapshot();
 });
+
+test("renders a basic table with mobile navigation", async () => {
+  const { container } = render(
+    <Table
+      selection="none"
+      columns={columns}
+      rows={rows}
+      disablePagination={true}
+      mobileNavigation
+    />
+  );
+  expect(container).toMatchSnapshot();
+});

--- a/frontend/src/components/__tests__/TableWidget.test.tsx
+++ b/frontend/src/components/__tests__/TableWidget.test.tsx
@@ -33,6 +33,7 @@ test("renders the table title", async () => {
       summaryBelow={false}
       columnsMetadata={[]}
       significantDigitLabels={false}
+      displayWithPages={false}
     />,
     { wrapper: MemoryRouter }
   );
@@ -69,6 +70,7 @@ test("renders the summary below the chart", async () => {
       summaryBelow={true}
       columnsMetadata={[]}
       significantDigitLabels={false}
+      displayWithPages={false}
     />,
     { wrapper: MemoryRouter }
   );
@@ -102,6 +104,7 @@ test("table preview should match snapshot", async () => {
       summaryBelow={false}
       columnsMetadata={[]}
       significantDigitLabels={false}
+      displayWithPages={false}
     />,
     { wrapper: MemoryRouter }
   );
@@ -133,6 +136,7 @@ test("table should not crash when a column header is an empty string", async () 
       summaryBelow={false}
       columnsMetadata={[]}
       significantDigitLabels={false}
+      displayWithPages={false}
     />,
     { wrapper: MemoryRouter }
   );

--- a/frontend/src/components/__tests__/VisualizeTable.test.tsx
+++ b/frontend/src/components/__tests__/VisualizeTable.test.tsx
@@ -62,6 +62,7 @@ test("renders the VisualizeTable component", async () => {
       ]}
       showTitle={true}
       significantDigitLabels={false}
+      displayWithPages={false}
       summary={""}
       title={""}
       configHeader={<></>}

--- a/frontend/src/components/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/Table.test.tsx.snap
@@ -339,6 +339,187 @@ exports[`renders a basic table 1`] = `
 </div>
 `;
 
+exports[`renders a basic table with mobile navigation 1`] = `
+<div>
+  <div
+    class="overflow-x-hidden overflow-y-hidden"
+  >
+    <table
+      class="usa-table usa-table--borderless"
+      role="table"
+    >
+      <thead>
+        <tr
+          role="row"
+        >
+          <th
+            colspan="1"
+            role="columnheader"
+            scope="col"
+            style="min-width: 0;"
+          >
+            <span>
+              ID
+            </span>
+            <button
+              class="margin-left-1 usa-button usa-button--unstyled"
+              style="cursor: pointer;"
+              title="Toggle SortBy ID"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base-lighter"
+                data-icon="chevron-up"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </th>
+          <th
+            colspan="1"
+            role="columnheader"
+            scope="col"
+            style="min-width: 0;"
+          >
+            <span>
+              Name
+            </span>
+            <button
+              class="margin-left-1 usa-button usa-button--unstyled"
+              style="cursor: pointer;"
+              title="Toggle SortBy Name"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base-lighter"
+                data-icon="chevron-up"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </th>
+          <th
+            colspan="1"
+            role="columnheader"
+            scope="col"
+            style="min-width: 0;"
+          >
+            <span>
+              Last Updated
+            </span>
+            <button
+              class="margin-left-1 usa-button usa-button--unstyled"
+              style="cursor: pointer;"
+              title="Toggle SortBy Last Updated"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base-lighter"
+                data-icon="chevron-up"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        role="rowgroup"
+      >
+        <tr
+          role="row"
+        >
+          <th
+            role="cell"
+            scope="row"
+          >
+            1
+          </th>
+          <td
+            role="cell"
+          >
+            Banana
+          </td>
+          <td
+            role="cell"
+          >
+            2021-11-11
+          </td>
+        </tr>
+        <tr
+          role="row"
+        >
+          <th
+            role="cell"
+            scope="row"
+          >
+            2
+          </th>
+          <td
+            role="cell"
+          >
+            Chocolate
+          </td>
+          <td
+            role="cell"
+          >
+            2020-11-11
+          </td>
+        </tr>
+        <tr
+          role="row"
+        >
+          <th
+            role="cell"
+            scope="row"
+          >
+            3
+          </th>
+          <td
+            role="cell"
+          >
+            Vanilla
+          </td>
+          <td
+            role="cell"
+          >
+            2019-11-11
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  
+</div>
+`;
+
 exports[`renders a basic table without pagination 1`] = `
 <div>
   <div

--- a/frontend/src/components/__tests__/__snapshots__/VisualizeTable.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/VisualizeTable.test.tsx.snap
@@ -137,6 +137,22 @@ exports[`renders the VisualizeTable component 1`] = `
               Significant digit labels (123K, 1.2M)
             </label>
           </div>
+          <div
+            class="usa-checkbox"
+          >
+            <input
+              class="usa-checkbox__input"
+              id="displayWithPages"
+              name="displayWithPages"
+              type="checkbox"
+            />
+            <label
+              class="usa-checkbox__label"
+              for="displayWithPages"
+            >
+              Display with pages
+            </label>
+          </div>
         </div>
         <div
           class="usa-form-group"

--- a/frontend/src/containers/AddTable.tsx
+++ b/frontend/src/containers/AddTable.tsx
@@ -37,6 +37,7 @@ interface FormValues {
   datasetType: string;
   sortData: string;
   significantDigitLabels: boolean;
+  displayWithPages: boolean;
 }
 
 interface PathParams {
@@ -105,6 +106,7 @@ function AddTable() {
   const summary = watch("summary");
   const summaryBelow = watch("summaryBelow");
   const significantDigitLabels = watch("significantDigitLabels");
+  const displayWithPages = watch("displayWithPages");
 
   const initializeColumnsMetadata = () => {
     setSelectedHeaders(new Set<string>());
@@ -164,6 +166,7 @@ function AddTable() {
           summaryBelow: values.summaryBelow,
           datasetType: datasetType,
           significantDigitLabels: values.significantDigitLabels,
+          displayWithPages: values.displayWithPages,
           datasetId: newDataset
             ? newDataset.id
             : datasetType === DatasetType.DynamicDataset
@@ -432,6 +435,7 @@ function AddTable() {
               title={title}
               showTitle={showTitle}
               significantDigitLabels={significantDigitLabels}
+              displayWithPages={displayWithPages}
               summary={summary}
               summaryBelow={summaryBelow}
               columnsMetadata={ColumnsMetadataService.getColumnsMetadata(

--- a/frontend/src/containers/EditTable.tsx
+++ b/frontend/src/containers/EditTable.tsx
@@ -42,6 +42,7 @@ interface FormValues {
   datasetType: string;
   sortData: string;
   significantDigitLabels: boolean;
+  displayWithPages: boolean;
   staticFileName: string | undefined;
   dynamicFileName: string | undefined;
 }
@@ -116,6 +117,7 @@ function EditTable() {
   const summary = watch("summary");
   const summaryBelow = watch("summaryBelow");
   const significantDigitLabels = watch("significantDigitLabels");
+  const displayWithPages = watch("displayWithPages");
 
   const [filteredJson, setFilteredJson] = useState<any[]>([]);
   const [displayedJson, setDisplayedJson] = useState<Array<any>>([]);
@@ -154,6 +156,7 @@ function EditTable() {
       const summary = widget.content.summary;
       const summaryBelow = widget.content.summaryBelow;
       const significantDigitLabels = widget.content.significantDigitLabels;
+      const displayWithPages = widget.content.displayWithPages;
 
       if (dynamicDataset) {
         setDynamicFileName(dynamicDataset?.fileName);
@@ -172,7 +175,8 @@ function EditTable() {
           : datasetType,
         summary,
         summaryBelow,
-        significantDigitLabels: significantDigitLabels,
+        significantDigitLabels,
+        displayWithPages,
         dynamicDatasets:
           widget.content.datasetType === DatasetType.DynamicDataset
             ? widget.content.s3Key.json
@@ -325,6 +329,7 @@ function EditTable() {
           summaryBelow: values.summaryBelow,
           datasetType: displayedDatasetType,
           significantDigitLabels: values.significantDigitLabels,
+          displayWithPages: values.displayWithPages,
           datasetId: newDataset
             ? newDataset.id
             : displayedDatasetType === DatasetType.DynamicDataset
@@ -600,6 +605,7 @@ function EditTable() {
                   setSortByColumn={setSortByColumn}
                   setSortByDesc={setSortByDesc}
                   significantDigitLabels={significantDigitLabels}
+                  displayWithPages={displayWithPages}
                   columnsMetadata={ColumnsMetadataService.getColumnsMetadata(
                     hiddenColumns,
                     dataTypes,

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -922,5 +922,6 @@
   "NoTableOfContentsItems": "This dashboard has no content items. Content items must be added to the dashboard before they can be included in the table of contents.",
   "SelectAll": "Select all",
   "DeselectAll": "Deselect all",
-  "EditTableOfContentsDescription": "The table of contents displays an overview of the content items in your dashboard. Customize the table of contents by selecting which content items to include. If a content item is selected below, its title will be included in the table of contents."
+  "EditTableOfContentsDescription": "The table of contents displays an overview of the content items in your dashboard. Customize the table of contents by selecting which content items to include. If a content item is selected below, its title will be included in the table of contents.",
+  "DisplayWithPages": "Display with pages"
 }

--- a/frontend/src/models/index.tsx
+++ b/frontend/src/models/index.tsx
@@ -154,6 +154,7 @@ export interface TableWidget extends Widget {
     sortByColumn?: string;
     sortByDesc?: boolean;
     significantDigitLabels: boolean;
+    displayWithPages: boolean;
   };
 }
 


### PR DESCRIPTION
## Description

Add option to not show all rows of extensive tables.

## Testing

Added unit tests. You can test it here: https://migdizn.badger.wwps.aws.dev/admin/dashboard/6a7412e7-f962-4d76-835d-74a2a92ec219/edit-table/4dd577e1-62d0-4d8a-a53d-69897048a357

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
