### PR TITLE
Add a hover state to tabs and make topic areas hidden by default

### DIFF
--- a/frontend/src/components/Accordion.tsx
+++ b/frontend/src/components/Accordion.tsx
@@ -16,6 +16,7 @@ interface ItemProps {
   id: string;
   title: string;
   children: ReactNode;
+  hidden?: boolean;
 }
 
 function Item(props: ItemProps) {
@@ -24,13 +25,17 @@ function Item(props: ItemProps) {
       <h2 className="usa-accordion__heading">
         <button
           className="usa-accordion__button"
-          aria-expanded="true"
+          aria-expanded={props.hidden ? "false" : "true"}
           aria-controls={props.id}
         >
           {props.title}
         </button>
       </h2>
-      <div id={props.id} className="usa-accordion__content usa-prose">
+      <div
+        id={props.id}
+        className="usa-accordion__content usa-prose"
+        hidden={props.hidden ? true : false}
+      >
         <ul>{props.children}</ul>
       </div>
     </>

--- a/frontend/src/components/Tab.scss
+++ b/frontend/src/components/Tab.scss
@@ -1,0 +1,15 @@
+@import "../styles/base";
+
+.tab {
+  @include u-text("base", "!important");
+  background-color: transparent !important;
+}
+.tab:hover {
+  @include u-text("base-dark", "!important");
+  background-color: transparent !important;
+}
+.tab-active {
+  @include u-text("base", "!important");
+  background-color: transparent !important;
+  border-bottom: 3px solid color("base-dark") !important;
+}

--- a/frontend/src/components/Tab.tsx
+++ b/frontend/src/components/Tab.tsx
@@ -1,5 +1,6 @@
 import React, { MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
+import "./Tab.scss";
 
 interface Props {
   id: string;
@@ -25,14 +26,14 @@ function Tab(props: Props) {
   };
 
   let className =
-    "display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md";
+    "tab display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md";
 
   let ariaLabelStr = `${props.container} ${t("Tab")} ${
     props.label.split("(")[0]
   }`;
 
   if (props.activeTab === props.id) {
-    className += " border-base-dark border-x-0 border-top-0 border-bottom-05";
+    className += " tab-active ";
     ariaLabelStr = `${t("Active")} ${ariaLabelStr}`;
   }
 

--- a/frontend/src/components/TabVertical.tsx
+++ b/frontend/src/components/TabVertical.tsx
@@ -1,5 +1,6 @@
 import React, { MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
+import "./Tab.scss";
 
 interface Props {
   id: string;
@@ -25,7 +26,7 @@ function TabVertical(props: Props) {
   };
 
   let className =
-    "display-block border-base-lighter border-y padding-x-2 padding-y-105 text-bold font-sans-md margin-bottom-neg-1px";
+    "tab display-block border-base-lighter border-y padding-x-2 padding-y-105 text-bold font-sans-md margin-bottom-neg-1px";
 
   let ariaLabelStr = `${props.container} ${t("Tab")} ${
     props.label.split("(")[0]

--- a/frontend/src/components/__tests__/__snapshots__/Tab.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/Tab.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`renders the Tab component 1`] = `
 <div>
   <div
     aria-label="Active undefined Tab Tab 1"
-    class="display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md border-base-dark border-x-0 border-top-0 border-bottom-05"
+    class="tab display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md tab-active "
     role="tab"
     style="cursor: pointer; white-space: nowrap;"
     tabindex="0"
@@ -18,7 +18,7 @@ exports[`renders the Tab component with default tab 2 selected 1`] = `
 <div>
   <div
     aria-label="undefined Tab Tab 1"
-    class="display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md"
+    class="tab display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md"
     role="tab"
     style="cursor: pointer; white-space: nowrap;"
     tabindex="0"

--- a/frontend/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`Tabs tests renders the Tabs component 1`] = `
         >
           <div
             aria-label="Active tab1test Tab Tab 1"
-            class="display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md border-base-dark border-x-0 border-top-0 border-bottom-05"
+            class="tab display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md tab-active "
             role="tab"
             style="cursor: pointer; white-space: nowrap;"
             tabindex="0"
@@ -39,7 +39,7 @@ exports[`Tabs tests renders the Tabs component 1`] = `
         >
           <div
             aria-label="tab1test Tab Tab 2"
-            class="display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md"
+            class="tab display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md"
             role="tab"
             style="cursor: pointer; white-space: nowrap;"
             tabindex="0"
@@ -78,7 +78,7 @@ exports[`Tabs tests renders the Tabs component with default tab 2 selected 1`] =
         >
           <div
             aria-label="tab2test Tab Tab 1"
-            class="display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md"
+            class="tab display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md"
             role="tab"
             style="cursor: pointer; white-space: nowrap;"
             tabindex="0"
@@ -98,7 +98,7 @@ exports[`Tabs tests renders the Tabs component with default tab 2 selected 1`] =
         >
           <div
             aria-label="Active tab2test Tab Tab 2"
-            class="display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md border-base-dark border-x-0 border-top-0 border-bottom-05"
+            class="tab display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md tab-active "
             role="tab"
             style="cursor: pointer; white-space: nowrap;"
             tabindex="0"

--- a/frontend/src/containers/Home.tsx
+++ b/frontend/src/containers/Home.tsx
@@ -68,7 +68,10 @@ function Home() {
               <Accordion.Item
                 id={topicarea.id}
                 key={topicarea.id}
-                title={topicarea.name}
+                title={
+                  topicarea.name + " (" + topicarea.dashboards?.length + ")"
+                }
+                hidden={true}
               >
                 {topicarea.dashboards?.map((dashboard) => {
                   const updatedAt = dateFormatter(dashboard.updatedAt);

--- a/frontend/src/containers/__tests__/Home.test.tsx
+++ b/frontend/src/containers/__tests__/Home.test.tsx
@@ -21,8 +21,8 @@ test("renders homepage description", async () => {
 
 test("renders dashboards list", async () => {
   const { getByText } = render(<Home />, { wrapper: MemoryRouter });
-  expect(getByText("Topic Area Bananas")).toBeInTheDocument();
+  expect(getByText("Topic Area Bananas (1)")).toBeInTheDocument();
   expect(getByText("Dashboard One")).toBeInTheDocument();
-  expect(getByText("Topic Area Grapes")).toBeInTheDocument();
+  expect(getByText("Topic Area Grapes (1)")).toBeInTheDocument();
   expect(getByText("Dashboard Two")).toBeInTheDocument();
 });


### PR DESCRIPTION
## Description

GTT-1931: Collapses the topic areas on the public dashboards view by default.
GTT-1933: Adds a hover state to the tab component.


## Testing

* Unit tests.
* Local run.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
