### PR TITLE
GTT-1857 Favicon should retain the original file name

### DIFF
--- a/cdk/lib/constructs/contentstorage.ts
+++ b/cdk/lib/constructs/contentstorage.ts
@@ -55,6 +55,7 @@ export class ContentStorage extends cdk.Construct {
             "x-amz-server-side-encryption",
             "x-amz-request-id",
             "x-amz-id-2",
+            "x-amz-meta-filename",
             "ETag",
           ],
         },

--- a/frontend/src/containers/EditFavicon.tsx
+++ b/frontend/src/containers/EditFavicon.tsx
@@ -15,7 +15,9 @@ function EditFavicon() {
   const { t } = useTranslation();
   const history = useHistory();
   const { settings, reloadSettings, loadingSettings } = useSettings(true);
-  const { loadingFile, favicon } = useFavicon(settings.customFaviconS3Key);
+  const { loadingFile, favicon, faviconFileName } = useFavicon(
+    settings.customFaviconS3Key
+  );
   const { register, handleSubmit } = useForm();
 
   const [currentFavicon, setCurrentFavicon] = useState(favicon);
@@ -117,6 +119,8 @@ function EditFavicon() {
                 fileName={
                   currentFavicon
                     ? currentFavicon.name
+                    : faviconFileName
+                    ? faviconFileName
                     : defaultFavicon.replace(/^.*[\\/]/, "")
                 }
                 onFileProcessed={onFileProcessed}

--- a/frontend/src/hooks/favicon-hooks.ts
+++ b/frontend/src/hooks/favicon-hooks.ts
@@ -5,12 +5,14 @@ import { useTranslation } from "react-i18next";
 type UseFaviconHook = {
   loadingFile: boolean;
   favicon: File | undefined;
+  faviconFileName: string | undefined;
 };
 
 export function useFavicon(s3Key?: string): UseFaviconHook {
   const { t } = useTranslation();
   const [loading, setLoading] = useState<boolean>(false);
   const [favicon, setFile] = useState<File>();
+  const [faviconFileName, setFileName] = useState<string>();
 
   const fetchData = useCallback(async () => {
     if (s3Key) {
@@ -19,6 +21,7 @@ export function useFavicon(s3Key?: string): UseFaviconHook {
         const data = await StorageService.downloadFavicon(s3Key, t);
         setFile(data);
         setLoading(false);
+        setFileName(data.name);
       } catch (err) {
         console.log("Can't retrieve favicon from S3", err);
         setLoading(false);
@@ -33,5 +36,6 @@ export function useFavicon(s3Key?: string): UseFaviconHook {
   return {
     loadingFile: loading,
     favicon,
+    faviconFileName,
   };
 }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -289,6 +289,7 @@
     "ChooseData": "Choose data",
     "Visualize": "Visualize",
     "UploadingFile": "Uploading file",
+    "FileNameDoesNotExist": "Metadata does not contain file name",
     "CreatingMetrics": "Creating metrics",
     "Data": "Data",
     "DataHint": "Choose an existing dataset or create a new one to populate this metrics",

--- a/frontend/src/services/StorageService.ts
+++ b/frontend/src/services/StorageService.ts
@@ -54,6 +54,11 @@ async function downloadFile(
   if (!data || !data.Body) {
     throw new Error(t("DownloadFileError"));
   }
+  try {
+    data.Body.name = data.Metadata.filename;
+  } catch (err) {
+    console.log(t("FileNameDoesNotExist"));
+  }
   return data.Body as File;
 }
 
@@ -103,12 +108,14 @@ async function uploadFile(
         contentDisposition: `attachment; filename="${rawFile.name}"`,
         contentType: rawFile.type,
         serverSideEncryption,
+        metadata: { fileName: rawFile.name },
       })
     : await Storage.put(fileS3Key, rawFile, {
         level: accessLevel,
         contentDisposition: `attachment; filename="${rawFile.name}"`,
         contentType: rawFile.type,
         serverSideEncryption,
+        metadata: { fileName: rawFile.name },
       });
 }
 

--- a/frontend/src/services/__tests__/StorageService.test.ts
+++ b/frontend/src/services/__tests__/StorageService.test.ts
@@ -36,6 +36,7 @@ describe("uploadImage", () => {
       contentType: "image/png",
       contentDisposition: 'attachment; filename="myphoto.png"',
       serverSideEncryption: "aws:kms",
+      metadata: { fileName: "myphoto.png" },
     });
   });
 
@@ -65,6 +66,7 @@ describe("uploadDataset", () => {
       contentType: "text/csv",
       contentDisposition: 'attachment; filename="dataset.csv"',
       serverSideEncryption: "aws:kms",
+      metadata: { fileName: "dataset.csv" },
     });
   });
 


### PR DESCRIPTION
## Description

- Amplify S3 wasn't storing image name. Added image name as part of the metadata.
- Fetch image name from metadata in Favicon Hook
- Use "Current Favicon" name if user is uploading new Favicon
- Use default if image name is missing from metadata

## Testing

1. Added image metadata to unit test
2. Deployed and confirmed CORS settings updated on AWS S3
3. Tested by uploading favicon and re-entering page to confirm name stayed
          - Confirmed if metadata is deleted/missing, default to "default favicon" name

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
