### PR TITLE
Miguel.abreu/gtt 1583 use container width

### DIFF
--- a/frontend/src/components/BarChartWidget.tsx
+++ b/frontend/src/components/BarChartWidget.tsx
@@ -63,7 +63,13 @@ const BarChartWidget = (props: Props) => {
         props.data
       )
     );
-  }, [chartRef, props.bars, props.data, props.stackedChart]);
+  }, [
+    chartRef,
+    props.showMobilePreview,
+    props.bars,
+    props.data,
+    props.stackedChart,
+  ]);
 
   const { xAxisLargestValue } = useXAxisMetadata(
     chartRef,

--- a/frontend/src/services/UtilsService.ts
+++ b/frontend/src/services/UtilsService.ts
@@ -142,7 +142,7 @@ function calculateBarDimentions(
 ): ComputedDimensions {
   const style = container ? window.getComputedStyle(container) : undefined;
   if (!maxLabelWidth) {
-    maxLabelWidth = 0.3 * window.innerWidth;
+    maxLabelWidth = container ? 0.3 * container.clientWidth : 200;
   }
   if (!barSize) {
     barSize = 32;


### PR DESCRIPTION
## Description

Use container width for the calculation instead of the screen size because this will not work for the mobile preview. 

## Testing

* Go to https://d2h803e1awe3zo.cloudfront.net/admin/dashboard/ed082eb5-b83c-4f63-a6a0-81a8a9b94263
* Preview the dashboard
* Enable mobile preview
* Verify that bar graph is showing correctly and that labels are not hidding the content part.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
