### PR TITLE
Miguel.abreu/gtt 1729 disabled button

### DIFF
--- a/frontend/src/components/FileInput.tsx
+++ b/frontend/src/components/FileInput.tsx
@@ -16,7 +16,7 @@ interface Props {
   staticFileName?: string | undefined;
   hint?: string | React.ReactNode;
   accept?: string;
-  errors?: Array<object>;
+  errors?: object[];
   loading?: boolean;
   onFileProcessed?: Function;
 }
@@ -65,7 +65,7 @@ function FileInput(props: Props) {
   return (
     <div
       className={`usa-form-group${
-        props.errors && props.errors.length ? " usa-form-group--error" : ""
+        props.errors && props.errors.length > 0 ? " usa-form-group--error" : ""
       }`}
     >
       <label className="usa-label text-bold" htmlFor={props.id}>
@@ -73,15 +73,17 @@ function FileInput(props: Props) {
         {props.label && props.required && <span>&#42;</span>}
       </label>
       <div className="usa-hint">{props.hint}</div>
-      {props.errors && props.errors.length && (
-        <span
-          className="usa-error-message"
-          id="file-input-error-alert"
-          role="alert"
-        >
-          {t("InvalidFileFormat")}
-        </span>
-      )}
+      {props.errors &&
+        props.errors.length > 0 &&
+        props.errors.map((error) => (
+          <span
+            className="usa-error-message"
+            id="file-input-error-alert"
+            role="alert"
+          >
+            {error}
+          </span>
+        ))}
       <div
         className={`usa-file-input${
           props.disabled ? " usa-file-input--disabled" : ""
@@ -89,7 +91,7 @@ function FileInput(props: Props) {
       >
         <div
           className={`${
-            props.errors && props.errors.length
+            props.errors && props.errors.length > 0
               ? "usa-form-group--error margin-left-1px "
               : ""
           }usa-file-input__target`}
@@ -103,7 +105,7 @@ function FileInput(props: Props) {
             name={props.name}
             accept={props.accept}
             disabled={props.disabled}
-            ref={props.register && props.register()}
+            ref={props.register && props.register({ required: props.required })}
             onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
               if (props.onFileProcessed) {
                 props.onFileProcessed(

--- a/frontend/src/components/FileInput.tsx
+++ b/frontend/src/components/FileInput.tsx
@@ -16,7 +16,7 @@ interface Props {
   staticFileName?: string | undefined;
   hint?: string | React.ReactNode;
   accept?: string;
-  errors?: object[];
+  errors?: any;
   loading?: boolean;
   onFileProcessed?: Function;
 }
@@ -73,17 +73,15 @@ function FileInput(props: Props) {
         {props.label && props.required && <span>&#42;</span>}
       </label>
       <div className="usa-hint">{props.hint}</div>
-      {props.errors &&
-        props.errors.length > 0 &&
-        props.errors.map((error) => (
-          <span
-            className="usa-error-message"
-            id="file-input-error-alert"
-            role="alert"
-          >
-            {error}
-          </span>
-        ))}
+      {props.errors && (
+        <span
+          className="usa-error-message"
+          id="file-input-error-alert"
+          role="alert"
+        >
+          {props.errors}
+        </span>
+      )}
       <div
         className={`usa-file-input${
           props.disabled ? " usa-file-input--disabled" : ""

--- a/frontend/src/components/__tests__/__snapshots__/ChooseData.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/ChooseData.test.tsx.snap
@@ -172,6 +172,11 @@ exports[`renders the ChooseData component 1`] = `
                 </a>
               </span>
             </div>
+            <span
+              class="usa-error-message"
+              id="file-input-error-alert"
+              role="alert"
+            />
             <div
               class="usa-file-input"
             >

--- a/frontend/src/components/__tests__/__snapshots__/ChooseData.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/ChooseData.test.tsx.snap
@@ -172,7 +172,6 @@ exports[`renders the ChooseData component 1`] = `
                 </a>
               </span>
             </div>
-            0
             <div
               class="usa-file-input"
             >

--- a/frontend/src/containers/AddContent.tsx
+++ b/frontend/src/containers/AddContent.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useHistory, useParams } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -7,6 +7,7 @@ import Breadcrumbs from "../components/Breadcrumbs";
 import Button from "../components/Button";
 import PrimaryActionBar from "../components/PrimaryActionBar";
 import RadioButtonsTile from "../components/RadioButtonsTile";
+import Alert from "../components/Alert";
 
 interface FormValues {
   widgetType: string;
@@ -22,8 +23,15 @@ function AddContent() {
   const { dashboardId } = useParams<PathParams>();
   const { dashboard, loading } = useDashboard(dashboardId);
   const { register, handleSubmit, watch } = useForm<FormValues>();
+  const [error, setError] = useState("");
 
   const widgetType = watch("widgetType");
+
+  useEffect(() => {
+    if (error && widgetType) {
+      setError("");
+    }
+  }, [widgetType, error]);
 
   const onSubmit = async (values: FormValues) => {
     if (values.widgetType === "chart") {
@@ -38,6 +46,8 @@ function AddContent() {
       history.push(`/admin/dashboard/${dashboardId}/add-metrics`);
     } else if (values.widgetType === "section") {
       history.push(`/admin/dashboard/${dashboardId}/add-section`);
+    } else {
+      setError(t("AddContentScreen.InvalidWidgetType"));
     }
   };
 
@@ -83,6 +93,9 @@ function AddContent() {
               <legend className="margin-y-1 text-semibold display-inline-block font-sans-lg">
                 {t("AddContentScreen.Instructions")}
               </legend>
+
+              {error && <Alert type="error" message={error} slim></Alert>}
+
               <RadioButtonsTile
                 isHorizontally={false}
                 register={register}
@@ -142,7 +155,6 @@ function AddContent() {
             <hr />
             <Button
               variant="base"
-              disabled={!widgetType}
               type="submit"
               disabledToolTip={
                 !widgetType ? t("AddContentScreen.DisabledToolTip") : ""

--- a/frontend/src/containers/AddImage.tsx
+++ b/frontend/src/containers/AddImage.tsx
@@ -192,9 +192,8 @@ function AddImage() {
                       imageFile && imageFile.length > 0 ? imageFile[0].name : ""
                     }
                     errors={
-                      errors.imageFile
-                        ? [t("AddImageScreen.ImageFileNotSpecified")]
-                        : []
+                      errors.imageFile &&
+                      t("AddImageScreen.ImageFileNotSpecified")
                     }
                   />
                 </div>

--- a/frontend/src/containers/AddImage.tsx
+++ b/frontend/src/containers/AddImage.tsx
@@ -188,6 +188,9 @@ function AddImage() {
                     register={register}
                     required
                     hint={<span>{t("AddImageScreen.FileHint")}</span>}
+                    fileName={
+                      imageFile && imageFile.length > 0 ? imageFile[0].name : ""
+                    }
                     errors={
                       errors.imageFile
                         ? [t("AddImageScreen.ImageFileNotSpecified")]

--- a/frontend/src/containers/AddMetrics.tsx
+++ b/frontend/src/containers/AddMetrics.tsx
@@ -89,6 +89,21 @@ function AddMetrics() {
   const [datasetType, setDatasetType] = useState<DatasetType | undefined>(
     state && state.datasetType ? state.datasetType : undefined
   );
+  const [datasetError, setDatasetError] = useState("");
+
+  function hasDatasetErrors() {
+    return (
+      !datasetType ||
+      (datasetType === DatasetType.DynamicDataset && !metrics.length)
+    );
+  }
+
+  useEffect(() => {
+    if (datasetError && !hasDatasetErrors()) {
+      setDatasetError("");
+    }
+  }, [datasetError, datasetType, metrics]);
+
   const { fullPreview, fullPreviewButton } = useFullPreview();
   const [oldStep, setOldStep] = useState<number>(-1);
   const title = watch("title");
@@ -96,17 +111,6 @@ function AddMetrics() {
   const oneMetricPerRow = watch("oneMetricPerRow");
   const significantDigitLabels = watch("significantDigitLabels");
   const metricsCenterAlign = watch("metricsCenterAlign");
-
-  useEffect(() => {
-    if (datasetType) {
-      reset({
-        title,
-        showTitle,
-        oneMetricPerRow,
-        datasetType,
-      });
-    }
-  }, []);
 
   const rows = useMemo(() => dynamicMetricDatasets, [dynamicMetricDatasets]);
   const columns = useMemo(
@@ -300,6 +304,10 @@ function AddMetrics() {
   );
 
   const advanceStep = () => {
+    if (hasDatasetErrors()) {
+      setDatasetError(t("AddMetricsScreen.InvalidDatasetType"));
+      return;
+    }
     setStep(1);
     document.getElementById("Home")?.focus();
   };
@@ -395,6 +403,10 @@ function AddMetrics() {
                     </p>
                   </legend>
 
+                  {datasetError && (
+                    <Alert type="error" message={datasetError} slim></Alert>
+                  )}
+
                   <div className="grid-row">
                     <RadioButtonsTile
                       isHorizontally={true}
@@ -484,11 +496,6 @@ function AddMetrics() {
                 <Button
                   type="button"
                   onClick={advanceStep}
-                  disabled={
-                    !datasetType ||
-                    (datasetType === DatasetType.DynamicDataset &&
-                      !metrics.length)
-                  }
                   disabledToolTip={
                     datasetType === DatasetType.DynamicDataset
                       ? t("AddMetricsScreen.SelectDataset")

--- a/frontend/src/containers/__tests__/AddChart.test.tsx
+++ b/frontend/src/containers/__tests__/AddChart.test.tsx
@@ -85,11 +85,15 @@ test("on submit, it calls createWidget api and uploads dataset", async () => {
     fireEvent.click(radioButton);
   });
 
-  fireEvent.change(getByLabelText("Static datasets*"), {
-    target: {
-      files: ["dataset.csv"],
-    },
+  const file = new File(["dummy content"], "test.csv", {
+    type: "text/csv",
   });
+  const uploadFile = getByLabelText("Static datasets*");
+  Object.defineProperty(uploadFile, "files", { value: [file] });
+  Object.defineProperty(uploadFile, "value", {
+    value: file.name,
+  });
+  fireEvent.change(uploadFile);
 
   await act(async () => {
     fireEvent.click(continueButton);

--- a/frontend/src/containers/__tests__/AddImage.test.tsx
+++ b/frontend/src/containers/__tests__/AddImage.test.tsx
@@ -68,11 +68,15 @@ test("on submit, it calls createWidget api and uploads dataset", async () => {
     },
   });
 
-  fireEvent.change(getByLabelText("File upload*"), {
-    target: {
-      files: ["image.jpg"],
-    },
+  const file = new File(["dummy content"], "filename.png", {
+    type: "image/png",
   });
+  const uploadFile = getByLabelText("File upload*");
+  Object.defineProperty(uploadFile, "files", { value: [file] });
+  Object.defineProperty(uploadFile, "value", {
+    value: file.name,
+  });
+  fireEvent.change(uploadFile);
 
   fireEvent.change(getByLabelText("75%"), {
     target: {

--- a/frontend/src/containers/__tests__/AddTable.test.tsx
+++ b/frontend/src/containers/__tests__/AddTable.test.tsx
@@ -73,11 +73,15 @@ test("on submit, it calls createWidget api and uploads dataset", async () => {
     fireEvent.click(radioButton);
   });
 
-  fireEvent.change(getByLabelText("Static datasets*"), {
-    target: {
-      files: ["dataset.csv"],
-    },
+  const file = new File(["dummy content"], "test.csv", {
+    type: "text/csv",
   });
+  const uploadFile = getByLabelText("Static datasets*");
+  Object.defineProperty(uploadFile, "files", { value: [file] });
+  Object.defineProperty(uploadFile, "value", {
+    value: file.name,
+  });
+  fireEvent.change(uploadFile);
 
   await act(async () => {
     fireEvent.click(continueButton);

--- a/frontend/src/containers/__tests__/EditFavicon.test.tsx
+++ b/frontend/src/containers/__tests__/EditFavicon.test.tsx
@@ -46,11 +46,15 @@ test("on submit, it calls updateSetting and upload favicon", async () => {
 
   const submitButton = getByRole("button", { name: "Save" });
 
-  fireEvent.change(getByLabelText("File upload*"), {
-    target: {
-      files: ["image.jpg"],
-    },
+  const file = new File(["dummy content"], "filename.png", {
+    type: "image/png",
   });
+  const uploadFile = getByLabelText("File upload*");
+  Object.defineProperty(uploadFile, "files", { value: [file] });
+  Object.defineProperty(uploadFile, "value", {
+    value: file.name,
+  });
+  fireEvent.change(uploadFile);
 
   await act(async () => {
     fireEvent.click(submitButton);

--- a/frontend/src/containers/__tests__/EditImage.test.tsx
+++ b/frontend/src/containers/__tests__/EditImage.test.tsx
@@ -83,11 +83,15 @@ test("on submit, it calls editWidget api and uploads dataset", async () => {
     },
   });
 
-  fireEvent.change(getByLabelText("File upload*"), {
-    target: {
-      files: ["image.jpg"],
-    },
+  const file = new File(["dummy content"], "filename.png", {
+    type: "image/png",
   });
+  const uploadFile = getByLabelText("File upload*");
+  Object.defineProperty(uploadFile, "files", { value: [file] });
+  Object.defineProperty(uploadFile, "value", {
+    value: file.name,
+  });
+  fireEvent.change(uploadFile);
 
   fireEvent.change(getByLabelText("75%"), {
     target: {

--- a/frontend/src/containers/__tests__/EditLogo.test.tsx
+++ b/frontend/src/containers/__tests__/EditLogo.test.tsx
@@ -62,11 +62,16 @@ test("on submit, it calls updateSetting and upload logo", async () => {
 
   const submitButton = getByRole("button", { name: "Save" });
 
-  fireEvent.change(getByLabelText("File upload*"), {
-    target: {
-      files: ["image.jpg"],
-    },
+  const file = new File(["dummy content"], "filename.png", {
+    type: "image/png",
   });
+  const uploadFile = getByLabelText("File upload*");
+  Object.defineProperty(uploadFile, "files", { value: [file] });
+  Object.defineProperty(uploadFile, "value", {
+    value: file.name,
+  });
+  fireEvent.change(uploadFile);
+
   fireEvent.change(getByLabelText("Logo alt text*"), {
     target: {
       value: "Alt text",

--- a/frontend/src/containers/__tests__/__snapshots__/AddContent.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/AddContent.test.tsx.snap
@@ -78,6 +78,7 @@ Object {
               >
                 Select the type of content you want to add
               </legend>
+              
               <div
                 class=""
                 role="radiogroup"
@@ -254,19 +255,12 @@ Object {
             </fieldset>
             <br />
             <hr />
-            <span
-              data-placement="top"
-              data-toggle="tooltip"
-              title="Choose a content item to continue"
+            <button
+              class="usa-button usa-button--base"
+              type="submit"
             >
-              <button
-                class="usa-button usa-button--base"
-                disabled=""
-                type="submit"
-              >
-                Continue
-              </button>
-            </span>
+              Continue
+            </button>
             <button
               class="usa-button usa-button--unstyled margin-left-1 text-base-dark hover:text-base-darker active:text-base-darkest"
               type="button"
@@ -355,6 +349,7 @@ Object {
             >
               Select the type of content you want to add
             </legend>
+            
             <div
               class=""
               role="radiogroup"
@@ -531,19 +526,12 @@ Object {
           </fieldset>
           <br />
           <hr />
-          <span
-            data-placement="top"
-            data-toggle="tooltip"
-            title="Choose a content item to continue"
+          <button
+            class="usa-button usa-button--base"
+            type="submit"
           >
-            <button
-              class="usa-button usa-button--base"
-              disabled=""
-              type="submit"
-            >
-              Continue
-            </button>
-          </span>
+            Continue
+          </button>
           <button
             class="usa-button usa-button--unstyled margin-left-1 text-base-dark hover:text-base-darker active:text-base-darkest"
             type="button"

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -603,6 +603,7 @@
   "SettingsTopicAreaNameEditSuccess": "{{name}} was successfully edited.",
   "AddContentScreen": {
     "Title": "Add content item",
+    "InvalidWidgetType": "Please select content type to continue.",
     "Instructions": "Select the type of content you want to add",
     "TextImageAlt": "Text Content Item Preview",
     "MetricsImageAlt": "Metrics Content Item Preview",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -316,6 +316,7 @@
   },
   "AddMetricsScreen": {
     "MetricsAddedSuccessfully": "Metrics '{{title}}' have been successfully added.",
+    "InvalidDatasetType": "Choose a dataset to continue",
     "Name": "Name",
     "LastUpdated": "Last updated",
     "Description": "Description",


### PR DESCRIPTION
## Description

Replace disable continue button behavior: AddContent/ AddImage / AddMetrics

## Testing

Describe how you tested your changes and/or give instructions to the reviewers on how they can verify them.

1- Go to https://d2h803e1awe3zo.cloudfront.net/admin/dashboard/2146fd37-6e1c-482f-bbcd-cb9d83e2b299/add-content
2- Verify "Continue" button is enabled
3- Click without selection a content type
4- Shows error
5- Select content type
6- Click "Continue" again
7- Page should redirect to the content adding page

Repeat similar use case with:

* https://d2h803e1awe3zo.cloudfront.net/admin/dashboard/2146fd37-6e1c-482f-bbcd-cb9d83e2b299/add-metrics
* https://d2h803e1awe3zo.cloudfront.net/admin/dashboard/2146fd37-6e1c-482f-bbcd-cb9d83e2b299/add-image

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
