### PR TITLE
Click scrolls when not visible

### DIFF
--- a/frontend/src/components/Tab.tsx
+++ b/frontend/src/components/Tab.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { MouseEvent } from "react";
 interface Props {
   id: string;
   itemId: string;
@@ -9,7 +9,22 @@ interface Props {
 }
 
 function Tab(props: Props) {
-  const onClick = () => {
+  const onClick = (e: MouseEvent<HTMLElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const wrapper = e.currentTarget?.closest(
+      ".react-horizontal-scrolling-menu--wrapper"
+    );
+    if (rect && wrapper) {
+      if (rect.left < 0) {
+        const leftScroll: HTMLElement | null =
+          wrapper.querySelector("button:first-child");
+        leftScroll?.click();
+      } else if (rect.right > wrapper.clientWidth + 50) {
+        const rightScroll: HTMLElement | null =
+          wrapper.querySelector("button:last-child");
+        rightScroll?.click();
+      }
+    }
     props.onClick(props.id);
   };
 

--- a/frontend/src/components/Tab.tsx
+++ b/frontend/src/components/Tab.tsx
@@ -10,30 +10,7 @@ interface Props {
 
 function Tab(props: Props) {
   const onClick = (e: MouseEvent<HTMLElement>) => {
-    const rect = e.currentTarget.getBoundingClientRect();
-    const wrapper = e.currentTarget?.closest(
-      ".react-horizontal-scrolling-menu--wrapper"
-    );
-    if (rect && wrapper) {
-      const wrapperRect = wrapper.getBoundingClientRect();
-      if (rect.left < wrapperRect.left) {
-        wrapper.querySelector<HTMLElement>("button:first-child")?.click();
-      } else {
-        const shownWidth = wrapperRect.right - rect.left;
-        if (shownWidth < rect.width) {
-          wrapper.querySelector<HTMLElement>("button:last-child")?.click();
-        }
-      }
-      console.log({
-        left: rect.left,
-        right: rect.right,
-      });
-      console.log({
-        left: wrapperRect.left,
-        right: wrapperRect.right,
-      });
-    }
-    props.onClick(props.id);
+    props.onClick(props.id, e.currentTarget);
   };
 
   let className =

--- a/frontend/src/components/Tab.tsx
+++ b/frontend/src/components/Tab.tsx
@@ -15,15 +15,23 @@ function Tab(props: Props) {
       ".react-horizontal-scrolling-menu--wrapper"
     );
     if (rect && wrapper) {
-      if (rect.left < 0) {
-        const leftScroll: HTMLElement | null =
-          wrapper.querySelector("button:first-child");
-        leftScroll?.click();
-      } else if (rect.right > wrapper.clientWidth + 50) {
-        const rightScroll: HTMLElement | null =
-          wrapper.querySelector("button:last-child");
-        rightScroll?.click();
+      const wrapperRect = wrapper.getBoundingClientRect();
+      if (rect.left < wrapperRect.left) {
+        wrapper.querySelector<HTMLElement>("button:first-child")?.click();
+      } else {
+        const shownWidth = wrapperRect.right - rect.left;
+        if (shownWidth < rect.width) {
+          wrapper.querySelector<HTMLElement>("button:last-child")?.click();
+        }
       }
+      console.log({
+        left: rect.left,
+        right: rect.right,
+      });
+      console.log({
+        left: wrapperRect.left,
+        right: wrapperRect.right,
+      });
     }
     props.onClick(props.id);
   };

--- a/frontend/src/components/Tabs.tsx
+++ b/frontend/src/components/Tabs.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useContext } from "react";
 import Tab from "./Tab";
 import { ScrollMenu, VisibilityContext } from "react-horizontal-scrolling-menu";
 import { LeftArrow, RightArrow } from "./Arrows";
@@ -13,6 +13,7 @@ interface Props {
 type scrollVisibilityApiType = React.ContextType<typeof VisibilityContext>;
 
 function Tabs(props: Props) {
+  const [scrollMenuObj, setScrollMenuObj] = useState<scrollVisibilityApiType>();
   const [activeTab, setActiveTab] = useState<string>(props.defaultActive);
 
   useEffect(() => {
@@ -21,17 +22,15 @@ function Tabs(props: Props) {
 
   const onClickTabItem = (tab: string, currentTab: HTMLElement) => {
     const rect = currentTab.getBoundingClientRect();
-    const wrapper = currentTab?.closest(
-      ".react-horizontal-scrolling-menu--wrapper"
-    );
+    const wrapper = scrollMenuObj?.scrollContainer?.current;
     if (rect && wrapper) {
       const wrapperRect = wrapper.getBoundingClientRect();
       if (rect.left < wrapperRect.left) {
-        wrapper.querySelector<HTMLElement>("button:first-child")?.click();
+        scrollMenuObj?.scrollPrev();
       } else {
         const shownWidth = wrapperRect.right - rect.left;
         if (shownWidth < rect.width) {
-          wrapper.querySelector<HTMLElement>("button:last-child")?.click();
+          scrollMenuObj?.scrollNext();
         }
       }
       console.log({
@@ -51,6 +50,7 @@ function Tabs(props: Props) {
       <ScrollMenu
         LeftArrow={props.showArrows && LeftArrow}
         RightArrow={props.showArrows && RightArrow}
+        onInit={setScrollMenuObj}
         onWheel={onWheel}
         wrapperClassName="border-base-lighter border-bottom margin-top-1"
       >

--- a/frontend/src/components/Tabs.tsx
+++ b/frontend/src/components/Tabs.tsx
@@ -33,14 +33,6 @@ function Tabs(props: Props) {
           scrollMenuObj?.scrollNext();
         }
       }
-      console.log({
-        left: rect.left,
-        right: rect.right,
-      });
-      console.log({
-        left: wrapperRect.left,
-        right: wrapperRect.right,
-      });
     }
     setActiveTab(tab);
   };

--- a/frontend/src/components/Tabs.tsx
+++ b/frontend/src/components/Tabs.tsx
@@ -19,7 +19,30 @@ function Tabs(props: Props) {
     setActiveTab(props.defaultActive);
   }, [props.defaultActive]);
 
-  const onClickTabItem = (tab: string) => {
+  const onClickTabItem = (tab: string, currentTab: HTMLElement) => {
+    const rect = currentTab.getBoundingClientRect();
+    const wrapper = currentTab?.closest(
+      ".react-horizontal-scrolling-menu--wrapper"
+    );
+    if (rect && wrapper) {
+      const wrapperRect = wrapper.getBoundingClientRect();
+      if (rect.left < wrapperRect.left) {
+        wrapper.querySelector<HTMLElement>("button:first-child")?.click();
+      } else {
+        const shownWidth = wrapperRect.right - rect.left;
+        if (shownWidth < rect.width) {
+          wrapper.querySelector<HTMLElement>("button:last-child")?.click();
+        }
+      }
+      console.log({
+        left: rect.left,
+        right: rect.right,
+      });
+      console.log({
+        left: wrapperRect.left,
+        right: wrapperRect.right,
+      });
+    }
     setActiveTab(tab);
   };
 

--- a/frontend/src/components/Tabs.tsx
+++ b/frontend/src/components/Tabs.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useContext } from "react";
+import React, { useEffect, useState } from "react";
 import Tab from "./Tab";
 import { ScrollMenu, VisibilityContext } from "react-horizontal-scrolling-menu";
 import { LeftArrow, RightArrow } from "./Arrows";

--- a/frontend/src/components/__tests__/Tabs.test.tsx
+++ b/frontend/src/components/__tests__/Tabs.test.tsx
@@ -82,4 +82,23 @@ describe("Tabs tests", () => {
       expect(getByText(`Tab ${index + 1}`)).toBeInTheDocument();
     });
   });
+
+  test("it should contains .react-horizontal-scrolling-menu--wrapper class for auto scroll to work", () => {
+    const wrapper = render(
+      <Tabs defaultActive="tab1">
+        <div id="tab1" label="Tab 1">
+          Tab 1
+        </div>
+        <div id="tab2" label="Tab 2">
+          Tab 2
+        </div>
+      </Tabs>
+    );
+
+    expect(
+      wrapper.baseElement.querySelector(
+        ".react-horizontal-scrolling-menu--wrapper"
+      )
+    ).toBeDefined();
+  });
 });

--- a/frontend/src/components/__tests__/Tabs.test.tsx
+++ b/frontend/src/components/__tests__/Tabs.test.tsx
@@ -82,23 +82,4 @@ describe("Tabs tests", () => {
       expect(getByText(`Tab ${index + 1}`)).toBeInTheDocument();
     });
   });
-
-  test("it should contains .react-horizontal-scrolling-menu--wrapper class for auto scroll to work", () => {
-    const wrapper = render(
-      <Tabs defaultActive="tab1">
-        <div id="tab1" label="Tab 1">
-          Tab 1
-        </div>
-        <div id="tab2" label="Tab 2">
-          Tab 2
-        </div>
-      </Tabs>
-    );
-
-    expect(
-      wrapper.baseElement.querySelector(
-        ".react-horizontal-scrolling-menu--wrapper"
-      )
-    ).toBeDefined();
-  });
 });


### PR DESCRIPTION
## Description

Detect when tab is not visible and click the scroll button programatically. The solution may not work after updating USWDS package. 

## Testing

* Go to https://d2h803e1awe3zo.cloudfront.net/admin/dashboard/ed082eb5-b83c-4f63-a6a0-81a8a9b94263
* Show preview
* Enable mobile view 
* Scroll to the section at the end
* Click on the tabs that aren't fully displayed and the scroll should move to show the full text

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
