### PR TITLE
Updated url-parse to version 1.5.7 per dependabot finding

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19741,9 +19741,9 @@
       }
     },
     "url-parse": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
-      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.7.tgz",
+      "integrity": "sha512-HxWkieX+STA38EDk7CE9MEryFeHCKzgagxlGvsdS7WBImq9Mk+PGwiT56w82WI3aicwJA8REp42Cxo98c8FZMA==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"


### PR DESCRIPTION
## Description

Bump url-parse from 1.5.3 to 1.5.7 in /frontend per dependabot [finding](https://github.com/awslabs/performance-dashboard-on-aws/pull/782/files)

## Testing

* unit testing
*  deployed to AWS and performed smoke tests
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
