### PR TITLE
Adds backend support for copying dashboards

### DIFF
--- a/backend/postman/Performance Dashboard API.postman_collection.json
+++ b/backend/postman/Performance Dashboard API.postman_collection.json
@@ -298,6 +298,50 @@
           "response": []
         },
         {
+          "name": "Copy Dashboard",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"updatedAt\": \"2020-10-16T00:25:24.576Z\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/dashboard/:id/copy",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "dashboard",
+                ":id",
+                "copy"
+              ],
+              "variable": [
+                {
+                  "key": "id",
+                  "value": "49b1e4c5-c621-459b-96c4-66504a6b21eb"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
           "name": "Archive Dashboard",
           "request": {
             "auth": {

--- a/backend/src/lib/api/dashboard-api.ts
+++ b/backend/src/lib/api/dashboard-api.ts
@@ -70,6 +70,12 @@ router.put(
   errorHandler(DashboardCtrl.moveToDraftDashboard)
 );
 
+router.post(
+  "/:id/copy",
+  rbac(Role.Admin, Role.Editor),
+  errorHandler(DashboardCtrl.copyDashboard)
+);
+
 router.put(
   "/:id/widgetorder",
   rbac(Role.Admin, Role.Editor),

--- a/backend/src/lib/controllers/__tests__/dashboard-ctrl.test.ts
+++ b/backend/src/lib/controllers/__tests__/dashboard-ctrl.test.ts
@@ -870,17 +870,20 @@ describe("copyDashboard", () => {
       createdBy: "johndoe",
       state: DashboardState.Published,
       description: "",
-      widgets: [{
-        id: "12345678",
-        name: "Text Widget",
-        widgetType: WidgetType.Text,
-        dashboardId: "abcdef00",
-        order: 0,
-        updatedAt: new Date(),
-        showTitle: true,
-        content: {
-          text: "Just some simple text."
-        }}],
+      widgets: [
+        {
+          id: "12345678",
+          name: "Text Widget",
+          widgetType: WidgetType.Text,
+          dashboardId: "abcdef00",
+          order: 0,
+          updatedAt: new Date(),
+          showTitle: true,
+          content: {
+            text: "Just some simple text.",
+          },
+        },
+      ],
       releaseNotes: "Release note test",
     };
   });

--- a/backend/src/lib/controllers/__tests__/dashboard-ctrl.test.ts
+++ b/backend/src/lib/controllers/__tests__/dashboard-ctrl.test.ts
@@ -13,6 +13,7 @@ import FriendlyURLService from "../../services/friendlyurl-service";
 import DashboardRepository from "../../repositories/dashboard-repo";
 import TopicAreaRepository from "../../repositories/topicarea-repo";
 import dashboardCtrl from "../dashboard-ctrl";
+import { WidgetType } from "../../models/widget";
 
 jest.mock("../../repositories/dashboard-repo");
 jest.mock("../../repositories/topicarea-repo");
@@ -869,8 +870,18 @@ describe("copyDashboard", () => {
       createdBy: "johndoe",
       state: DashboardState.Published,
       description: "",
-      widgets: [],
-      releaseNotes: "release note test",
+      widgets: [{
+        id: "12345678",
+        name: "Text Widget",
+        widgetType: WidgetType.Text,
+        dashboardId: "abcdef00",
+        order: 0,
+        updatedAt: new Date(),
+        showTitle: true,
+        content: {
+          text: "Just some simple text."
+        }}],
+      releaseNotes: "Release note test",
     };
   });
 

--- a/backend/src/lib/controllers/__tests__/dashboard-ctrl.test.ts
+++ b/backend/src/lib/controllers/__tests__/dashboard-ctrl.test.ts
@@ -845,3 +845,40 @@ describe("getPublicDashboardByFriendlyURL", () => {
     expect(res.send).toBeCalledWith("Dashboard not found");
   });
 });
+
+describe("copyDashboard", () => {
+  let req: Request;
+  let dashboard: Dashboard;
+  beforeEach(() => {
+    req = {
+      user,
+      params: {
+        id: "abcdef00",
+      },
+    } as any as Request;
+
+    dashboard = {
+      id: "abcdef00",
+      version: 3,
+      parentDashboardId: "abcdef00",
+      name: "My Dashboard",
+      topicAreaId: "abc",
+      topicAreaName: "My Topic Area",
+      displayTableOfContents: false,
+      updatedAt: new Date(),
+      createdBy: "johndoe",
+      state: DashboardState.Published,
+      description: "",
+      widgets: [],
+      releaseNotes: "release note test",
+    };
+  });
+
+  it("creates a copy dashboard in draft state", async () => {
+    repository.getDashboardWithWidgets = jest.fn().mockReturnValue(dashboard);
+
+    await DashboardCtrl.copyDashboard(req, res);
+
+    expect(repository.saveDashboardAndWidgets).toBeCalledTimes(2);
+  });
+});

--- a/backend/src/lib/controllers/dashboard-ctrl.ts
+++ b/backend/src/lib/controllers/dashboard-ctrl.ts
@@ -352,6 +352,23 @@ async function createNewDraft(req: Request, res: Response) {
   return res.json(draft);
 }
 
+async function copyDashboard(req: Request, res: Response) {
+  const user = req.user;
+  const { id } = req.params;
+
+  const repo = DashboardRepository.getInstance();
+
+  const origDashboard = await repo.getDashboardWithWidgets(id);
+
+  const newDashboard = DashboardFactory.createCopyFromDashboard(
+    origDashboard,
+    user
+  );
+
+  await repo.saveDashboardAndWidgets(newDashboard);
+  res.json(newDashboard);
+}
+
 export default {
   listDashboards,
   createDashboard,
@@ -367,4 +384,5 @@ export default {
   deleteDashboards,
   getPublicDashboardById,
   createNewDraft,
+  copyDashboard,
 };

--- a/backend/src/lib/factories/__tests__/dashboard-factory.test.ts
+++ b/backend/src/lib/factories/__tests__/dashboard-factory.test.ts
@@ -5,6 +5,7 @@ import {
   DashboardState,
 } from "../../models/dashboard";
 import { User } from "../../models/user";
+import { convertCompilerOptionsFromJson } from "typescript";
 
 const user: User = {
   userId: "johndoe",
@@ -302,5 +303,36 @@ describe("createDraftFromDashboard", () => {
       nextVersion
     );
     expect(draft.friendlyURL).toBeUndefined();
+  });
+});
+
+describe("createCopyFromDashboard", () => {
+  const dashboard: Dashboard = {
+    id: "123",
+    version: 3,
+    parentDashboardId: "123",
+    name: "Original Dashboard",
+    topicAreaId: "456",
+    topicAreaName: "Topic 1",
+    displayTableOfContents: false,
+    description: "Description original dashboard",
+    createdBy: user.userId,
+    updatedAt: new Date(),
+    state: DashboardState.Published,
+    releaseNotes: "release note test",
+  };
+
+  it("Should create a copy of the original dashboard", () => {
+    const copy = factory.createCopyFromDashboard(dashboard, user);
+
+    expect(copy.id).not.toEqual(dashboard.id);
+    expect(copy.name).toEqual("Copy of Original Dashboard");
+    expect(copy.version).toEqual(1);
+    expect(copy.topicAreaId).toEqual(dashboard.topicAreaId);
+    expect(copy.topicAreaName).toEqual(dashboard.topicAreaName);
+    expect(copy.createdBy).toEqual(dashboard.createdBy);
+    expect(copy.state).toEqual(DashboardState.Draft);
+    expect(copy.parentDashboardId).not.toEqual(dashboard.parentDashboardId);
+    expect(copy.friendlyURL).toBeUndefined();
   });
 });

--- a/backend/src/lib/factories/dashboard-factory.ts
+++ b/backend/src/lib/factories/dashboard-factory.ts
@@ -86,6 +86,55 @@ function createDraftFromDashboard(
   };
 }
 
+function createCopyFromDashboard(dashboard: Dashboard, user: User): Dashboard {
+  const id = uuidv4();
+
+  // Copy all widgets associated with the dashboard.
+  let widgets: Array<Widget> = [];
+  if (dashboard.widgets) {
+    widgets = dashboard.widgets.map((widget) =>
+      WidgetFactory.createFromWidget(id, widget)
+    );
+    for (const widget of widgets) {
+      if (widget.section) {
+        const sectionIndex = dashboard.widgets.findIndex(
+          (w) => w.id === widget.section
+        );
+        widget.section = widgets[sectionIndex].id;
+      }
+      if (widget.content && widget.content.widgetIds) {
+        const widgetIds: string[] = [];
+        for (const id of widget.content.widgetIds) {
+          const widgetIndex = dashboard.widgets.findIndex((w) => w.id === id);
+          widgetIds.push(widgets[widgetIndex].id);
+        }
+        widget.content.widgetIds = widgetIds;
+      }
+    }
+  }
+
+  return {
+    id,
+    name: "Copy of " + dashboard.name,
+    version: 1,
+    parentDashboardId: id,
+    topicAreaId: dashboard.topicAreaId,
+    topicAreaName: dashboard.topicAreaName,
+    displayTableOfContents: dashboard.displayTableOfContents,
+    tableOfContents: dashboard.tableOfContents,
+    description: dashboard.description,
+    state: DashboardState.Draft,
+    createdBy: user.userId,
+    updatedAt: new Date(),
+    updatedBy: user.userId,
+    submittedBy: undefined,
+    publishedBy: undefined,
+    archivedBy: undefined,
+    widgets,
+    friendlyURL: undefined,
+  };
+}
+
 /**
  * Converts a Dashboard to a DynamoDB item.
  */
@@ -177,6 +226,7 @@ function toVersion(dashboard: Dashboard): DashboardVersion {
 export default {
   createNew,
   createDraftFromDashboard,
+  createCopyFromDashboard,
   toItem,
   fromItem,
   itemId,


### PR DESCRIPTION
## Description

GTT-1449: Adds backend support for copying dashboards. A new draft dashboard is created from the original one.

## Testing

Added unit tests.
Tested with Postman.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
