### PR TITLE
GTT-1608: Added horizontal annotation for throttle threshold in the Lambda related widgets

### DIFF
--- a/cdk/lib/ops-stack.ts
+++ b/cdk/lib/ops-stack.ts
@@ -3,7 +3,7 @@ import * as sns from "@aws-cdk/aws-sns";
 import * as lambda from "@aws-cdk/aws-lambda";
 import * as apigateway from "@aws-cdk/aws-apigateway";
 import * as dynamodb from "@aws-cdk/aws-dynamodb";
-import * as cloudwatch from '@aws-cdk/aws-cloudwatch';
+import * as cloudwatch from "@aws-cdk/aws-cloudwatch";
 import { SnsAction } from "@aws-cdk/aws-cloudwatch-actions";
 import * as kms from "@aws-cdk/aws-kms";
 import {


### PR DESCRIPTION
## Description

Added a horizontal line to show the threshold for Lambda throttles for the public and private Lambda functions, and for the DynamoDB stream handler Lambda function

## Testing

* Verified that horizontal threshold line shows up on CloudWatch dashboards

<img width="443" alt="Screen Shot 2022-01-14 at 12 32 35 PM" src="https://user-images.githubusercontent.com/40174644/149560211-4b2e688a-1b02-4d00-a4bd-3be06e3230fc.png">

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.