### PR TITLE
Miguel.abreu/gtt 1780 more aria labels

### DIFF
--- a/frontend/src/containers/AddImage.tsx
+++ b/frontend/src/containers/AddImage.tsx
@@ -151,16 +151,19 @@ function AddImage() {
       <div className="grid-row width-desktop grid-gap">
         <div className="grid-col-6" hidden={fullPreview}>
           <PrimaryActionBar>
-            <h1 className="margin-top-0">{t("AddImageScreen.AddImage")}</h1>
+            <h1 id="addImageFormHeader" className="margin-top-0">
+              {t("AddImageScreen.AddImage")}
+            </h1>
 
-            <div className="margin-y-1 text-semibold display-inline-block font-sans-lg">
-              {t("AddImageScreen.ConfigureImage")}
-            </div>
             <form
               className="usa-form usa-form--large"
               onSubmit={handleSubmit(onSubmit)}
+              aria-labelledby="addImageFormHeader"
             >
               <fieldset className="usa-fieldset">
+                <legend className="usa-hint">
+                  {t("AddImageScreen.ConfigureImage")}
+                </legend>
                 {errors.title || errors.altText ? (
                   <Alert
                     type="error"

--- a/frontend/src/containers/AddSection.tsx
+++ b/frontend/src/containers/AddSection.tsx
@@ -128,17 +128,15 @@ function AddSection() {
           <div className="grid-row width-desktop grid-gap">
             <div className="grid-col-6" hidden={fullPreview}>
               <PrimaryActionBar>
-                <h1 className="margin-top-0">
+                <h1 id="addSectionFormHeader" className="margin-top-0">
                   {t("AddSectionScreen.AddSection")}
                 </h1>
 
-                <div className="margin-y-1 text-semibold display-inline-block font-sans-lg">
-                  {t("AddSectionScreen.Configure")}
-                </div>
                 <form
                   className="usa-form usa-form--large"
                   onChange={onFormChange}
                   onSubmit={handleSubmit(onSubmit)}
+                  aria-labelledby="addSectionFormHeader"
                 >
                   <fieldset className="usa-fieldset">
                     {errors.title ? (
@@ -150,6 +148,11 @@ function AddSection() {
                     ) : (
                       ""
                     )}
+
+                    <legend className="usa-hint">
+                      {t("AddSectionScreen.Configure")}
+                    </legend>
+
                     <TextField
                       id="title"
                       name="title"

--- a/frontend/src/containers/EditImage.tsx
+++ b/frontend/src/containers/EditImage.tsx
@@ -210,9 +210,11 @@ function EditImage() {
                     ) : (
                       ""
                     )}
-                    <legend className="usa-hint">
+
+                    <legend className="margin-y-1 text-semibold display-inline-block font-sans-lg">
                       {t("EditImageScreen.ConfigureImage")}
                     </legend>
+
                     <TextField
                       id="title"
                       name="title"

--- a/frontend/src/containers/EditImage.tsx
+++ b/frontend/src/containers/EditImage.tsx
@@ -192,12 +192,13 @@ function EditImage() {
           <div className="grid-row width-desktop grid-gap">
             <div className="grid-col-6" hidden={fullPreview}>
               <PrimaryActionBar>
-                <h1 className="margin-top-0">
+                <h1 id="editImageFormHeader" className="margin-top-0">
                   {t("EditImageScreen.EditImage")}
                 </h1>
                 <form
                   className="usa-form usa-form--large"
                   onSubmit={handleSubmit(onSubmit)}
+                  aria-labelledby="editImageFormHeader"
                 >
                   <fieldset className="usa-fieldset">
                     {errors.title || errors.altText ? (
@@ -209,6 +210,9 @@ function EditImage() {
                     ) : (
                       ""
                     )}
+                    <legend className="usa-hint">
+                      {t("EditImageScreen.ConfigureImage")}
+                    </legend>
                     <TextField
                       id="title"
                       name="title"

--- a/frontend/src/containers/EditImage.tsx
+++ b/frontend/src/containers/EditImage.tsx
@@ -211,7 +211,7 @@ function EditImage() {
                       ""
                     )}
 
-                    <legend className="margin-y-1 text-semibold display-inline-block font-sans-lg">
+                    <legend className="usa-hint">
                       {t("EditImageScreen.ConfigureImage")}
                     </legend>
 

--- a/frontend/src/containers/EditSection.tsx
+++ b/frontend/src/containers/EditSection.tsx
@@ -138,13 +138,14 @@ function EditSection() {
           <div className="grid-row width-desktop grid-gap">
             <div className="grid-col-6" hidden={fullPreview}>
               <PrimaryActionBar>
-                <h1 className="margin-top-0">
+                <h1 id="editSectionFormHeader" className="margin-top-0">
                   {t("EditSectionScreen.EditSection")}
                 </h1>
                 <form
                   className="usa-form usa-form--large"
                   onChange={onFormChange}
                   onSubmit={handleSubmit(onSubmit)}
+                  aria-labelledby="editSectionFormHeader"
                 >
                   <fieldset className="usa-fieldset">
                     {errors.title ? (
@@ -156,6 +157,11 @@ function EditSection() {
                     ) : (
                       ""
                     )}
+
+                    <legend className="usa-hint">
+                      {t("EditTextScreen.Configure")}
+                    </legend>
+
                     <TextField
                       id="title"
                       name="title"

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -893,6 +893,7 @@
   },
   "EditImageScreen": {
     "ImageEditedSuccessfully": "Image '{{title}}' has been successfully edited.",
+    "ConfigureImage": "Configure image",
     "EditImage": "Edit Image",
     "ResolveError": "Resolve error(s) to edit the image",
     "Title": "Image title",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -251,6 +251,7 @@
     "SectionSummaryHint": "Give your section a summary to explain it in more depth. It can also be read by screen readers to describe the section for those with visual impairments. This field supports markdown."
   },
   "EditTextScreen": {
+    "Configure": "Configure section content",
     "EditText": "Edit text",
     "EditTextError": "Resolve error(s) to edit the text",
     "EditTextSuccess": "'{{title}}' text has been successfully edited.",


### PR DESCRIPTION
## Description

Fix ARIA labels for Add/Edit Image/Section forms

![Screen Shot 2021-12-30 at 12 51 02 PM](https://user-images.githubusercontent.com/6969135/147776377-1f16c277-52fd-4eb8-90cf-f12a419ad8a8.png)

## Testing

Describe how you tested your changes and/or give instructions to the reviewers on how they can verify them.

1- Go to https://d2h803e1awe3zo.cloudfront.net/admin/dashboard/edit/95b776fd-bf45-4c06-9e3a-1842a9c214de
2- Validate aria labels for the forms

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
