### PR TITLE
GTT-1602 : bump ansi-regex from 5.0.0 to 5.0.1

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -992,9 +992,9 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -1768,9 +1768,9 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {


### PR DESCRIPTION
## Description

Per the dependabot alert, bump ansi-regex in cdk and backend to 5.0.1

## Testing

* unit tests
* deployed on AWS and performed manual regression testing

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
