### PR TITLE
Add backend support for metrics/analytics collection

### DIFF
--- a/backend/postman/Performance Dashboard API.postman_collection.json
+++ b/backend/postman/Performance Dashboard API.postman_collection.json
@@ -1181,7 +1181,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"title\": \"Performance Dashboard\",\n    \"description\": \"The Performance Dashboard makes data open and accessible to provide transparency and helps drive the ongoing improvement of digital services.\",\n    \"updatedAt\": \"2020-12-03T17:22:20.464Z\"\n}",
+              "raw": "{\n    \"title\": \"Performance Dashboard\",\n    \"description\": \"The Performance Dashboard makes data open and accessible to provide transparency and helps drive the ongoing improvement of digital services.\",\n    \"metricsScript\": \"<script></script>\",\n    \"updatedAt\": \"2020-12-03T17:22:20.464Z\"\n}",
               "options": {
                 "raw": {
                   "language": "json"

--- a/backend/src/lib/controllers/__tests__/homepage-ctrl.test.ts
+++ b/backend/src/lib/controllers/__tests__/homepage-ctrl.test.ts
@@ -43,6 +43,7 @@ describe("getPublicHomepage", () => {
     HomepageFactory.getDefaultHomepage = jest.fn().mockReturnValueOnce({
       title: "Performance Dashboard",
       description: "Welcome to the performance dashboard",
+      metricsScript: "<script></script>",
     });
 
     await HomepageCtrl.getPublicHomepage(req, res);
@@ -51,6 +52,7 @@ describe("getPublicHomepage", () => {
       expect.objectContaining({
         title: "Performance Dashboard",
         description: "Welcome to the performance dashboard",
+        metricsScript: "<script></script>",
       })
     );
   });
@@ -60,6 +62,7 @@ describe("getPublicHomepage", () => {
     repository.getHomepage = jest.fn().mockReturnValueOnce({
       title: "Kingdom of Wakanda",
       description: "Welcome to the performance dashboard of our kingdom",
+      metricsScript: "<script></script>",
     });
 
     await HomepageCtrl.getPublicHomepage(req, res);
@@ -68,6 +71,7 @@ describe("getPublicHomepage", () => {
       expect.objectContaining({
         title: "Kingdom of Wakanda",
         description: "Welcome to the performance dashboard of our kingdom",
+        metricsScript: "<script></script>",
       })
     );
   });
@@ -128,6 +132,7 @@ describe("getHomepage", () => {
     HomepageFactory.getDefaultHomepage = jest.fn().mockReturnValueOnce({
       title: "Performance Dashboard",
       description: "Welcome to the performance dashboard",
+      metricsScript: "<script></script>",
     });
 
     await HomepageCtrl.getHomepage(req, res);
@@ -136,6 +141,7 @@ describe("getHomepage", () => {
       expect.objectContaining({
         title: "Performance Dashboard",
         description: "Welcome to the performance dashboard",
+        metricsScript: "<script></script>",
       })
     );
   });
@@ -145,6 +151,7 @@ describe("getHomepage", () => {
     repository.getHomepage = jest.fn().mockReturnValueOnce({
       title: "Kingdom of Wakanda",
       description: "Welcome to the performance dashboard of our kingdom",
+      metricsScript: "<script></script>",
     });
 
     await HomepageCtrl.getHomepage(req, res);
@@ -153,6 +160,7 @@ describe("getHomepage", () => {
       expect.objectContaining({
         title: "Kingdom of Wakanda",
         description: "Welcome to the performance dashboard of our kingdom",
+        metricsScript: "<script></script>",
       })
     );
   });
@@ -169,6 +177,7 @@ describe("updateHomepage", () => {
       body: {
         title: "abc",
         description: "description test",
+        metricsScript: "<script></script>",
         updatedAt: now.toISOString(),
       },
     } as any as Request;
@@ -200,6 +209,7 @@ describe("updateHomepage", () => {
     expect(repository.updateHomepage).toHaveBeenCalledWith(
       "abc",
       "description test",
+      "<script></script>",
       now.toISOString(),
       user
     );

--- a/backend/src/lib/controllers/homepage-ctrl.ts
+++ b/backend/src/lib/controllers/homepage-ctrl.ts
@@ -24,6 +24,7 @@ async function getPublicHomepage(req: Request, res: Response) {
   return res.json({
     title: homepage.title,
     description: homepage.description,
+    metricsScript: homepage.metricsScript,
     dashboards: publicDashboards,
   });
 }
@@ -42,7 +43,7 @@ async function getHomepage(req: Request, res: Response) {
 
 async function updateHomepage(req: Request, res: Response) {
   const user = req.user;
-  const { title, description, updatedAt } = req.body;
+  const { title, description, metricsScript, updatedAt } = req.body;
 
   if (!title) {
     res.status(400).send("Missing required body `title`");
@@ -60,7 +61,7 @@ async function updateHomepage(req: Request, res: Response) {
   }
 
   const repo = HomepageRepository.getInstance();
-  await repo.updateHomepage(title, description, updatedAt, user);
+  await repo.updateHomepage(title, description, metricsScript, updatedAt, user);
 
   res.send();
 }
@@ -156,6 +157,7 @@ async function getPublicHomepageWithQuery(req: Request, res: Response) {
   return res.json({
     title: homepage.title,
     description: homepage.description,
+    metricsScript: homepage.metricsScript,
     dashboards: publicDashboards,
   });
 }

--- a/backend/src/lib/factories/homepage-factory.ts
+++ b/backend/src/lib/factories/homepage-factory.ts
@@ -15,6 +15,9 @@ function fromItem(item: HomepageItem): Homepage {
   return {
     title: item.title,
     description: item.description,
+    metricsScript: item.metricsScript
+      ? item.metricsScript
+      : "<script></script>",
     updatedAt: item.updatedAt ? new Date(item.updatedAt) : new Date(),
   };
 }

--- a/backend/src/lib/models/homepage.ts
+++ b/backend/src/lib/models/homepage.ts
@@ -1,6 +1,7 @@
 export interface Homepage {
   title: string;
   description: string;
+  metricsScript?: string;
   updatedAt: Date;
 }
 
@@ -11,4 +12,5 @@ export interface HomepageItem {
   updatedAt?: string;
   title: string;
   description: string;
+  metricsScript?: string;
 }

--- a/backend/src/lib/repositories/__tests__/homepage-repo.test.ts
+++ b/backend/src/lib/repositories/__tests__/homepage-repo.test.ts
@@ -39,6 +39,7 @@ describe("getHomepage", () => {
       type: "Homepage",
       title: "Kingdom of Wakanda",
       description: "Welcome to our kingdom",
+      metricsScript: "<script></script>",
     };
 
     dynamodb.get = jest.fn().mockReturnValueOnce({ Item: item });
@@ -46,6 +47,7 @@ describe("getHomepage", () => {
 
     expect(homepage.title).toEqual("Kingdom of Wakanda");
     expect(homepage.description).toEqual("Welcome to our kingdom");
+    expect(homepage.metricsScript).toEqual("<script></script>");
   });
 });
 
@@ -55,6 +57,7 @@ describe("updateHomepage", () => {
     await repo.updateHomepage(
       "abc",
       "description test",
+      "<script></script>",
       now.toISOString(),
       user
     );
@@ -76,16 +79,18 @@ describe("updateHomepage", () => {
     await repo.updateHomepage(
       "abc",
       "description test",
+      "<script></script>",
       now.toISOString(),
       user
     );
     expect(dynamodb.update).toHaveBeenCalledWith(
       expect.objectContaining({
         UpdateExpression:
-          "set #title = :title, #description = :description, #type = :type, #updatedAt = :updatedAt, #updatedBy = :userId",
+          "set #title = :title, #description = :description, #metricsScript = :metricsScript, #type = :type, #updatedAt = :updatedAt, #updatedBy = :userId",
         ExpressionAttributeValues: {
           ":title": "abc",
           ":description": "description test",
+          ":metricsScript": "<script></script>",
           ":lastUpdatedAt": now.toISOString(),
           ":updatedAt": now.toISOString(),
           ":userId": user.userId,

--- a/backend/src/lib/repositories/homepage-repo.ts
+++ b/backend/src/lib/repositories/homepage-repo.ts
@@ -44,7 +44,7 @@ class HomepageRepository extends BaseRepository {
     lastUpdatedAt: string,
     user: User
   ) {
-    console.log("Mazen: " + title + " " + metricsScript);
+
     try {
       await this.dynamodb.update({
         TableName: this.tableName,

--- a/backend/src/lib/repositories/homepage-repo.ts
+++ b/backend/src/lib/repositories/homepage-repo.ts
@@ -44,7 +44,6 @@ class HomepageRepository extends BaseRepository {
     lastUpdatedAt: string,
     user: User
   ) {
-
     try {
       await this.dynamodb.update({
         TableName: this.tableName,

--- a/backend/src/lib/repositories/homepage-repo.ts
+++ b/backend/src/lib/repositories/homepage-repo.ts
@@ -40,9 +40,11 @@ class HomepageRepository extends BaseRepository {
   public async updateHomepage(
     title: string,
     description: string,
+    metricsScript: string,
     lastUpdatedAt: string,
     user: User
   ) {
+    console.log("Mazen: " + title + " " + metricsScript);
     try {
       await this.dynamodb.update({
         TableName: this.tableName,
@@ -51,12 +53,13 @@ class HomepageRepository extends BaseRepository {
           sk: "Homepage",
         },
         UpdateExpression:
-          "set #title = :title, #description = :description, #type = :type, #updatedAt = :updatedAt, #updatedBy = :userId",
+          "set #title = :title, #description = :description, #metricsScript = :metricsScript, #type = :type, #updatedAt = :updatedAt, #updatedBy = :userId",
         ConditionExpression:
           "attribute_not_exists(#updatedAt) or #updatedAt <= :lastUpdatedAt",
         ExpressionAttributeValues: {
           ":title": title,
           ":description": description,
+          ":metricsScript": metricsScript,
           ":lastUpdatedAt": lastUpdatedAt,
           ":updatedAt": new Date().toISOString(),
           ":userId": user.userId,
@@ -65,6 +68,7 @@ class HomepageRepository extends BaseRepository {
         ExpressionAttributeNames: {
           "#title": "title",
           "#description": "description",
+          "#metricsScript": "metricsScript",
           "#updatedBy": "updatedBy",
           "#updatedAt": "updatedAt",
           "#type": "type",


### PR DESCRIPTION
## Description

GTT-1938: Adds backend support for metrics/analytics collection by allowing admins to store a script with the homepage.

## Testing

* Unit tests.
* Postman.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
