### PR TITLE
Adds text alternative to label images

### DIFF
--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -434,6 +434,7 @@ function Table(props: Props) {
                           <FontAwesomeIcon
                             icon={faAngleDoubleLeft}
                             className="margin-top-2px"
+                            aria-label={t("GoToFirstPage")}
                           />
                         </button>
                         <button
@@ -449,6 +450,7 @@ function Table(props: Props) {
                           <FontAwesomeIcon
                             icon={faAngleLeft}
                             className="margin-top-2px"
+                            aria-label={t("GoToPrevPage")}
                           />
                         </button>
                       </>
@@ -469,6 +471,7 @@ function Table(props: Props) {
                           <FontAwesomeIcon
                             icon={faAngleDoubleLeft}
                             className="margin-top-2px"
+                            aria-label={t("GoToFirstPage")}
                           />
                         </button>
                         <button
@@ -484,6 +487,7 @@ function Table(props: Props) {
                           <FontAwesomeIcon
                             icon={faAngleLeft}
                             className="margin-top-2px"
+                            aria-label={t("GoToPrevPage")}
                           />
                         </button>
                       </>
@@ -501,6 +505,7 @@ function Table(props: Props) {
                       <FontAwesomeIcon
                         icon={faAngleRight}
                         className="margin-top-2px"
+                        aria-label={t("GoToNextPage")}
                       />
                     </button>
                     <button
@@ -515,6 +520,7 @@ function Table(props: Props) {
                       <FontAwesomeIcon
                         icon={faAngleDoubleRight}
                         className="margin-top-2px"
+                        aria-label={t("GoToLastPage")}
                       />
                     </button>
                   </div>

--- a/frontend/src/components/__tests__/__snapshots__/CheckData.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/CheckData.test.tsx.snap
@@ -374,6 +374,7 @@ exports[`renders the CheckData component 1`] = `
                       >
                         <svg
                           aria-hidden="true"
+                          aria-label="Go to the first page"
                           class="svg-inline--fa fa-angle-double-left fa-w-14 margin-top-2px"
                           data-icon="angle-double-left"
                           data-prefix="fas"
@@ -396,6 +397,7 @@ exports[`renders the CheckData component 1`] = `
                       >
                         <svg
                           aria-hidden="true"
+                          aria-label="Go to the previous page"
                           class="svg-inline--fa fa-angle-left fa-w-8 margin-top-2px"
                           data-icon="angle-left"
                           data-prefix="fas"
@@ -418,6 +420,7 @@ exports[`renders the CheckData component 1`] = `
                       >
                         <svg
                           aria-hidden="true"
+                          aria-label="Go to the next page"
                           class="svg-inline--fa fa-angle-right fa-w-8 margin-top-2px"
                           data-icon="angle-right"
                           data-prefix="fas"
@@ -439,6 +442,7 @@ exports[`renders the CheckData component 1`] = `
                       >
                         <svg
                           aria-hidden="true"
+                          aria-label="Go to the last page"
                           class="svg-inline--fa fa-angle-double-right fa-w-14 margin-top-2px"
                           data-icon="angle-double-right"
                           data-prefix="fas"

--- a/frontend/src/components/__tests__/__snapshots__/ChooseData.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/ChooseData.test.tsx.snap
@@ -508,6 +508,7 @@ exports[`renders the ChooseData component 1`] = `
                       >
                         <svg
                           aria-hidden="true"
+                          aria-label="Go to the first page"
                           class="svg-inline--fa fa-angle-double-left fa-w-14 margin-top-2px"
                           data-icon="angle-double-left"
                           data-prefix="fas"
@@ -530,6 +531,7 @@ exports[`renders the ChooseData component 1`] = `
                       >
                         <svg
                           aria-hidden="true"
+                          aria-label="Go to the previous page"
                           class="svg-inline--fa fa-angle-left fa-w-8 margin-top-2px"
                           data-icon="angle-left"
                           data-prefix="fas"
@@ -553,6 +555,7 @@ exports[`renders the ChooseData component 1`] = `
                       >
                         <svg
                           aria-hidden="true"
+                          aria-label="Go to the next page"
                           class="svg-inline--fa fa-angle-right fa-w-8 margin-top-2px"
                           data-icon="angle-right"
                           data-prefix="fas"
@@ -574,6 +577,7 @@ exports[`renders the ChooseData component 1`] = `
                       >
                         <svg
                           aria-hidden="true"
+                          aria-label="Go to the last page"
                           class="svg-inline--fa fa-angle-double-right fa-w-14 margin-top-2px"
                           data-icon="angle-double-right"
                           data-prefix="fas"

--- a/frontend/src/components/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/Table.test.tsx.snap
@@ -228,6 +228,7 @@ exports[`renders a basic table 1`] = `
                 >
                   <svg
                     aria-hidden="true"
+                    aria-label="Go to the first page"
                     class="svg-inline--fa fa-angle-double-left fa-w-14 margin-top-2px"
                     data-icon="angle-double-left"
                     data-prefix="fas"
@@ -250,6 +251,7 @@ exports[`renders a basic table 1`] = `
                 >
                   <svg
                     aria-hidden="true"
+                    aria-label="Go to the previous page"
                     class="svg-inline--fa fa-angle-left fa-w-8 margin-top-2px"
                     data-icon="angle-left"
                     data-prefix="fas"
@@ -273,6 +275,7 @@ exports[`renders a basic table 1`] = `
                 >
                   <svg
                     aria-hidden="true"
+                    aria-label="Go to the next page"
                     class="svg-inline--fa fa-angle-right fa-w-8 margin-top-2px"
                     data-icon="angle-right"
                     data-prefix="fas"
@@ -294,6 +297,7 @@ exports[`renders a basic table 1`] = `
                 >
                   <svg
                     aria-hidden="true"
+                    aria-label="Go to the last page"
                     class="svg-inline--fa fa-angle-double-right fa-w-14 margin-top-2px"
                     data-icon="angle-double-right"
                     data-prefix="fas"
@@ -1002,6 +1006,7 @@ exports[`sorting buttons are clickable 1`] = `
                 >
                   <svg
                     aria-hidden="true"
+                    aria-label="Go to the first page"
                     class="svg-inline--fa fa-angle-double-left fa-w-14 margin-top-2px"
                     data-icon="angle-double-left"
                     data-prefix="fas"
@@ -1024,6 +1029,7 @@ exports[`sorting buttons are clickable 1`] = `
                 >
                   <svg
                     aria-hidden="true"
+                    aria-label="Go to the previous page"
                     class="svg-inline--fa fa-angle-left fa-w-8 margin-top-2px"
                     data-icon="angle-left"
                     data-prefix="fas"
@@ -1047,6 +1053,7 @@ exports[`sorting buttons are clickable 1`] = `
                 >
                   <svg
                     aria-hidden="true"
+                    aria-label="Go to the next page"
                     class="svg-inline--fa fa-angle-right fa-w-8 margin-top-2px"
                     data-icon="angle-right"
                     data-prefix="fas"
@@ -1068,6 +1075,7 @@ exports[`sorting buttons are clickable 1`] = `
                 >
                   <svg
                     aria-hidden="true"
+                    aria-label="Go to the last page"
                     class="svg-inline--fa fa-angle-double-right fa-w-14 margin-top-2px"
                     data-icon="angle-double-right"
                     data-prefix="fas"
@@ -1410,6 +1418,7 @@ exports[`sorting buttons are clickable 2`] = `
                 >
                   <svg
                     aria-hidden="true"
+                    aria-label="Go to the first page"
                     class="svg-inline--fa fa-angle-double-left fa-w-14 margin-top-2px"
                     data-icon="angle-double-left"
                     data-prefix="fas"
@@ -1432,6 +1441,7 @@ exports[`sorting buttons are clickable 2`] = `
                 >
                   <svg
                     aria-hidden="true"
+                    aria-label="Go to the previous page"
                     class="svg-inline--fa fa-angle-left fa-w-8 margin-top-2px"
                     data-icon="angle-left"
                     data-prefix="fas"
@@ -1455,6 +1465,7 @@ exports[`sorting buttons are clickable 2`] = `
                 >
                   <svg
                     aria-hidden="true"
+                    aria-label="Go to the next page"
                     class="svg-inline--fa fa-angle-right fa-w-8 margin-top-2px"
                     data-icon="angle-right"
                     data-prefix="fas"
@@ -1476,6 +1487,7 @@ exports[`sorting buttons are clickable 2`] = `
                 >
                   <svg
                     aria-hidden="true"
+                    aria-label="Go to the last page"
                     class="svg-inline--fa fa-angle-double-right fa-w-14 margin-top-2px"
                     data-icon="angle-double-right"
                     data-prefix="fas"

--- a/frontend/src/components/__tests__/__snapshots__/TableWidget.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/TableWidget.test.tsx.snap
@@ -243,6 +243,7 @@ exports[`table preview should match snapshot 1`] = `
                   >
                     <svg
                       aria-hidden="true"
+                      aria-label="Go to the first page"
                       class="svg-inline--fa fa-angle-double-left fa-w-14 margin-top-2px"
                       data-icon="angle-double-left"
                       data-prefix="fas"
@@ -265,6 +266,7 @@ exports[`table preview should match snapshot 1`] = `
                   >
                     <svg
                       aria-hidden="true"
+                      aria-label="Go to the previous page"
                       class="svg-inline--fa fa-angle-left fa-w-8 margin-top-2px"
                       data-icon="angle-left"
                       data-prefix="fas"
@@ -288,6 +290,7 @@ exports[`table preview should match snapshot 1`] = `
                   >
                     <svg
                       aria-hidden="true"
+                      aria-label="Go to the next page"
                       class="svg-inline--fa fa-angle-right fa-w-8 margin-top-2px"
                       data-icon="angle-right"
                       data-prefix="fas"
@@ -309,6 +312,7 @@ exports[`table preview should match snapshot 1`] = `
                   >
                     <svg
                       aria-hidden="true"
+                      aria-label="Go to the last page"
                       class="svg-inline--fa fa-angle-double-right fa-w-14 margin-top-2px"
                       data-icon="angle-double-right"
                       data-prefix="fas"

--- a/frontend/src/components/__tests__/__snapshots__/VisualizeTable.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/VisualizeTable.test.tsx.snap
@@ -501,6 +501,7 @@ exports[`renders the VisualizeTable component 1`] = `
                         >
                           <svg
                             aria-hidden="true"
+                            aria-label="Go to the first page"
                             class="svg-inline--fa fa-angle-double-left fa-w-14 margin-top-2px"
                             data-icon="angle-double-left"
                             data-prefix="fas"
@@ -523,6 +524,7 @@ exports[`renders the VisualizeTable component 1`] = `
                         >
                           <svg
                             aria-hidden="true"
+                            aria-label="Go to the previous page"
                             class="svg-inline--fa fa-angle-left fa-w-8 margin-top-2px"
                             data-icon="angle-left"
                             data-prefix="fas"
@@ -546,6 +548,7 @@ exports[`renders the VisualizeTable component 1`] = `
                         >
                           <svg
                             aria-hidden="true"
+                            aria-label="Go to the next page"
                             class="svg-inline--fa fa-angle-right fa-w-8 margin-top-2px"
                             data-icon="angle-right"
                             data-prefix="fas"
@@ -567,6 +570,7 @@ exports[`renders the VisualizeTable component 1`] = `
                         >
                           <svg
                             aria-hidden="true"
+                            aria-label="Go to the last page"
                             class="svg-inline--fa fa-angle-double-right fa-w-14 margin-top-2px"
                             data-icon="angle-double-right"
                             data-prefix="fas"

--- a/frontend/src/layouts/Admin.tsx
+++ b/frontend/src/layouts/Admin.tsx
@@ -87,8 +87,14 @@ function AdminLayout(props: LayoutProps) {
             aria-label={t("AdminMenu.PrimaryNavigation")}
             className="usa-nav"
           >
-            <button className="usa-nav__close">
-              <FontAwesomeIcon icon={faWindowClose} size="lg" role="img" />
+            <button className="usa-nav__close" aria-label={t("CloseMenu")}>
+              <FontAwesomeIcon
+                icon={faWindowClose}
+                size="lg"
+                role="img"
+                aria-hidden="true"
+                aria-label={t("CloseMenu")}
+              />
             </button>
             <ul className="usa-nav__primary usa-accordion">
               {isAdmin || isEditor ? (

--- a/frontend/src/layouts/Public.tsx
+++ b/frontend/src/layouts/Public.tsx
@@ -58,8 +58,14 @@ function PublicLayout(props: LayoutProps) {
             </button>
           </div>
           <nav aria-label="Primary navigation" className="usa-nav">
-            <button className="usa-nav__close">
-              <FontAwesomeIcon icon={faWindowClose} size="lg" role="img" />
+            <button className="usa-nav__close" aria-label={t("CloseMenu")}>
+              <FontAwesomeIcon
+                icon={faWindowClose}
+                size="lg"
+                role="img"
+                aria-hidden="true"
+                aria-label={t("CloseMenu")}
+              />
             </button>
             <ul className="usa-nav__primary usa-accordion">
               <li className="usa-nav__primary-item">

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -954,6 +954,7 @@
   "SortDashboards": "Sort by dashboard name",
   "SortCreatedBy": "Sort by created by name",
   "SortTopicAreaName": "Sort by {{topicAreaName}} name",
+  "CloseMenu": "Close Menu",
   "ARIA": {
     "Header": "Header",
     "Main": "Main",


### PR DESCRIPTION
## Description

GTT-1639: Adds text alternative to label images for accessibility.

## Testing

- Unit tests: Updated snapshots.
- Ran locally.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
