### PR TITLE
Adds backend support for searching inside published dashboards.

### DIFF
--- a/backend/postman/Performance Dashboard API.postman_collection.json
+++ b/backend/postman/Performance Dashboard API.postman_collection.json
@@ -26,8 +26,12 @@
             "header": [],
             "url": {
               "raw": "{{baseUrl}}/dashboard",
-              "host": ["{{baseUrl}}"],
-              "path": ["dashboard"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "dashboard"
+              ]
             }
           },
           "response": []
@@ -49,8 +53,14 @@
             "header": [],
             "url": {
               "raw": "{{baseUrl}}/dashboard/:id/auditlogs",
-              "host": ["{{baseUrl}}"],
-              "path": ["dashboard", ":id", "auditlogs"],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "dashboard",
+                ":id",
+                "auditlogs"
+              ],
               "variable": [
                 {
                   "key": "id",
@@ -77,8 +87,12 @@
             },
             "url": {
               "raw": "{{baseUrl}}/dashboard",
-              "host": ["{{baseUrl}}"],
-              "path": ["dashboard"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "dashboard"
+              ]
             }
           },
           "response": []
@@ -99,8 +113,13 @@
             },
             "url": {
               "raw": "{{baseUrl}}/dashboard/:id",
-              "host": ["{{baseUrl}}"],
-              "path": ["dashboard", ":id"],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "dashboard",
+                ":id"
+              ],
               "variable": [
                 {
                   "key": "id",
@@ -128,8 +147,13 @@
             "header": [],
             "url": {
               "raw": "{{baseUrl}}/dashboard/:id",
-              "host": ["{{baseUrl}}"],
-              "path": ["dashboard", ":id"],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "dashboard",
+                ":id"
+              ],
               "variable": [
                 {
                   "key": "id",
@@ -167,8 +191,13 @@
             },
             "url": {
               "raw": "{{baseUrl}}/dashboard/:id",
-              "host": ["{{baseUrl}}"],
-              "path": ["dashboard", ":id"],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "dashboard",
+                ":id"
+              ],
               "variable": [
                 {
                   "key": "id",
@@ -206,8 +235,14 @@
             },
             "url": {
               "raw": "{{baseUrl}}/dashboard/:id/publish",
-              "host": ["{{baseUrl}}"],
-              "path": ["dashboard", ":id", "publish"],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "dashboard",
+                ":id",
+                "publish"
+              ],
               "variable": [
                 {
                   "key": "id",
@@ -244,8 +279,14 @@
             },
             "url": {
               "raw": "{{baseUrl}}/dashboard/:id/draft",
-              "host": ["{{baseUrl}}"],
-              "path": ["dashboard", ":id", "draft"],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "dashboard",
+                ":id",
+                "draft"
+              ],
               "variable": [
                 {
                   "key": "id",
@@ -282,8 +323,14 @@
             },
             "url": {
               "raw": "{{baseUrl}}/dashboard/:id/archive",
-              "host": ["{{baseUrl}}"],
-              "path": ["dashboard", ":id", "archive"],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "dashboard",
+                ":id",
+                "archive"
+              ],
               "variable": [
                 {
                   "key": "id",
@@ -320,8 +367,14 @@
             },
             "url": {
               "raw": "{{baseUrl}}/dashboard/:id/publishpending",
-              "host": ["{{baseUrl}}"],
-              "path": ["dashboard", ":id", "publishpending"],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "dashboard",
+                ":id",
+                "publishpending"
+              ],
               "variable": [
                 {
                   "key": "id",
@@ -349,8 +402,13 @@
             "header": [],
             "url": {
               "raw": "{{baseUrl}}/dashboard/:id",
-              "host": ["{{baseUrl}}"],
-              "path": ["dashboard", ":id"],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "dashboard",
+                ":id"
+              ],
               "variable": [
                 {
                   "key": "id",
@@ -392,8 +450,12 @@
             },
             "url": {
               "raw": "{{baseUrl}}/topicarea",
-              "host": ["{{baseUrl}}"],
-              "path": ["topicarea"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "topicarea"
+              ]
             }
           },
           "response": []
@@ -415,8 +477,12 @@
             "header": [],
             "url": {
               "raw": "{{baseUrl}}/topicarea",
-              "host": ["{{baseUrl}}"],
-              "path": ["topicarea"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "topicarea"
+              ]
             }
           },
           "response": []
@@ -437,8 +503,13 @@
             },
             "url": {
               "raw": "{{baseUrl}}/topicarea/:id",
-              "host": ["{{baseUrl}}"],
-              "path": ["topicarea", ":id"],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "topicarea",
+                ":id"
+              ],
               "variable": [
                 {
                   "key": "id",
@@ -457,8 +528,13 @@
             "header": [],
             "url": {
               "raw": "{{baseUrl}}/topicarea/:id",
-              "host": ["{{baseUrl}}"],
-              "path": ["topicarea", ":id"],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "topicarea",
+                ":id"
+              ],
               "variable": [
                 {
                   "key": "id",
@@ -477,8 +553,13 @@
             "header": [],
             "url": {
               "raw": "{{baseUrl}}/topicarea/:id",
-              "host": ["{{baseUrl}}"],
-              "path": ["topicarea", ":id"],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "topicarea",
+                ":id"
+              ],
               "variable": [
                 {
                   "key": "id",
@@ -520,8 +601,14 @@
             },
             "url": {
               "raw": "{{baseUrl}}/dashboard/:id/widget",
-              "host": ["{{baseUrl}}"],
-              "path": ["dashboard", ":id", "widget"],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "dashboard",
+                ":id",
+                "widget"
+              ],
               "variable": [
                 {
                   "key": "id",
@@ -559,7 +646,9 @@
             },
             "url": {
               "raw": "{{baseUrl}}/dashboard/090b0410-001e-4880-87fd-bab3de102574/widget",
-              "host": ["{{baseUrl}}"],
+              "host": [
+                "{{baseUrl}}"
+              ],
               "path": [
                 "dashboard",
                 "090b0410-001e-4880-87fd-bab3de102574",
@@ -595,7 +684,9 @@
             },
             "url": {
               "raw": "{{baseUrl}}/dashboard/090b0410-001e-4880-87fd-bab3de102574/widget",
-              "host": ["{{baseUrl}}"],
+              "host": [
+                "{{baseUrl}}"
+              ],
               "path": [
                 "dashboard",
                 "090b0410-001e-4880-87fd-bab3de102574",
@@ -631,8 +722,14 @@
             },
             "url": {
               "raw": "{{baseUrl}}/dashboard/:id/widget",
-              "host": ["{{baseUrl}}"],
-              "path": ["dashboard", ":id", "widget"],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "dashboard",
+                ":id",
+                "widget"
+              ],
               "variable": [
                 {
                   "key": "id",
@@ -669,8 +766,14 @@
             },
             "url": {
               "raw": "{{baseUrl}}/dashboard/:id/widget",
-              "host": ["{{baseUrl}}"],
-              "path": ["dashboard", ":id", "widget"],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "dashboard",
+                ":id",
+                "widget"
+              ],
               "variable": [
                 {
                   "key": "id",
@@ -688,8 +791,15 @@
             "header": [],
             "url": {
               "raw": "{{baseUrl}}/dashboard/:id/widget/:widgetId",
-              "host": ["{{baseUrl}}"],
-              "path": ["dashboard", ":id", "widget", ":widgetId"],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "dashboard",
+                ":id",
+                "widget",
+                ":widgetId"
+              ],
               "variable": [
                 {
                   "key": "id",
@@ -722,8 +832,14 @@
             },
             "url": {
               "raw": "{{baseUrl}}/dashboard/:id/widgetorder",
-              "host": ["{{baseUrl}}"],
-              "path": ["dashboard", ":id", "widgetorder"],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "dashboard",
+                ":id",
+                "widgetorder"
+              ],
               "variable": [
                 {
                   "key": "id",
@@ -766,8 +882,12 @@
             },
             "url": {
               "raw": "{{baseUrl}}/dataset",
-              "host": ["{{baseUrl}}"],
-              "path": ["dataset"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "dataset"
+              ]
             }
           },
           "response": []
@@ -779,8 +899,12 @@
             "header": [],
             "url": {
               "raw": "{{baseUrl}}/dataset",
-              "host": ["{{baseUrl}}"],
-              "path": ["dataset"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "dataset"
+              ]
             }
           },
           "response": []
@@ -792,8 +916,13 @@
             "header": [],
             "url": {
               "raw": "{{baseUrl}}/dataset/:id",
-              "host": ["{{baseUrl}}"],
-              "path": ["dataset", ":id"],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "dataset",
+                ":id"
+              ],
               "variable": [
                 {
                   "key": "id",
@@ -819,8 +948,14 @@
             "header": [],
             "url": {
               "raw": "{{baseUrl}}/public/dashboard/:id",
-              "host": ["{{baseUrl}}"],
-              "path": ["public", "dashboard", ":id"],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "public",
+                "dashboard",
+                ":id"
+              ],
               "variable": [
                 {
                   "key": "id",
@@ -839,8 +974,13 @@
             "header": [],
             "url": {
               "raw": "{{baseUrl}}/public/homepage",
-              "host": ["{{baseUrl}}"],
-              "path": ["public", "homepage"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "public",
+                "homepage"
+              ]
             },
             "description": "Returns homepage title, description and a list of dashboards"
           },
@@ -853,8 +993,15 @@
             "header": [],
             "url": {
               "raw": "{{baseUrl}}/public/dashboard/friendly-url/:friendlyURL",
-              "host": ["{{baseUrl}}"],
-              "path": ["public", "dashboard", "friendly-url", ":friendlyURL"],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "public",
+                "dashboard",
+                "friendly-url",
+                ":friendlyURL"
+              ],
               "variable": [
                 {
                   "key": "friendlyURL",
@@ -872,9 +1019,43 @@
             "header": [],
             "url": {
               "raw": "{{baseUrl}}/public/settings",
-              "host": ["{{baseUrl}}"],
-              "path": ["public", "settings"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "public",
+                "settings"
+              ]
             }
+          },
+          "response": []
+        },
+        {
+          "name": "Get Public Homepage with Search Query",
+          "request": {
+            "auth": {
+              "type": "noauth"
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/public/search/:query",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "public",
+                "search",
+                ":query"
+              ],
+              "variable": [
+                {
+                  "key": "query",
+                  "value": ""
+                }
+              ]
+            },
+            "description": "Returns homepage title, description and a list of dashboards with content that matches the query"
           },
           "response": []
         }
@@ -887,14 +1068,18 @@
           "listen": "prerequest",
           "script": {
             "type": "text/javascript",
-            "exec": [""]
+            "exec": [
+              ""
+            ]
           }
         },
         {
           "listen": "test",
           "script": {
             "type": "text/javascript",
-            "exec": [""]
+            "exec": [
+              ""
+            ]
           }
         }
       ]
@@ -909,8 +1094,12 @@
             "header": [],
             "url": {
               "raw": "{{baseUrl}}/settings",
-              "host": ["{{baseUrl}}"],
-              "path": ["settings"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "settings"
+              ]
             }
           },
           "response": []
@@ -931,8 +1120,12 @@
             },
             "url": {
               "raw": "{{baseUrl}}/settings",
-              "host": ["{{baseUrl}}"],
-              "path": ["settings"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "settings"
+              ]
             }
           },
           "response": []
@@ -953,8 +1146,13 @@
             },
             "url": {
               "raw": "{{baseUrl}}/settings/homepage",
-              "host": ["{{baseUrl}}"],
-              "path": ["settings", "homepage"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "settings",
+                "homepage"
+              ]
             }
           },
           "response": []
@@ -966,8 +1164,13 @@
             "header": [],
             "url": {
               "raw": "{{baseUrl}}/settings/homepage",
-              "host": ["{{baseUrl}}"],
-              "path": ["settings", "homepage"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "settings",
+                "homepage"
+              ]
             }
           },
           "response": []
@@ -1013,8 +1216,13 @@
             },
             "url": {
               "raw": "{{baseUrl}}/ingestapi/dataset",
-              "host": ["{{baseUrl}}"],
-              "path": ["ingestapi", "dataset"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "ingestapi",
+                "dataset"
+              ]
             },
             "description": "Unlike regular Datasets, a Metrics dataset has a defined schema to populate Content Items of type \"Metrics\". "
           },
@@ -1056,8 +1264,13 @@
             },
             "url": {
               "raw": "{{baseUrl}}/ingestapi/dataset",
-              "host": ["{{baseUrl}}"],
-              "path": ["ingestapi", "dataset"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "ingestapi",
+                "dataset"
+              ]
             }
           },
           "response": []
@@ -1098,8 +1311,14 @@
             },
             "url": {
               "raw": "{{baseUrl}}/ingestapi/dataset/:datasetId",
-              "host": ["{{baseUrl}}"],
-              "path": ["ingestapi", "dataset", ":datasetId"],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "ingestapi",
+                "dataset",
+                ":datasetId"
+              ],
               "variable": [
                 {
                   "key": "datasetId",
@@ -1146,8 +1365,14 @@
             },
             "url": {
               "raw": "{{baseUrl}}/ingestapi/dataset/:datasetId",
-              "host": ["{{baseUrl}}"],
-              "path": ["ingestapi", "dataset", ":datasetId"],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "ingestapi",
+                "dataset",
+                ":datasetId"
+              ],
               "variable": [
                 {
                   "key": "datasetId",
@@ -1185,8 +1410,14 @@
             "header": [],
             "url": {
               "raw": "{{baseUrl}}/ingestapi/dataset/:datasetId",
-              "host": ["{{baseUrl}}"],
-              "path": ["ingestapi", "dataset", ":datasetId"],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "ingestapi",
+                "dataset",
+                ":datasetId"
+              ],
               "variable": [
                 {
                   "key": "datasetId",
@@ -1219,8 +1450,12 @@
             "header": [],
             "url": {
               "raw": "{{baseUrl}}/user",
-              "host": ["{{baseUrl}}"],
-              "path": ["user"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "user"
+              ]
             }
           },
           "response": []
@@ -1251,8 +1486,12 @@
             },
             "url": {
               "raw": "{{baseUrl}}/user",
-              "host": ["{{baseUrl}}"],
-              "path": ["user"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "user"
+              ]
             }
           },
           "response": []
@@ -1283,8 +1522,13 @@
             },
             "url": {
               "raw": "{{baseUrl}}/user/invite",
-              "host": ["{{baseUrl}}"],
-              "path": ["user", "invite"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "user",
+                "invite"
+              ]
             }
           },
           "response": []
@@ -1315,8 +1559,13 @@
             },
             "url": {
               "raw": "{{baseUrl}}/user/role",
-              "host": ["{{baseUrl}}"],
-              "path": ["user", "role"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "user",
+                "role"
+              ]
             }
           },
           "response": []
@@ -1339,14 +1588,18 @@
       "listen": "prerequest",
       "script": {
         "type": "text/javascript",
-        "exec": [""]
+        "exec": [
+          ""
+        ]
       }
     },
     {
       "listen": "test",
       "script": {
         "type": "text/javascript",
-        "exec": [""]
+        "exec": [
+          ""
+        ]
       }
     }
   ],

--- a/backend/src/lib/api/public-api.ts
+++ b/backend/src/lib/api/public-api.ts
@@ -16,6 +16,11 @@ router.get(
   errorHandler(DashboardCtrl.getPublicDashboardByFriendlyURL)
 );
 
+router.get(
+  "/search/:query",
+  errorHandler(HomepageCtrl.getPublicHomepageWithQuery)
+);
+
 router.get("/homepage", errorHandler(HomepageCtrl.getPublicHomepage));
 router.get("/settings", errorHandler(SettingsCtrl.getPublicSettings));
 

--- a/backend/src/lib/controllers/__tests__/homepage-ctrl.test.ts
+++ b/backend/src/lib/controllers/__tests__/homepage-ctrl.test.ts
@@ -208,22 +208,22 @@ describe("updateHomepage", () => {
 
 describe("getPublicHomepageWithQuery", () => {
   let req: Request;
-    beforeEach(() => {
-      req = {
-        user,
-        params: {
-          query: "UK",
-        },
-      } as any as Request;
-      jest.resetAllMocks();
-      jest.resetModules();
-      HomepageRepository.getInstance = jest.fn().mockReturnValue(repository);
-      DashboardRepository.getInstance = jest.fn().mockReturnValue(dashboardRepo);
-    });
+  beforeEach(() => {
+    req = {
+      user,
+      params: {
+        query: "UK",
+      },
+    } as any as Request;
+    jest.resetAllMocks();
+    jest.resetModules();
+    HomepageRepository.getInstance = jest.fn().mockReturnValue(repository);
+    DashboardRepository.getInstance = jest.fn().mockReturnValue(dashboardRepo);
+  });
 
   it("returns a list of published dashboards with content matching a query", async () => {
     const now = new Date();
- 
+
     // The two public dashboards.
     const publicDashboard1: PublicDashboard = {
       id: "123",
@@ -233,7 +233,7 @@ describe("getPublicHomepageWithQuery", () => {
       displayTableOfContents: false,
       description: "All about the United States of America.",
       updatedAt: now,
-     };
+    };
     const publicDashboard2: PublicDashboard = {
       id: "456",
       name: "UK",
@@ -243,7 +243,7 @@ describe("getPublicHomepageWithQuery", () => {
       description: "All about the United Kingdom.",
       updatedAt: now,
     };
-    
+
     // The two corresponding published dashboards.
     let publishedDashboard1: Dashboard = {
       ...publicDashboard1,
@@ -259,24 +259,28 @@ describe("getPublicHomepageWithQuery", () => {
       createdBy: "johndoe",
       state: DashboardState.Published,
     };
-    
+
     // The two corresponding published dashboards with widgets.
     let publishedDashboardWithWidget1: Dashboard = {
       ...publishedDashboard1,
-      widgets: [{
-        id: "111",
-        name: "Geography of the USA",
-        widgetType: WidgetType.Text,
-        dashboardId: "123",
-        order: 1,
-        updatedAt: now,
-        content: {
-          text: "The USA is in North America. The capital of the USA is Washington, DC."
+      widgets: [
+        {
+          id: "111",
+          name: "Geography of the USA",
+          widgetType: WidgetType.Text,
+          dashboardId: "123",
+          order: 1,
+          updatedAt: now,
+          content: {
+            text: "The USA is in North America. The capital of the USA is Washington, DC.",
+          },
         },
-      },],};
-      let publishedDashboardWithWidget2: Dashboard = {
-        ...publishedDashboard2,
-        widgets: [{
+      ],
+    };
+    let publishedDashboardWithWidget2: Dashboard = {
+      ...publishedDashboard2,
+      widgets: [
+        {
           id: "222",
           name: "Geography of the UK",
           widgetType: WidgetType.Text,
@@ -284,9 +288,11 @@ describe("getPublicHomepageWithQuery", () => {
           order: 1,
           updatedAt: now,
           content: {
-            text: "The UK is in Europe. The capital of the UK is London."
+            text: "The UK is in Europe. The capital of the UK is London.",
           },
-        },],};
+        },
+      ],
+    };
 
     repository.getHomepage = jest.fn().mockReturnValueOnce({
       title: "Performance Dashboard",
@@ -308,20 +314,22 @@ describe("getPublicHomepageWithQuery", () => {
       .mockReturnValueOnce(publishedDashboardWithWidget2)
       .mockReturnValueOnce(publishedDashboardWithWidget1);
 
-    const matchedDashboard: PublicDashboard[] = [{
-      id: "456",
-      name: "UK",
-      topicAreaId: "abc",
-      topicAreaName: "Europe",
-      displayTableOfContents: false,
-      description: "All about the United Kingdom.",
-      updatedAt: now,
-      queryMatches: [
-        "UK",
-        "The UK is in Europe.",
-        "The capital of the UK is London.",
-      ]
-    },];
+    const matchedDashboard: PublicDashboard[] = [
+      {
+        id: "456",
+        name: "UK",
+        topicAreaId: "abc",
+        topicAreaName: "Europe",
+        displayTableOfContents: false,
+        description: "All about the United Kingdom.",
+        updatedAt: now,
+        queryMatches: [
+          "UK",
+          "The UK is in Europe.",
+          "The capital of the UK is London.",
+        ],
+      },
+    ];
 
     await HomepageCtrl.getPublicHomepageWithQuery(req, res);
     expect(res.json).toBeCalledWith(

--- a/backend/src/lib/controllers/__tests__/homepage-ctrl.test.ts
+++ b/backend/src/lib/controllers/__tests__/homepage-ctrl.test.ts
@@ -11,6 +11,7 @@ import HomepageRepository from "../../repositories/homepage-repo";
 import DashboardRepository from "../../repositories/dashboard-repo";
 import DashboardFactory from "../../factories/dashboard-factory";
 import HomepageCtrl from "../homepage-ctrl";
+import { WidgetType } from "../../models/widget";
 
 jest.mock("../../repositories/homepage-repo");
 jest.mock("../../repositories/dashboard-repo");
@@ -201,6 +202,132 @@ describe("updateHomepage", () => {
       "description test",
       now.toISOString(),
       user
+    );
+  });
+});
+
+describe("getPublicHomepageWithQuery", () => {
+  let req: Request;
+    beforeEach(() => {
+      req = {
+        user,
+        params: {
+          query: "UK",
+        },
+      } as any as Request;
+      jest.resetAllMocks();
+      jest.resetModules();
+      HomepageRepository.getInstance = jest.fn().mockReturnValue(repository);
+      DashboardRepository.getInstance = jest.fn().mockReturnValue(dashboardRepo);
+    });
+
+  it("returns a list of published dashboards with content matching a query", async () => {
+    const now = new Date();
+ 
+    // The two public dashboards.
+    const publicDashboard1: PublicDashboard = {
+      id: "123",
+      name: "USA",
+      topicAreaId: "xyz",
+      topicAreaName: "North America",
+      displayTableOfContents: false,
+      description: "All about the United States of America.",
+      updatedAt: now,
+     };
+    const publicDashboard2: PublicDashboard = {
+      id: "456",
+      name: "UK",
+      topicAreaId: "abc",
+      topicAreaName: "Europe",
+      displayTableOfContents: false,
+      description: "All about the United Kingdom.",
+      updatedAt: now,
+    };
+    
+    // The two corresponding published dashboards.
+    let publishedDashboard1: Dashboard = {
+      ...publicDashboard1,
+      version: 1,
+      parentDashboardId: "123",
+      createdBy: "johndoe",
+      state: DashboardState.Published,
+    };
+    let publishedDashboard2: Dashboard = {
+      ...publicDashboard2,
+      version: 1,
+      parentDashboardId: "456",
+      createdBy: "johndoe",
+      state: DashboardState.Published,
+    };
+    
+    // The two corresponding published dashboards with widgets.
+    let publishedDashboardWithWidget1: Dashboard = {
+      ...publishedDashboard1,
+      widgets: [{
+        id: "111",
+        name: "Geography of the USA",
+        widgetType: WidgetType.Text,
+        dashboardId: "123",
+        order: 1,
+        updatedAt: now,
+        content: {
+          text: "The USA is in North America. The capital of the USA is Washington, DC."
+        },
+      },],};
+      let publishedDashboardWithWidget2: Dashboard = {
+        ...publishedDashboard2,
+        widgets: [{
+          id: "222",
+          name: "Geography of the UK",
+          widgetType: WidgetType.Text,
+          dashboardId: "456",
+          order: 1,
+          updatedAt: now,
+          content: {
+            text: "The UK is in Europe. The capital of the UK is London."
+          },
+        },],};
+
+    repository.getHomepage = jest.fn().mockReturnValueOnce({
+      title: "Performance Dashboard",
+      description: "Welcome to the performance dashboard",
+    });
+    HomepageFactory.getDefaultHomepage = jest.fn().mockReturnValueOnce({
+      title: "Performance Dashboard",
+      description: "Welcome to the performance dashboard",
+    });
+    dashboardRepo.listPublishedDashboards = jest
+      .fn()
+      .mockReturnValue([publishedDashboard1, publishedDashboard2]);
+    DashboardFactory.toPublic = jest
+      .fn()
+      .mockReturnValueOnce(publicDashboard1)
+      .mockReturnValueOnce(publicDashboard2);
+    dashboardRepo.getDashboardWithWidgets = jest
+      .fn()
+      .mockReturnValueOnce(publishedDashboardWithWidget2)
+      .mockReturnValueOnce(publishedDashboardWithWidget1);
+
+    const matchedDashboard: PublicDashboard[] = [{
+      id: "456",
+      name: "UK",
+      topicAreaId: "abc",
+      topicAreaName: "Europe",
+      displayTableOfContents: false,
+      description: "All about the United Kingdom.",
+      updatedAt: now,
+      queryMatches: [
+        "UK",
+        "The UK is in Europe.",
+        "The capital of the UK is London.",
+      ]
+    },];
+
+    await HomepageCtrl.getPublicHomepageWithQuery(req, res);
+    expect(res.json).toBeCalledWith(
+      expect.objectContaining({
+        dashboards: matchedDashboard,
+      })
     );
   });
 });

--- a/backend/src/lib/controllers/homepage-ctrl.ts
+++ b/backend/src/lib/controllers/homepage-ctrl.ts
@@ -3,7 +3,11 @@ import HomepageFactory from "../factories/homepage-factory";
 import HomepageRepository from "../repositories/homepage-repo";
 import DashboardRepository from "../repositories/dashboard-repo";
 import DashboardFactory from "../factories/dashboard-factory";
+import DashboardCtrl from "../controllers/dashboard-ctrl";
 import AuthService from "../services/auth";
+import { RSA_NO_PADDING } from "constants";
+import { setUncaughtExceptionCaptureCallback } from "process";
+import { convertCompilerOptionsFromJson } from "typescript";
 
 async function getPublicHomepage(req: Request, res: Response) {
   const repo = HomepageRepository.getInstance();
@@ -61,8 +65,99 @@ async function updateHomepage(req: Request, res: Response) {
   res.send();
 }
 
+// A helper function that splits a paragraph into sentences,
+// then returns an array of sentences that contain a queried string.
+function splitAndSearch(paragraph: string, query: string) {
+  let matches: Array<string> = [];
+  let sentences = paragraph.replace(/([.?!:])\s*(?=[A-Z])/g, "$1|").split("|");
+  for (var sentence of sentences) {
+    if (sentence.toLowerCase().includes(query)) {
+      matches.push(sentence);
+    }
+  }
+  return matches;
+}
+
+// Returns homepage title, description and a list of dashboards
+// with content that matches a search query.
+async function getPublicHomepageWithQuery(req: Request, res: Response) {
+  let { query } = req.params;
+  query = query.toLowerCase();
+
+  const repo = HomepageRepository.getInstance();
+  let homepage = await repo.getHomepage();
+  if (!homepage) {
+    homepage = HomepageFactory.getDefaultHomepage();
+  }
+
+  const dashboardRepo = DashboardRepository.getInstance();
+  const dashboards = await dashboardRepo.listPublishedDashboards();
+  let publicDashboards = dashboards.map(DashboardFactory.toPublic);
+
+  if (publicDashboards) {
+    var index = publicDashboards.length;
+
+    while (index--) {
+      let found = false;
+      let dashboard = publicDashboards[index];
+      dashboard.queryMatches = [];
+
+      const dashboardWithWidgets = await dashboardRepo.getDashboardWithWidgets(dashboard.id);
+
+      if (dashboardWithWidgets.name.toLowerCase().includes(query)) {
+        dashboard.queryMatches.push(dashboardWithWidgets.name);
+        found = true;
+      }
+
+      if (dashboardWithWidgets.description.toLowerCase().includes(query)) {
+        dashboard.queryMatches.push(dashboardWithWidgets.description);
+        found = true;
+      }
+
+      if (dashboardWithWidgets.widgets) {
+        for (var widget of dashboardWithWidgets.widgets) {
+          if (widget.content.text) {
+            let matches = splitAndSearch(widget.content.text, query);
+            if (matches.length) {
+              dashboard.queryMatches = dashboard.queryMatches.concat(matches);
+              found = true;
+            }
+          }
+
+          if (widget.content.title) {
+            let matches = splitAndSearch(widget.content.title, query);
+            if (matches.length) {
+              dashboard.queryMatches = dashboard.queryMatches.concat(matches);
+              found = true;
+            }
+          }
+
+          if (widget.content.summary) {
+            let matches = splitAndSearch(widget.content.summary, query);
+            if (matches.length) {
+              dashboard.queryMatches = dashboard.queryMatches.concat(matches);
+              found = true;
+            }
+          }
+        }
+      }
+
+      if (!found) {
+        publicDashboards.splice(index, 1);
+      }
+    }
+  }
+
+  return res.json({
+    title: homepage.title,
+    description: homepage.description,
+    dashboards: publicDashboards,
+  });
+}
+
 export default {
   getPublicHomepage,
   getHomepage,
   updateHomepage,
+  getPublicHomepageWithQuery,
 };

--- a/backend/src/lib/controllers/homepage-ctrl.ts
+++ b/backend/src/lib/controllers/homepage-ctrl.ts
@@ -102,7 +102,9 @@ async function getPublicHomepageWithQuery(req: Request, res: Response) {
       let dashboard = publicDashboards[index];
       dashboard.queryMatches = [];
 
-      const dashboardWithWidgets = await dashboardRepo.getDashboardWithWidgets(dashboard.id);
+      const dashboardWithWidgets = await dashboardRepo.getDashboardWithWidgets(
+        dashboard.id
+      );
 
       if (dashboardWithWidgets.name.toLowerCase().includes(query)) {
         dashboard.queryMatches.push(dashboardWithWidgets.name);

--- a/backend/src/lib/models/dashboard.ts
+++ b/backend/src/lib/models/dashboard.ts
@@ -80,4 +80,8 @@ export interface PublicDashboard {
   updatedAt: Date;
   widgets?: Array<Widget>;
   friendlyURL?: string;
+
+  // Filled on a homepage search with dashboard content
+  // that matches the search query.
+  queryMatches?: Array<string>;
 }


### PR DESCRIPTION
## Description

GTT-1557: Adds backend support for searching inside of published dashboards. Given a query, searches text fields inside published dashboards, and returns those dashboards with content matching the query. Text snippets are also returned.

## Testing

- Added a unit test and tested with it.
- Tested with Postman.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
