### PR TITLE
Add aria-role alert for Alert component.

### DIFF
--- a/frontend/src/components/Alert.tsx
+++ b/frontend/src/components/Alert.tsx
@@ -19,7 +19,7 @@ function Alert(props: Props) {
   }
 
   return (
-    <div className={className}>
+    <div className={className} role="alert">
       {typeof props.message === "object" ? (
         props.message
       ) : (

--- a/frontend/src/components/VisualizeChart.tsx
+++ b/frontend/src/components/VisualizeChart.tsx
@@ -399,7 +399,7 @@ function VisualizeChart(props: Props) {
                         </Link>
                       </div>
                       <div className="grid-col-1">
-                        <div className="margin-left-3">
+                        <div className="margin-1">
                           <Button
                             variant="unstyled"
                             className="margin-0-important text-base-dark hover:text-base-darker active:text-base-darkest"

--- a/frontend/src/components/VisualizeTable.tsx
+++ b/frontend/src/components/VisualizeTable.tsx
@@ -257,7 +257,7 @@ function VisualizeTable(props: Props) {
                         </Link>
                       </div>
                       <div className="grid-col-1">
-                        <div className="margin-left-3">
+                        <div className="margin-1">
                           <Button
                             variant="unstyled"
                             className="margin-0-important text-base-dark hover:text-base-darker active:text-base-darkest"

--- a/frontend/src/components/__tests__/__snapshots__/Alert.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/Alert.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`renders a info alert 1`] = `
 <div>
   <div
     class="usa-alert usa-alert--info"
+    role="alert"
   >
     <div
       class="usa-alert__body"
@@ -22,6 +23,7 @@ exports[`renders a slim alert 1`] = `
 <div>
   <div
     class="usa-alert usa-alert--success usa-alert--slim"
+    role="alert"
   >
     <div
       class="usa-alert__body"
@@ -40,6 +42,7 @@ exports[`renders a slim alert ignoring title 1`] = `
 <div>
   <div
     class="usa-alert usa-alert--success usa-alert--slim"
+    role="alert"
   >
     <div
       class="usa-alert__body"
@@ -58,6 +61,7 @@ exports[`renders a success alert 1`] = `
 <div>
   <div
     class="usa-alert usa-alert--success"
+    role="alert"
   >
     <div
       class="usa-alert__body"
@@ -76,6 +80,7 @@ exports[`renders a warning alert 1`] = `
 <div>
   <div
     class="usa-alert usa-alert--warning"
+    role="alert"
   >
     <div
       class="usa-alert__body"
@@ -94,6 +99,7 @@ exports[`renders an alert with HTML content as message 1`] = `
 <div>
   <div
     class="usa-alert usa-alert--success usa-alert--slim usa-alert--no-icon"
+    role="alert"
   >
     <a
       href="#"
@@ -108,6 +114,7 @@ exports[`renders an alert with title 1`] = `
 <div>
   <div
     class="usa-alert usa-alert--success"
+    role="alert"
   >
     <div
       class="usa-alert__body"
@@ -131,6 +138,7 @@ exports[`renders an alert without icon 1`] = `
 <div>
   <div
     class="usa-alert usa-alert--success usa-alert--slim usa-alert--no-icon"
+    role="alert"
   >
     <div
       class="usa-alert__body"
@@ -149,6 +157,7 @@ exports[`renders an error alert 1`] = `
 <div>
   <div
     class="usa-alert usa-alert--error"
+    role="alert"
   >
     <div
       class="usa-alert__body"


### PR DESCRIPTION
## Description

Assign alert aria role to alert components

![Screen Shot 2022-03-14 at 2 33 10 PM](https://user-images.githubusercontent.com/6969135/158238449-dc791f3f-1c52-4add-8938-055575d88c87.png)

## Testing

Describe how you tested your changes and/or give instructions to the reviewers on how they can verify them.

1- Go to https://d2h803e1awe3zo.cloudfront.net/admin/dashboard/2146fd37-6e1c-482f-bbcd-cb9d83e2b299/add-chart
2- Use the following [dataset](https://github.com/awslabs/performance-dashboard-on-aws/files/8247688/7sZuKu4O.csv) for the chart
3- Click next until the visualize step
4- Verify alert is showing and have the correct aria role.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
