### PR TITLE
Adds frontend support for searching inside published dashboards.

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import withPublicLayout from "./layouts/Public";
 import withAdminLayout from "./layouts/Admin";
 
 import Home from "./containers/Home";
+import HomeWithSearch from "./containers/HomeWithSearch";
 import DashboardListing from "./containers/DashboardListing";
 import CreateDashboard from "./containers/CreateDashboard";
 import EditDetails from "./containers/EditDetails";
@@ -294,6 +295,11 @@ const routes: Array<AppRoute> = [
   {
     path: "/",
     component: Home,
+    public: true,
+  },
+  {
+    path: "/search/:query",
+    component: HomeWithSearch,
     public: true,
   },
 ];

--- a/frontend/src/containers/Home.tsx
+++ b/frontend/src/containers/Home.tsx
@@ -16,7 +16,7 @@ function Home() {
   const dateFormatter = useDateTimeFormatter();
 
   const onSearch = (query: string) => {
-    window.location.assign("/search/"+query);
+    window.location.assign("/search/" + query);
   };
 
   const onClear = () => {

--- a/frontend/src/containers/HomeWithSearch.tsx
+++ b/frontend/src/containers/HomeWithSearch.tsx
@@ -1,19 +1,28 @@
 import React, { useState } from "react";
+import { useParams, Redirect } from "react-router-dom";
 import Link from "../components/Link";
-import { usePublicHomepage, useDateTimeFormatter } from "../hooks";
+import { usePublicHomepage, useDateTimeFormatter, usePublicHomepageSearch } from "../hooks";
 import { useTranslation } from "react-i18next";
 import UtilsService from "../services/UtilsService";
 import Accordion from "../components/Accordion";
 import Search from "../components/Search";
-import { PublicDashboard } from "../models";
+import { PublicHomepage } from "../models";
 import Spinner from "../components/Spinner";
 import MarkdownRender from "../components/MarkdownRender";
+import Button from "../components/Button";
 import "./Home.css";
 
-function Home() {
-  const { homepage, loading } = usePublicHomepage();
+interface PathParams {
+  query: string;
+}
+
+function HomeWithSearch() {
+  const { query } = useParams<PathParams>();
+  const { homepage, loading } = usePublicHomepageSearch(query);
   const { t } = useTranslation();
   const dateFormatter = useDateTimeFormatter();
+
+  const topicareas = UtilsService.groupByTopicArea(homepage.dashboards);
 
   const onSearch = (query: string) => {
     window.location.assign("/search/"+query);
@@ -22,8 +31,6 @@ function Home() {
   const onClear = () => {
     window.location.assign("/");
   };
-
-  const topicareas = UtilsService.groupByTopicArea(homepage.dashboards);
 
   return loading ? (
     <Spinner
@@ -52,11 +59,15 @@ function Home() {
           <Search
             id="search"
             onSubmit={onSearch}
-            size="big"
             onClear={onClear}
+            size="big"
             query=""
             results={homepage.dashboards.length}
           />
+          {homepage.dashboards.length} dashboard(s) contain "{query}" &emsp;
+          <Link to={`/`}>{t("ClearSearchText")}
+          </Link>
+          <br />
         </div>
       </div>
       <div className="grid-row">
@@ -86,7 +97,15 @@ function Home() {
                       <br />
                       <span className="text-base text-italic">
                         {t("LastUpdatedLabel")} {updatedAt}
+                      <br />
                       </span>
+                      {dashboard.queryMatches?.map((queryMatch) => {
+                        return (
+                          <span className="text-base margin-left-2 margin-right-2"> ... {queryMatch} ...
+                          <br />
+                          </span>
+                        );
+                      })}
                     </div>
                   );
                 })}
@@ -99,4 +118,4 @@ function Home() {
   );
 }
 
-export default Home;
+export default HomeWithSearch;

--- a/frontend/src/containers/HomeWithSearch.tsx
+++ b/frontend/src/containers/HomeWithSearch.tsx
@@ -1,7 +1,6 @@
-import React, { useState } from "react";
-import { useParams, Redirect } from "react-router-dom";
+import React, { useParams } from "react-router-dom";
 import Link from "../components/Link";
-import { usePublicHomepage, useDateTimeFormatter, usePublicHomepageSearch } from "../hooks";
+import { useDateTimeFormatter, usePublicHomepageSearch } from "../hooks";
 import { useTranslation } from "react-i18next";
 import UtilsService from "../services/UtilsService";
 import Accordion from "../components/Accordion";
@@ -9,7 +8,6 @@ import Search from "../components/Search";
 import { PublicHomepage } from "../models";
 import Spinner from "../components/Spinner";
 import MarkdownRender from "../components/MarkdownRender";
-import Button from "../components/Button";
 import "./Home.css";
 
 interface PathParams {
@@ -25,7 +23,7 @@ function HomeWithSearch() {
   const topicareas = UtilsService.groupByTopicArea(homepage.dashboards);
 
   const onSearch = (query: string) => {
-    window.location.assign("/search/"+query);
+    window.location.assign("/search/" + query);
   };
 
   const onClear = () => {
@@ -65,8 +63,7 @@ function HomeWithSearch() {
             results={homepage.dashboards.length}
           />
           {homepage.dashboards.length} dashboard(s) contain "{query}" &emsp;
-          <Link to={`/`}>{t("ClearSearchText")}
-          </Link>
+          <Link to={`/`}>{t("ClearSearchText")}</Link>
           <br />
         </div>
       </div>
@@ -97,13 +94,15 @@ function HomeWithSearch() {
                       <br />
                       <span className="text-base text-italic">
                         {t("LastUpdatedLabel")} {updatedAt}
-                      <br />
+                        <br />
                       </span>
                       {dashboard.queryMatches?.map((queryMatch) => {
                         return (
-                          <span className="text-base margin-left-2 margin-right-2"> ... {queryMatch} ...
-                          <br />
-                          </span>
+                          <p className="text-base margin-left-2 margin-right-2">
+                            {" "}
+                            ... {queryMatch} ...
+                            <br />
+                          </p>
                         );
                       })}
                     </div>

--- a/frontend/src/containers/__tests__/HomeWithSearch.test.tsx
+++ b/frontend/src/containers/__tests__/HomeWithSearch.test.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { render, fireEvent, act } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import Home from "../Home";
+import HomeWithSearch from "../HomeWithSearch";
 
 jest.mock("../../hooks");
 
-test("renders homepage title", async () => {
-  const { getByRole } = render(<Home />, {
+test("Renders homepage title", async () => {
+  const { getByRole } = render(<HomeWithSearch />, {
     wrapper: MemoryRouter,
   });
   expect(
@@ -14,15 +14,15 @@ test("renders homepage title", async () => {
   ).toBeInTheDocument();
 });
 
-test("renders homepage description", async () => {
-  const { getByText } = render(<Home />, { wrapper: MemoryRouter });
+test("Renders homepage description", async () => {
+  const { getByText } = render(<HomeWithSearch />, {
+    wrapper: MemoryRouter,
+  });
   expect(getByText("Welcome to our dashboard")).toBeInTheDocument();
 });
 
-test("renders dashboards list", async () => {
-  const { getByText } = render(<Home />, { wrapper: MemoryRouter });
+test("Renders dashboards list", async () => {
+  const { getByText } = render(<HomeWithSearch />, { wrapper: MemoryRouter });
   expect(getByText("Topic Area Bananas")).toBeInTheDocument();
   expect(getByText("Dashboard One")).toBeInTheDocument();
-  expect(getByText("Topic Area Grapes")).toBeInTheDocument();
-  expect(getByText("Dashboard Two")).toBeInTheDocument();
 });

--- a/frontend/src/hooks/__mocks__/index.tsx
+++ b/frontend/src/hooks/__mocks__/index.tsx
@@ -250,6 +250,25 @@ export function usePublicHomepage() {
   };
 }
 
+export function usePublicHomepageSearch(query: string) {
+  return {
+    loading: false,
+    homepage: {
+      title: "Kingdom of Wakanda",
+      description: "Welcome to our dashboard",
+      dashboards: [
+        {
+          id: "abc",
+          name: "Dashboard One",
+          topicAreaId: "123456789",
+          topicAreaName: "Topic Area Bananas",
+          queryMatches: ["Dashboard One"],
+        },
+      ],
+    },
+  };
+}
+
 export function useHomepage() {
   return {
     loading: false,

--- a/frontend/src/hooks/homepage-hooks.ts
+++ b/frontend/src/hooks/homepage-hooks.ts
@@ -65,8 +65,9 @@ type UsePublicHomepageSearchHook = {
   homepage: PublicHomepage;
 };
 
-export function usePublicHomepageSearch(query :string)
-    : UsePublicHomepageSearchHook {
+export function usePublicHomepageSearch(
+  query: string
+): UsePublicHomepageSearchHook {
   const [loading, setLoading] = useState<boolean>(false);
   const [homepage, setHomepage] = useState<PublicHomepage>({
     title: "",

--- a/frontend/src/hooks/homepage-hooks.ts
+++ b/frontend/src/hooks/homepage-hooks.ts
@@ -59,3 +59,33 @@ export function usePublicHomepage(): UsePublicHomepageHook {
     homepage,
   };
 }
+
+type UsePublicHomepageSearchHook = {
+  loading: boolean;
+  homepage: PublicHomepage;
+};
+
+export function usePublicHomepageSearch(query :string)
+    : UsePublicHomepageSearchHook {
+  const [loading, setLoading] = useState<boolean>(false);
+  const [homepage, setHomepage] = useState<PublicHomepage>({
+    title: "",
+    description: "",
+    dashboards: [],
+  });
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true);
+      const data = await BackendService.fetchPublicHomepageWithQuery(query);
+      setHomepage(data);
+      setLoading(false);
+    };
+    fetchData();
+  }, []);
+
+  return {
+    loading,
+    homepage,
+  };
+}

--- a/frontend/src/hooks/index.tsx
+++ b/frontend/src/hooks/index.tsx
@@ -8,7 +8,11 @@ import {
 } from "./dashboard-hooks";
 import { useWidget, useColors, useWidgetDataset } from "./widget-hooks";
 import { useTopicAreas, useTopicArea } from "./topicarea-hooks";
-import { useHomepage, usePublicHomepage, usePublicHomepageSearch } from "./homepage-hooks";
+import {
+  useHomepage,
+  usePublicHomepage,
+  usePublicHomepageSearch,
+} from "./homepage-hooks";
 import { useSettings, usePublicSettings } from "./settings-hooks";
 import { useJsonDataset, useSampleDataset } from "./dataset-hooks";
 import { useUsers, useCurrentAuthenticatedUser } from "./user-hooks";

--- a/frontend/src/hooks/index.tsx
+++ b/frontend/src/hooks/index.tsx
@@ -8,7 +8,7 @@ import {
 } from "./dashboard-hooks";
 import { useWidget, useColors, useWidgetDataset } from "./widget-hooks";
 import { useTopicAreas, useTopicArea } from "./topicarea-hooks";
-import { useHomepage, usePublicHomepage } from "./homepage-hooks";
+import { useHomepage, usePublicHomepage, usePublicHomepageSearch } from "./homepage-hooks";
 import { useSettings, usePublicSettings } from "./settings-hooks";
 import { useJsonDataset, useSampleDataset } from "./dataset-hooks";
 import { useUsers, useCurrentAuthenticatedUser } from "./user-hooks";
@@ -49,6 +49,7 @@ export {
   useTopicArea,
   usePublicHomepage,
   useHomepage,
+  usePublicHomepageSearch,
   useSettings,
   usePublicSettings,
   useJsonDataset,

--- a/frontend/src/models/index.tsx
+++ b/frontend/src/models/index.tsx
@@ -50,6 +50,7 @@ export type Dashboard = {
   publishedBy?: string;
   archivedBy?: string;
   friendlyURL?: string;
+  queryMatches?: Array<string>;
 };
 
 export type PublicDashboard = {
@@ -63,6 +64,7 @@ export type PublicDashboard = {
   widgets: Array<Widget>;
   updatedAt: Date;
   friendlyURL?: string;
+  queryMatches?: Array<string>;
 };
 
 export type DashboardVersion = {

--- a/frontend/src/services/BackendService.ts
+++ b/frontend/src/services/BackendService.ts
@@ -5,6 +5,7 @@ import {
   DashboardVersion,
   Dataset,
   PublicDashboard,
+  PublicHomepage,
   Widget,
   User,
   DatasetSchema,
@@ -62,6 +63,11 @@ async function fetchPublicDashboardByURL(
     `public/dashboard/friendly-url/${friendlyURL}`,
     {}
   );
+}
+
+async function fetchPublicHomepageWithQuery(query: string)
+    : Promise<PublicHomepage> {
+  return await API.get(apiName, `public/search/${query}`, {});
 }
 
 async function fetchTopicAreas() {
@@ -456,6 +462,7 @@ async function changeRole(role: string, usernames: Array<string>) {
 const BackendService = {
   fetchDashboards,
   fetchDashboardById,
+  fetchPublicHomepageWithQuery,
   fetchTopicAreas,
   fetchTopicAreaById,
   fetchWidgetById,

--- a/frontend/src/services/BackendService.ts
+++ b/frontend/src/services/BackendService.ts
@@ -65,8 +65,9 @@ async function fetchPublicDashboardByURL(
   );
 }
 
-async function fetchPublicHomepageWithQuery(query: string)
-    : Promise<PublicHomepage> {
+async function fetchPublicHomepageWithQuery(
+  query: string
+): Promise<PublicHomepage> {
   return await API.get(apiName, `public/search/${query}`, {});
 }
 

--- a/frontend/src/services/__tests__/BackendService.test.ts
+++ b/frontend/src/services/__tests__/BackendService.test.ts
@@ -29,6 +29,16 @@ test("fetchDashboardById makes a GET request to dashboard API", async () => {
   );
 });
 
+test("fetchPublicHomepageWithQuery makes a GET request to homepage API", async () => {
+  const query = "Hello";
+  await BackendService.fetchPublicHomepageWithQuery(query);
+  expect(API.get).toHaveBeenCalledWith(
+    "BackendApi",
+    `public/search/${query}`,
+    expect.anything()
+  );
+});
+
 test("createDashboard should make a POST request with payload", async () => {
   const name = "One Pretty Dashboard";
   const description = "Alexa, how is the weather?";


### PR DESCRIPTION
## Description

GTT-1557: Adds frontend support for searching inside of published dashboards. Given a query, searches text fields inside published dashboards, and displays those dashboards with content matching the query. Text snippets are also displayed.

## Testing

- Added unit tests and tested with it.
- Tested by running locally.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
