### PR TITLE
GTT-1590 - Removed 403 error handler.  Added bucket policy to allow for CF to access bucket

### DIFF
--- a/cdk/lib/frontend-stack.ts
+++ b/cdk/lib/frontend-stack.ts
@@ -56,6 +56,7 @@ export class FrontendStack extends cdk.Stack {
       "CloudFrontOriginAccess"
     );
     this.frontendBucket.grantRead(originAccess);
+
     const distribution = new cloudFront.CloudFrontWebDistribution(
       this,
       "CloudFrontDistribution",
@@ -65,7 +66,7 @@ export class FrontendStack extends cdk.Stack {
             errorCode: 404,
             responseCode: 200,
             responsePagePath: "/index.html",
-          }
+          },
         ],
         originConfigs: [
           {

--- a/cdk/lib/frontend-stack.ts
+++ b/cdk/lib/frontend-stack.ts
@@ -55,6 +55,7 @@ export class FrontendStack extends cdk.Stack {
       this,
       "CloudFrontOriginAccess"
     );
+    this.frontendBucket.grantRead(originAccess);
     const distribution = new cloudFront.CloudFrontWebDistribution(
       this,
       "CloudFrontDistribution",
@@ -64,12 +65,7 @@ export class FrontendStack extends cdk.Stack {
             errorCode: 404,
             responseCode: 200,
             responsePagePath: "/index.html",
-          },
-          {
-            errorCode: 403, // this is the new addition due to the bucket policy returning 403
-            responseCode: 200,
-            responsePagePath: "/index.html",
-          },
+          }
         ],
         originConfigs: [
           {

--- a/tools/WAF-enterprise-only.json
+++ b/tools/WAF-enterprise-only.json
@@ -3,11 +3,39 @@
     "Parameters": {
       "InternalCIDR": {
         "Type": "CommaDelimitedList"
-      }
-    },  
+      },
+      "RestrictPublicDashboard": {
+        "Description": "Whether to restrict access to public dashboards.",
+        "Default": false,
+        "Type": "String",
+        "AllowedValues": [
+            true,
+            false
+        ]
+      } 
+    },
+    "Conditions": {
+      "RestrictPublicDashboardToEnterprise": {
+          "Fn::Equals": [
+              true,
+              {
+                  "Ref": "RestrictPublicDashboard"
+              }
+          ]
+      },
+      "NotRestrictPublicDashboardToEnterprise": {
+        "Fn::Equals": [
+            false,
+            {
+                "Ref": "RestrictPublicDashboard"
+            }
+        ]
+    }
+  }, 
     "Resources": {
       "StackPerformanceDashboardEnterpriseOnly": {
         "Type": "AWS::WAFv2::WebACL",
+        "Condition": "RestrictPublicDashboardToEnterprise",
         "Properties": {
           "DefaultAction": {
             "Allow": {}
@@ -18,81 +46,66 @@
             "MetricName": "EnterpriseOnly",
             "SampledRequestsEnabled": true
           },
-          "Description": "EnterpriseOnly",
-          "Name": "PerformanceDashboardEnterpriseOnly",
+          "Name": "EnterpriseOnly",
           "Rules": [
             {
-              "Action": {
-                "Allow": {}
-              },
-              "Name": "AdminFromEnterprise",
-              "Priority": 1,
+              "Name": "EnterpriseOnly",
+              "Priority": 0,
               "Statement": {
-                "AndStatement": {
-                  "Statements": [
-                    {
-                      "IPSetReferenceStatement": {
-                        "Arn": {
-                          "Fn::GetAtt": [
-                            "InternalOnlyIPV4",
-                            "Arn"
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "ByteMatchStatement": {
-                        "FieldToMatch": {
-                          "UriPath": {}
-                        },
-                        "PositionalConstraint": "CONTAINS",
-                        "SearchString": "/admin",
-                        "TextTransformations": [
-                          {
-                            "Priority": 0,
-                            "Type": "NONE"
-                          }
+                "NotStatement": {
+                  "Statement": {
+                    "IPSetReferenceStatement": {
+                      "ARN": {
+                        "Fn::GetAtt": [
+                          "InternalOnlyIPV4",
+                          "Arn"
                         ]
                       }
                     }
-                  ]
+                  }
                 }
               },
               "VisibilityConfig": {
                 "CloudWatchMetricsEnabled": true,
-                "MetricName": "AdminFromEnterprise",
+                "MetricName": "EnterpriseOnly",
                 "SampledRequestsEnabled": true
-              }
-            },
-            {
+              },
               "Action": {
                 "Block": {}
-              },
-              "Name": "AdminNotFromEnterprise",
-              "Priority": 2,
+              }
+            }        
+          ]
+        },
+        "DependsOn": [
+          "InternalOnlyIPV4"
+        ]
+      },
+      "StackPerformanceDashboardEnterpriseOnlyForAdmin": {
+        "Type": "AWS::WAFv2::WebACL",
+        "Condition": "NotRestrictPublicDashboardToEnterprise",
+        "Properties": {
+          "DefaultAction": {
+            "Allow": {}
+          },
+          "Scope": "CLOUDFRONT",
+          "VisibilityConfig": {
+            "CloudWatchMetricsEnabled": true,
+            "MetricName": "EnterpriseOnly",
+            "SampledRequestsEnabled": true
+          },
+          "Name": "EnterpriseOnly",
+          "Rules": [
+            {
+              "Name": "EnterpriseOnly",
+              "Priority": 0,
               "Statement": {
                 "AndStatement": {
                   "Statements": [
                     {
-                      "ByteMatchStatement": {
-                        "FieldToMatch": {
-                          "UriPath": {}
-                        },
-                        "PositionalConstraint": "CONTAINS",
-                        "SearchString": "/admin",
-                        "TextTransformations": [
-                          {
-                            "Priority": 0,
-                            "Type": "NONE"
-                          }
-                        ]
-                      }
-                    },
-                    {
                       "NotStatement": {
                         "Statement": {
                           "IPSetReferenceStatement": {
-                            "Arn": {
+                            "ARN": {
                               "Fn::GetAtt": [
                                 "InternalOnlyIPV4",
                                 "Arn"
@@ -101,47 +114,34 @@
                           }
                         }
                       }
+                    },
+                    {
+                      "ByteMatchStatement": {
+                        "FieldToMatch": {
+                          "UriPath": {}
+                        },
+                        "PositionalConstraint": "CONTAINS",
+                        "SearchString": "/admin",
+                        "TextTransformations": [
+                          {
+                            "Type": "NONE",
+                            "Priority": 0
+                          }
+                        ]
+                      }
                     }
                   ]
-                }
+                }              
               },
               "VisibilityConfig": {
                 "CloudWatchMetricsEnabled": true,
-                "MetricName": "AdminNotFromEnterprise",
+                "MetricName": "EnterpriseOnly",
                 "SampledRequestsEnabled": true
-              }
-            },
-            {
+              },
               "Action": {
-                "Allow": {}
-              },
-              "Name": "PublicPage",
-              "Priority": 3,
-              "Statement": {
-                "NotStatement": {
-                  "Statement": {
-                    "ByteMatchStatement": {
-                      "FieldToMatch": {
-                        "UriPath": {}
-                      },
-                      "PositionalConstraint": "CONTAINS",
-                      "SearchString": "/admin",
-                      "TextTransformations": [
-                        {
-                          "Priority": 0,
-                          "Type": "NONE"
-                        }
-                      ]
-                    }
-                  }
-                }
-              },
-              "VisibilityConfig": {
-                "CloudWatchMetricsEnabled": true,
-                "MetricName": "PublicPage",
-                "SampledRequestsEnabled": true
+                "Block": {}
               }
-            }
+            }        
           ]
         },
         "DependsOn": [
@@ -157,7 +157,7 @@
           "IPAddressVersion": "IPV4",
           "Scope": "CLOUDFRONT",
           "Description": "This is the WAF v2 IPSet designating the CIDR of the internal network",
-          "Name": "InternalOnly_Performance_Dashboard"
+          "Name": "EnterpriseCIDROnly"
         }
       }
     }

--- a/tools/WAF-enterprise-only.json
+++ b/tools/WAF-enterprise-only.json
@@ -1,164 +1,151 @@
 {
-    "AWSTemplateFormatVersion": "2010-09-09",
-    "Parameters": {
-      "InternalCIDR": {
-        "Type": "CommaDelimitedList"
-      },
-      "RestrictPublicDashboard": {
-        "Description": "Whether to restrict access to public dashboards.",
-        "Default": false,
-        "Type": "String",
-        "AllowedValues": [
-            true,
-            false
-        ]
-      } 
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Parameters": {
+    "InternalCIDR": {
+      "Type": "CommaDelimitedList"
     },
-    "Conditions": {
-      "RestrictPublicDashboardToEnterprise": {
-          "Fn::Equals": [
-              true,
-              {
-                  "Ref": "RestrictPublicDashboard"
-              }
-          ]
-      },
-      "NotRestrictPublicDashboardToEnterprise": {
-        "Fn::Equals": [
-            false,
-            {
-                "Ref": "RestrictPublicDashboard"
-            }
-        ]
+    "RestrictPublicDashboard": {
+      "Description": "Whether to restrict access to public dashboards.",
+      "Default": false,
+      "Type": "String",
+      "AllowedValues": [true, false]
     }
-  }, 
-    "Resources": {
-      "StackPerformanceDashboardEnterpriseOnly": {
-        "Type": "AWS::WAFv2::WebACL",
-        "Condition": "RestrictPublicDashboardToEnterprise",
-        "Properties": {
-          "DefaultAction": {
-            "Allow": {}
-          },
-          "Scope": "CLOUDFRONT",
-          "VisibilityConfig": {
-            "CloudWatchMetricsEnabled": true,
-            "MetricName": "EnterpriseOnly",
-            "SampledRequestsEnabled": true
-          },
-          "Name": "EnterpriseOnly",
-          "Rules": [
-            {
-              "Name": "EnterpriseOnly",
-              "Priority": 0,
-              "Statement": {
-                "NotStatement": {
-                  "Statement": {
-                    "IPSetReferenceStatement": {
-                      "ARN": {
-                        "Fn::GetAtt": [
-                          "InternalOnlyIPV4",
-                          "Arn"
-                        ]
-                      }
+  },
+  "Conditions": {
+    "RestrictPublicDashboardToEnterprise": {
+      "Fn::Equals": [
+        true,
+        {
+          "Ref": "RestrictPublicDashboard"
+        }
+      ]
+    },
+    "NotRestrictPublicDashboardToEnterprise": {
+      "Fn::Equals": [
+        false,
+        {
+          "Ref": "RestrictPublicDashboard"
+        }
+      ]
+    }
+  },
+  "Resources": {
+    "StackPerformanceDashboardEnterpriseOnly": {
+      "Type": "AWS::WAFv2::WebACL",
+      "Condition": "RestrictPublicDashboardToEnterprise",
+      "Properties": {
+        "DefaultAction": {
+          "Allow": {}
+        },
+        "Scope": "CLOUDFRONT",
+        "VisibilityConfig": {
+          "CloudWatchMetricsEnabled": true,
+          "MetricName": "EnterpriseOnly",
+          "SampledRequestsEnabled": true
+        },
+        "Name": "EnterpriseOnly",
+        "Rules": [
+          {
+            "Name": "EnterpriseOnly",
+            "Priority": 0,
+            "Statement": {
+              "NotStatement": {
+                "Statement": {
+                  "IPSetReferenceStatement": {
+                    "ARN": {
+                      "Fn::GetAtt": ["InternalOnlyIPV4", "Arn"]
                     }
                   }
                 }
-              },
-              "VisibilityConfig": {
-                "CloudWatchMetricsEnabled": true,
-                "MetricName": "EnterpriseOnly",
-                "SampledRequestsEnabled": true
-              },
-              "Action": {
-                "Block": {}
               }
-            }        
-          ]
-        },
-        "DependsOn": [
-          "InternalOnlyIPV4"
+            },
+            "VisibilityConfig": {
+              "CloudWatchMetricsEnabled": true,
+              "MetricName": "EnterpriseOnly",
+              "SampledRequestsEnabled": true
+            },
+            "Action": {
+              "Block": {}
+            }
+          }
         ]
       },
-      "StackPerformanceDashboardEnterpriseOnlyForAdmin": {
-        "Type": "AWS::WAFv2::WebACL",
-        "Condition": "NotRestrictPublicDashboardToEnterprise",
-        "Properties": {
-          "DefaultAction": {
-            "Allow": {}
-          },
-          "Scope": "CLOUDFRONT",
-          "VisibilityConfig": {
-            "CloudWatchMetricsEnabled": true,
-            "MetricName": "EnterpriseOnly",
-            "SampledRequestsEnabled": true
-          },
-          "Name": "EnterpriseOnly",
-          "Rules": [
-            {
-              "Name": "EnterpriseOnly",
-              "Priority": 0,
-              "Statement": {
-                "AndStatement": {
-                  "Statements": [
-                    {
-                      "NotStatement": {
-                        "Statement": {
-                          "IPSetReferenceStatement": {
-                            "ARN": {
-                              "Fn::GetAtt": [
-                                "InternalOnlyIPV4",
-                                "Arn"
-                              ]
-                            }
+      "DependsOn": ["InternalOnlyIPV4"]
+    },
+    "StackPerformanceDashboardEnterpriseOnlyForAdmin": {
+      "Type": "AWS::WAFv2::WebACL",
+      "Condition": "NotRestrictPublicDashboardToEnterprise",
+      "Properties": {
+        "DefaultAction": {
+          "Allow": {}
+        },
+        "Scope": "CLOUDFRONT",
+        "VisibilityConfig": {
+          "CloudWatchMetricsEnabled": true,
+          "MetricName": "EnterpriseOnly",
+          "SampledRequestsEnabled": true
+        },
+        "Name": "EnterpriseOnly",
+        "Rules": [
+          {
+            "Name": "EnterpriseOnly",
+            "Priority": 0,
+            "Statement": {
+              "AndStatement": {
+                "Statements": [
+                  {
+                    "NotStatement": {
+                      "Statement": {
+                        "IPSetReferenceStatement": {
+                          "ARN": {
+                            "Fn::GetAtt": ["InternalOnlyIPV4", "Arn"]
                           }
                         }
                       }
-                    },
-                    {
-                      "ByteMatchStatement": {
-                        "FieldToMatch": {
-                          "UriPath": {}
-                        },
-                        "PositionalConstraint": "CONTAINS",
-                        "SearchString": "/admin",
-                        "TextTransformations": [
-                          {
-                            "Type": "NONE",
-                            "Priority": 0
-                          }
-                        ]
-                      }
                     }
-                  ]
-                }              
-              },
-              "VisibilityConfig": {
-                "CloudWatchMetricsEnabled": true,
-                "MetricName": "EnterpriseOnly",
-                "SampledRequestsEnabled": true
-              },
-              "Action": {
-                "Block": {}
+                  },
+                  {
+                    "ByteMatchStatement": {
+                      "FieldToMatch": {
+                        "UriPath": {}
+                      },
+                      "PositionalConstraint": "CONTAINS",
+                      "SearchString": "/admin",
+                      "TextTransformations": [
+                        {
+                          "Type": "NONE",
+                          "Priority": 0
+                        }
+                      ]
+                    }
+                  }
+                ]
               }
-            }        
-          ]
-        },
-        "DependsOn": [
-          "InternalOnlyIPV4"
+            },
+            "VisibilityConfig": {
+              "CloudWatchMetricsEnabled": true,
+              "MetricName": "EnterpriseOnly",
+              "SampledRequestsEnabled": true
+            },
+            "Action": {
+              "Block": {}
+            }
+          }
         ]
       },
-      "InternalOnlyIPV4": {
-        "Type": "AWS::WAFv2::IPSet",
-        "Properties": {
-          "Addresses": {
-            "Ref": "InternalCIDR"
-          },  
-          "IPAddressVersion": "IPV4",
-          "Scope": "CLOUDFRONT",
-          "Description": "This is the WAF v2 IPSet designating the CIDR of the internal network",
-          "Name": "EnterpriseCIDROnly"
-        }
+      "DependsOn": ["InternalOnlyIPV4"]
+    },
+    "InternalOnlyIPV4": {
+      "Type": "AWS::WAFv2::IPSet",
+      "Properties": {
+        "Addresses": {
+          "Ref": "InternalCIDR"
+        },
+        "IPAddressVersion": "IPV4",
+        "Scope": "CLOUDFRONT",
+        "Description": "This is the WAF v2 IPSet designating the CIDR of the internal network",
+        "Name": "EnterpriseCIDROnly"
       }
     }
   }
+}


### PR DESCRIPTION
## Description

When we upgraded CDK, there was a breaking change and we added a 403 error handler based on the CDK ticket below

https://github.com/aws/aws-cdk/issues/13272 

However, the better fix is to do what the CDK author pointed out, to give the Cloudfront identity access to the S3 bucket.  

bucket.grantRead(originAccessIdentity);

The 403 error handler we added prevented us from using the WAF, which would fail block request with a 403

The other change is to the sample CFT to create a WAF that will block access based on origin CIDR range and the path that the request is accessing.  For example, block all access that didn't originate from 10.0.0.0/8 and has /admin in the path.

## Testing

Installed in my AWS account and tested

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
