### PR TITLE
Assign tab roles to section tabs and enable keyboard navigation

### DIFF
--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import React, { KeyboardEvent, MouseEvent, ReactNode } from "react";
 import "./Button.scss";
 
 type Variant =
@@ -11,7 +11,8 @@ type Variant =
 
 interface Props {
   children: ReactNode;
-  onClick?: Function;
+  onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
+  onKeyDown?: (event: KeyboardEvent<HTMLButtonElement>) => void;
   variant?: Variant;
   className?: string;
   testid?: string;
@@ -57,9 +58,14 @@ const Button = React.forwardRef<HTMLButtonElement, Props>((props, ref) => {
       disabled={props.disabled}
       ref={ref}
       type={props.type}
-      onClick={() => {
+      onClick={(e) => {
         if (props.onClick) {
-          props.onClick();
+          props.onClick(e);
+        }
+      }}
+      onKeyDown={(e) => {
+        if (props.onKeyDown) {
+          props.onKeyDown(e);
         }
       }}
     >

--- a/frontend/src/components/Tab.tsx
+++ b/frontend/src/components/Tab.tsx
@@ -1,5 +1,6 @@
 import React, { MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
+import Button from "./Button";
 
 interface Props {
   id: string;
@@ -38,6 +39,7 @@ function Tab(props: Props) {
 
   return (
     <li
+      role="tab"
       className={className}
       onClick={onClick}
       onKeyDown={onKeyDown}

--- a/frontend/src/components/TabVertical.tsx
+++ b/frontend/src/components/TabVertical.tsx
@@ -38,6 +38,7 @@ function TabVertical(props: Props) {
 
   return (
     <li
+      role="tab"
       className={className}
       onClick={onClick}
       onKeyDown={onKeyDown}

--- a/frontend/src/components/TabsVertical.tsx
+++ b/frontend/src/components/TabsVertical.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, KeyboardEvent } from "react";
 import TabVertical from "./TabVertical";
 
 interface Props {
@@ -10,10 +10,37 @@ interface Props {
 
 function TabsVertical(props: Props) {
   const [activeTab, setActiveTab] = useState<string>(props.defaultActive);
+  const tabsMap = new Map<number, string>();
 
   useEffect(() => {
     setActiveTab(props.defaultActive);
   }, [props.defaultActive]);
+
+  function getActiveTabIndex(): number {
+    let index = 0;
+    tabsMap.forEach((value: string, key: number) => {
+      if (value === activeTab) {
+        index = key;
+        return;
+      }
+    });
+    return index;
+  }
+
+  const onKeyDown = (e: KeyboardEvent<HTMLElement>) => {
+    console.log(e.key);
+    if (e.key === "ArrowDown") {
+      const index = getActiveTabIndex();
+      if (index < tabsMap.size - 1) {
+        setActiveTab(tabsMap.get(index + 1) || props.defaultActive);
+      }
+    } else if (e.key === "ArrowUp") {
+      const index = getActiveTabIndex();
+      if (index > 0) {
+        setActiveTab(tabsMap.get(index - 1) || props.defaultActive);
+      }
+    }
+  };
 
   const onClickTabItem = (tab: string, currentTab: HTMLElement) => {
     setActiveTab(tab);
@@ -25,15 +52,21 @@ function TabsVertical(props: Props) {
 
   return (
     <div className="tabs grid-row">
-      <ol className="grid-col-2 padding-left-0">
-        {React.Children.map(props.children, (child) => {
+      <ol
+        className="grid-col-2 padding-left-0"
+        onKeyDown={onKeyDown}
+        role="tablist"
+      >
+        {React.Children.map(props.children, (child: any, index) => {
+          tabsMap.set(index, child.props.id);
           return (
             <TabVertical
-              id={(child as any).props.id}
-              itemId={(child as any).props.id}
+              aria-controls={child.props.id}
+              id={child.props.id}
+              itemId={child.props.id}
               activeTab={activeTab}
-              key={(child as any).props.id}
-              label={(child as any).props.label}
+              key={child.props.id}
+              label={child.props.label}
               onClick={onClickTabItem}
               onEnter={onEnterTabItem}
               activeColor={props.activeColor}
@@ -42,7 +75,7 @@ function TabsVertical(props: Props) {
           );
         })}
       </ol>
-      <div className="grid-col-10 tab-content padding-left-4">
+      <div className="grid-col-10 tab-content padding-left-4" role="tabpanel">
         {React.Children.map(props.children, (child) => {
           if ((child as any).props.id !== activeTab) return undefined;
           return (child as any).props.children;

--- a/frontend/src/components/__tests__/Tab.test.tsx
+++ b/frontend/src/components/__tests__/Tab.test.tsx
@@ -43,7 +43,7 @@ test("renders the tab", async () => {
     }
   );
 
-  const listItems = getAllByRole("listitem");
+  const listItems = getAllByRole("tab");
   expect(listItems).toHaveLength(1);
 
   listItems.forEach((item, index) => {

--- a/frontend/src/components/__tests__/Tabs.test.tsx
+++ b/frontend/src/components/__tests__/Tabs.test.tsx
@@ -74,7 +74,7 @@ describe("Tabs tests", () => {
       }
     );
 
-    const listItems = getAllByRole("listitem");
+    const listItems = getAllByRole("tab");
     expect(listItems).toHaveLength(2);
 
     listItems.forEach((item, index) => {

--- a/frontend/src/components/__tests__/__snapshots__/Tab.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/Tab.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`renders the Tab component 1`] = `
   <li
     aria-label="Active undefined Tab Tab 1"
     class="display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md border-base-dark border-x-0 border-top-0 border-bottom-05"
+    role="tab"
     style="cursor: pointer; white-space: nowrap;"
     tabindex="0"
   >
@@ -18,6 +19,7 @@ exports[`renders the Tab component with default tab 2 selected 1`] = `
   <li
     aria-label="undefined Tab Tab 1"
     class="display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md"
+    role="tab"
     style="cursor: pointer; white-space: nowrap;"
     tabindex="0"
   >

--- a/frontend/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Tabs tests renders the Tabs component 1`] = `
 <div>
   <div
     class="tabs"
+    role="tablist"
   >
     <div
       class="react-horizontal-scrolling-menu--wrapper border-base-lighter border-bottom margin-top-1"
@@ -19,6 +20,7 @@ exports[`Tabs tests renders the Tabs component 1`] = `
           <li
             aria-label="Active tab1test Tab Tab 1"
             class="display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md border-base-dark border-x-0 border-top-0 border-bottom-05"
+            role="tab"
             style="cursor: pointer; white-space: nowrap;"
             tabindex="0"
           >
@@ -38,6 +40,7 @@ exports[`Tabs tests renders the Tabs component 1`] = `
           <li
             aria-label="tab1test Tab Tab 2"
             class="display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md"
+            role="tab"
             style="cursor: pointer; white-space: nowrap;"
             tabindex="0"
           >
@@ -48,6 +51,7 @@ exports[`Tabs tests renders the Tabs component 1`] = `
     </div>
     <div
       class="tab-content"
+      role="tabpanel"
     >
       Tab 1
     </div>
@@ -59,6 +63,7 @@ exports[`Tabs tests renders the Tabs component with default tab 2 selected 1`] =
 <div>
   <div
     class="tabs"
+    role="tablist"
   >
     <div
       class="react-horizontal-scrolling-menu--wrapper border-base-lighter border-bottom margin-top-1"
@@ -74,6 +79,7 @@ exports[`Tabs tests renders the Tabs component with default tab 2 selected 1`] =
           <li
             aria-label="tab2test Tab Tab 1"
             class="display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md"
+            role="tab"
             style="cursor: pointer; white-space: nowrap;"
             tabindex="0"
           >
@@ -93,6 +99,7 @@ exports[`Tabs tests renders the Tabs component with default tab 2 selected 1`] =
           <li
             aria-label="Active tab2test Tab Tab 2"
             class="display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md border-base-dark border-x-0 border-top-0 border-bottom-05"
+            role="tab"
             style="cursor: pointer; white-space: nowrap;"
             tabindex="0"
           >
@@ -103,6 +110,7 @@ exports[`Tabs tests renders the Tabs component with default tab 2 selected 1`] =
     </div>
     <div
       class="tab-content"
+      role="tabpanel"
     >
       Tab 2
     </div>


### PR DESCRIPTION
## Description

Fix ARIA role for sections tabs. Enable keyboard navigation for tabs

![image](https://user-images.githubusercontent.com/6969135/146239590-2eaa7bc0-f34d-4ede-82eb-9abc76eac592.png)

## Testing

1- Go to https://d2h803e1awe3zo.cloudfront.net/admin/dashboard/fff0d32e-cd92-46e3-9195-b86ee34d10f6
2- Use keyboard tabs to the section below
3- Use keyboard arrows to move tabs
4- Edit the dashboard to use horizontal tabs
5- Go to preview and repeat steps 1-3

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
