### PR TITLE
GTT-1861: Perform html escape on the returned error message

### DIFF
--- a/backend/src/lib/controllers/__tests__/ingestapi-ctrl.test.ts
+++ b/backend/src/lib/controllers/__tests__/ingestapi-ctrl.test.ts
@@ -185,6 +185,9 @@ describe("createDataset", () => {
     await IngestApiCtrl.createDataset(req, res);
 
     expect(res.status).toBeCalledWith(400);
+    expect(res.send).toHaveBeenLastCalledWith(
+      "Unable to parse dataset: 0: instance is not of a type(s) array"
+    );
     expect(DatasetService.parse).toBeCalledWith(
       "This is not a valid JSON",
       undefined

--- a/backend/src/lib/controllers/ingestapi-ctrl.ts
+++ b/backend/src/lib/controllers/ingestapi-ctrl.ts
@@ -91,7 +91,9 @@ async function createDataset(req: Request, res: Response) {
     parsedData = DatasetService.parse(data, metadata.schema);
   } catch (err) {
     logger.warn("Unable to parse dataset %o", data);
-    return res.status(400).send(err.message);
+    return res
+      .status(400)
+      .send(`Unable to parse dataset: ${escapeHtml(err.message)}`.trim());
   }
 
   try {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19741,9 +19741,9 @@
       }
     },
     "url-parse": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.7.tgz",
-      "integrity": "sha512-HxWkieX+STA38EDk7CE9MEryFeHCKzgagxlGvsdS7WBImq9Mk+PGwiT56w82WI3aicwJA8REp42Cxo98c8FZMA==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19742,7 +19742,7 @@
     },
     "url-parse": {
       "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-10.tgz",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "requires": {
         "querystringify": "^2.1.1",


### PR DESCRIPTION
## Description

Two separate issues were fixed in this PR

gtt-1861: CodeQL reported a problem that exception text  is reinterpreted as HTML without escaping meta-characters.

https://github.com/awslabs/performance-dashboard-on-aws/security/code-scanning/11?query=ref%3Arefs%2Fheads%2Fmainline 

The problem is addressed by doing html escape on the exception text

gtt-1871: Bump url-parse to 1.5.10

https://github.com/awslabs/performance-dashboard-on-aws/pull/790 

## Testing

* Added unit test to test that escapHtml is called correctly
* Deployed to AWS and performed functional test

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
