### PR TITLE
Removes the aria-hidden attribute from the file selection field

### DIFF
--- a/frontend/src/components/FileInput.tsx
+++ b/frontend/src/components/FileInput.tsx
@@ -46,7 +46,7 @@ function FileInput(props: Props) {
           {t("SelectedFile")}{" "}
           <span className="usa-file-input__choose">{t("ChangeFile")}</span>
         </div>
-        <div className="usa-file-input__preview" aria-hidden="true">
+        <div className="usa-file-input__preview">
           <div className="usa-file-input__preview-image">
             <div className="fileIcon" id="fileIconDiv">
               <FontAwesomeIcon icon={faFile} size="lg" />


### PR DESCRIPTION
## Description

To support accessibility, removes the aria-hidden attribute from the file selection field so that it can be accessed by assistive technology.

## Testing

* Unit tests.
* Local run using a screen reader.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
