### PR TITLE
Makes scrollable regions focusable for accessibility

### DIFF
--- a/frontend/src/components/MetricsCardGroup.tsx
+++ b/frontend/src/components/MetricsCardGroup.tsx
@@ -1,4 +1,4 @@
-import React, from "react";
+import React from "react";
 import { Metric, NumberDataType } from "../models";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowUp, faArrowDown } from "@fortawesome/free-solid-svg-icons";

--- a/frontend/src/components/MetricsCardGroup.tsx
+++ b/frontend/src/components/MetricsCardGroup.tsx
@@ -1,4 +1,4 @@
-import React, { KeyboardEvent } from "react";
+import React, from "react";
 import { Metric, NumberDataType } from "../models";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowUp, faArrowDown } from "@fortawesome/free-solid-svg-icons";

--- a/frontend/src/components/MetricsCardGroup.tsx
+++ b/frontend/src/components/MetricsCardGroup.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { KeyboardEvent } from "react";
 import { Metric, NumberDataType } from "../models";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowUp, faArrowDown } from "@fortawesome/free-solid-svg-icons";
@@ -51,7 +51,10 @@ function MetricsCardGroup(props: Props) {
                     className={`grid-col-${12 / props.metricPerRow} padding-05`}
                     key={j}
                   >
-                    <div className="display-flex flex-column border-base-lightest border-2px height-card padding-1 overflow-x-hidden overflow-y-hidden">
+                    <div
+                      className="display-flex flex-column border-base-lightest border-2px height-card padding-1 overflow-x-auto overflow-y-auto"
+                      tabIndex={0}
+                    >
                       <div className="flex-5">
                         <p className="text-base-darker text-bold margin-0 text-no-wrap">
                           {metric.title}

--- a/frontend/src/components/__tests__/__snapshots__/MetricsWidget.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/MetricsWidget.test.tsx.snap
@@ -23,7 +23,8 @@ exports[`metrics preview should match snapshot 1`] = `
               class="grid-col-4 padding-05"
             >
               <div
-                class="display-flex flex-column border-base-lightest border-2px height-card padding-1 overflow-x-hidden overflow-y-hidden"
+                class="display-flex flex-column border-base-lightest border-2px height-card padding-1 overflow-x-auto overflow-y-auto"
+                tabindex="0"
               >
                 <div
                   class="flex-5"


### PR DESCRIPTION
## Description

GTT-1633: Makes metrics focusable (with the tab key) and scrollable (with keyboard arrows) for keyboard accessibility.

## Testing

- Unit tests: Updated snapshots.
- Ran locally.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
