### PR TITLE
Add backend support for analytics collection using a tracking ID

### DIFF
--- a/backend/postman/Performance Dashboard API.postman_collection.json
+++ b/backend/postman/Performance Dashboard API.postman_collection.json
@@ -1155,7 +1155,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"publishingGuidance\": \"I acknowledge that I have reviewed the dashboard and it is ready to publish\",\n     \"updatedAt\": \"2020-12-01T20:14:22.190Z\"\n}",
+              "raw": "{\n    \"publishingGuidance\": \"I acknowledge that I have reviewed the dashboard and it is ready to publish\",\n     \"updatedAt\": \"2020-12-01T20:14:22.190Z\"\n     \"analyticsTrackingId\": \"UA123\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -1181,7 +1181,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"title\": \"Performance Dashboard\",\n    \"description\": \"The Performance Dashboard makes data open and accessible to provide transparency and helps drive the ongoing improvement of digital services.\",\n    \"metricsScript\": \"<script></script>\",\n    \"updatedAt\": \"2020-12-03T17:22:20.464Z\"\n}",
+              "raw": "{\n    \"title\": \"Performance Dashboard\",\n    \"description\": \"The Performance Dashboard makes data open and accessible to provide transparency and helps drive the ongoing improvement of digital services.\",\n    \"updatedAt\": \"2020-12-03T17:22:20.464Z\"\n}",
               "options": {
                 "raw": {
                   "language": "json"

--- a/backend/src/lib/controllers/__tests__/homepage-ctrl.test.ts
+++ b/backend/src/lib/controllers/__tests__/homepage-ctrl.test.ts
@@ -43,7 +43,6 @@ describe("getPublicHomepage", () => {
     HomepageFactory.getDefaultHomepage = jest.fn().mockReturnValueOnce({
       title: "Performance Dashboard",
       description: "Welcome to the performance dashboard",
-      metricsScript: "<script></script>",
     });
 
     await HomepageCtrl.getPublicHomepage(req, res);
@@ -52,7 +51,6 @@ describe("getPublicHomepage", () => {
       expect.objectContaining({
         title: "Performance Dashboard",
         description: "Welcome to the performance dashboard",
-        metricsScript: "<script></script>",
       })
     );
   });
@@ -62,7 +60,6 @@ describe("getPublicHomepage", () => {
     repository.getHomepage = jest.fn().mockReturnValueOnce({
       title: "Kingdom of Wakanda",
       description: "Welcome to the performance dashboard of our kingdom",
-      metricsScript: "<script></script>",
     });
 
     await HomepageCtrl.getPublicHomepage(req, res);
@@ -71,7 +68,6 @@ describe("getPublicHomepage", () => {
       expect.objectContaining({
         title: "Kingdom of Wakanda",
         description: "Welcome to the performance dashboard of our kingdom",
-        metricsScript: "<script></script>",
       })
     );
   });
@@ -132,7 +128,6 @@ describe("getHomepage", () => {
     HomepageFactory.getDefaultHomepage = jest.fn().mockReturnValueOnce({
       title: "Performance Dashboard",
       description: "Welcome to the performance dashboard",
-      metricsScript: "<script></script>",
     });
 
     await HomepageCtrl.getHomepage(req, res);
@@ -141,7 +136,6 @@ describe("getHomepage", () => {
       expect.objectContaining({
         title: "Performance Dashboard",
         description: "Welcome to the performance dashboard",
-        metricsScript: "<script></script>",
       })
     );
   });
@@ -151,7 +145,6 @@ describe("getHomepage", () => {
     repository.getHomepage = jest.fn().mockReturnValueOnce({
       title: "Kingdom of Wakanda",
       description: "Welcome to the performance dashboard of our kingdom",
-      metricsScript: "<script></script>",
     });
 
     await HomepageCtrl.getHomepage(req, res);
@@ -160,7 +153,6 @@ describe("getHomepage", () => {
       expect.objectContaining({
         title: "Kingdom of Wakanda",
         description: "Welcome to the performance dashboard of our kingdom",
-        metricsScript: "<script></script>",
       })
     );
   });
@@ -177,7 +169,6 @@ describe("updateHomepage", () => {
       body: {
         title: "abc",
         description: "description test",
-        metricsScript: "<script></script>",
         updatedAt: now.toISOString(),
       },
     } as any as Request;
@@ -209,7 +200,6 @@ describe("updateHomepage", () => {
     expect(repository.updateHomepage).toHaveBeenCalledWith(
       "abc",
       "description test",
-      "<script></script>",
       now.toISOString(),
       user
     );

--- a/backend/src/lib/controllers/__tests__/settings-ctrl.test.ts
+++ b/backend/src/lib/controllers/__tests__/settings-ctrl.test.ts
@@ -186,6 +186,17 @@ describe("updateSettings", () => {
       user
     );
   });
+
+  it("updates analytics tracking id", async () => {
+    req.body.analyticsTrackingId = "UA123";
+    await SettingsCtrl.updateSettings(req, res);
+    expect(repository.updateSetting).toHaveBeenCalledWith(
+      "analyticsTrackingId",
+      "UA123",
+      now.toISOString(),
+      user
+    );
+  });
 });
 
 describe("getPublicSettings", () => {

--- a/backend/src/lib/controllers/homepage-ctrl.ts
+++ b/backend/src/lib/controllers/homepage-ctrl.ts
@@ -24,7 +24,6 @@ async function getPublicHomepage(req: Request, res: Response) {
   return res.json({
     title: homepage.title,
     description: homepage.description,
-    metricsScript: homepage.metricsScript,
     dashboards: publicDashboards,
   });
 }
@@ -43,7 +42,7 @@ async function getHomepage(req: Request, res: Response) {
 
 async function updateHomepage(req: Request, res: Response) {
   const user = req.user;
-  const { title, description, metricsScript, updatedAt } = req.body;
+  const { title, description, updatedAt } = req.body;
 
   if (!title) {
     res.status(400).send("Missing required body `title`");
@@ -61,7 +60,7 @@ async function updateHomepage(req: Request, res: Response) {
   }
 
   const repo = HomepageRepository.getInstance();
-  await repo.updateHomepage(title, description, metricsScript, updatedAt, user);
+  await repo.updateHomepage(title, description, updatedAt, user);
 
   res.send();
 }
@@ -157,7 +156,6 @@ async function getPublicHomepageWithQuery(req: Request, res: Response) {
   return res.json({
     title: homepage.title,
     description: homepage.description,
-    metricsScript: homepage.metricsScript,
     dashboards: publicDashboards,
   });
 }

--- a/backend/src/lib/controllers/settings-ctrl.ts
+++ b/backend/src/lib/controllers/settings-ctrl.ts
@@ -26,6 +26,7 @@ async function updateSettings(req: Request, res: Response) {
     adminContactEmailAddress,
     contactEmailAddress,
     contactUsContent,
+    analyticsTrackingId,
   } = req.body;
 
   if (!updatedAt) {
@@ -141,6 +142,15 @@ async function updateSettings(req: Request, res: Response) {
     updatedAt = await repo.updateSetting(
       "contactUsContent",
       contactUsContent,
+      updatedAt,
+      user
+    );
+  }
+
+  if (analyticsTrackingId) {
+    updatedAt = await repo.updateSetting(
+      "analyticsTrackingId",
+      analyticsTrackingId,
       updatedAt,
       user
     );

--- a/backend/src/lib/factories/__tests__/settings-factory.test.ts
+++ b/backend/src/lib/factories/__tests__/settings-factory.test.ts
@@ -21,6 +21,7 @@ describe("getDefaultSettings", () => {
         primary: "#005EA2",
         secondary: "#54278f",
       },
+      analyticsTrackingId: undefined,
     });
   });
 });
@@ -48,6 +49,7 @@ describe("fromItem", () => {
       contactEmailAddress: "test@aol.com",
       adminContactEmailAddress: "admin@aol.com",
       contactUsContent: "test content",
+      analyticsTrackingId: "UA123",
     };
 
     const settings = SettingsFactory.fromItem(item);
@@ -73,6 +75,7 @@ describe("fromItem", () => {
       contactEmailAddress: "test@aol.com",
       adminContactEmailAddress: "admin@aol.com",
       contactUsContent: "test content",
+      analyticsTrackingId: "UA123",
     });
   });
 });
@@ -100,6 +103,7 @@ describe("toPublicSettings", () => {
       },
       contactEmailAddress: "test@aol.com",
       contactUsContent: "test content",
+      analyticsTrackingId: "UA123",
     };
 
     const publicSettings = SettingsFactory.toPublicSettings(settings);
@@ -121,6 +125,7 @@ describe("toPublicSettings", () => {
       },
       contactEmailAddress: "test@aol.com",
       contactUsContent: "test content",
+      analyticsTrackingId: "UA123",
     });
   });
 });

--- a/backend/src/lib/factories/homepage-factory.ts
+++ b/backend/src/lib/factories/homepage-factory.ts
@@ -15,9 +15,6 @@ function fromItem(item: HomepageItem): Homepage {
   return {
     title: item.title,
     description: item.description,
-    metricsScript: item.metricsScript
-      ? item.metricsScript
-      : "<script></script>",
     updatedAt: item.updatedAt ? new Date(item.updatedAt) : new Date(),
   };
 }

--- a/backend/src/lib/factories/settings-factory.ts
+++ b/backend/src/lib/factories/settings-factory.ts
@@ -22,6 +22,7 @@ function getDefaultSettings(): Settings {
       primary: "#005EA2",
       secondary: "#54278f",
     },
+    analyticsTrackingId: undefined,
   };
 }
 
@@ -52,6 +53,9 @@ function fromItem(item: SettingsItem): Settings {
     contactEmailAddress: item.contactEmailAddress,
     adminContactEmailAddress: item.adminContactEmailAddress,
     contactUsContent: item.contactUsContent,
+    analyticsTrackingId: item.analyticsTrackingId
+      ? item.analyticsTrackingId
+      : defaults.analyticsTrackingId,
   };
 }
 
@@ -76,6 +80,9 @@ function toPublicSettings(settings: Settings): PublicSettings {
     colors: settings.colors ? settings.colors : defaults.colors,
     contactEmailAddress: settings.contactEmailAddress,
     contactUsContent: settings.contactUsContent,
+    analyticsTrackingId: settings.analyticsTrackingId
+      ? settings.analyticsTrackingId
+      : defaults.analyticsTrackingId,
   };
 }
 

--- a/backend/src/lib/models/homepage.ts
+++ b/backend/src/lib/models/homepage.ts
@@ -1,7 +1,6 @@
 export interface Homepage {
   title: string;
   description: string;
-  metricsScript?: string;
   updatedAt: Date;
 }
 
@@ -12,5 +11,4 @@ export interface HomepageItem {
   updatedAt?: string;
   title: string;
   description: string;
-  metricsScript?: string;
 }

--- a/backend/src/lib/models/settings.ts
+++ b/backend/src/lib/models/settings.ts
@@ -20,6 +20,7 @@ export interface Settings {
   contactEmailAddress?: string;
   adminContactEmailAddress?: string;
   contactUsContent?: string;
+  analyticsTrackingId?: string; // Only Google Analytics is supported at this time.
 }
 
 export interface PublicSettings {
@@ -40,6 +41,7 @@ export interface PublicSettings {
   };
   contactEmailAddress?: string;
   contactUsContent?: string;
+  analyticsTrackingId?: string; // Only Google Analytics is supported at this time.
 }
 
 export interface SettingsItem {
@@ -67,4 +69,5 @@ export interface SettingsItem {
   contactEmailAddress?: string;
   adminContactEmailAddress?: string;
   contactUsContent?: string;
+  analyticsTrackingId?: string; // Only Google Analytics is supported at this time.
 }

--- a/backend/src/lib/repositories/__tests__/homepage-repo.test.ts
+++ b/backend/src/lib/repositories/__tests__/homepage-repo.test.ts
@@ -39,7 +39,6 @@ describe("getHomepage", () => {
       type: "Homepage",
       title: "Kingdom of Wakanda",
       description: "Welcome to our kingdom",
-      metricsScript: "<script></script>",
     };
 
     dynamodb.get = jest.fn().mockReturnValueOnce({ Item: item });
@@ -47,7 +46,6 @@ describe("getHomepage", () => {
 
     expect(homepage.title).toEqual("Kingdom of Wakanda");
     expect(homepage.description).toEqual("Welcome to our kingdom");
-    expect(homepage.metricsScript).toEqual("<script></script>");
   });
 });
 
@@ -57,7 +55,6 @@ describe("updateHomepage", () => {
     await repo.updateHomepage(
       "abc",
       "description test",
-      "<script></script>",
       now.toISOString(),
       user
     );
@@ -79,18 +76,16 @@ describe("updateHomepage", () => {
     await repo.updateHomepage(
       "abc",
       "description test",
-      "<script></script>",
       now.toISOString(),
       user
     );
     expect(dynamodb.update).toHaveBeenCalledWith(
       expect.objectContaining({
         UpdateExpression:
-          "set #title = :title, #description = :description, #metricsScript = :metricsScript, #type = :type, #updatedAt = :updatedAt, #updatedBy = :userId",
+          "set #title = :title, #description = :description, #type = :type, #updatedAt = :updatedAt, #updatedBy = :userId",
         ExpressionAttributeValues: {
           ":title": "abc",
           ":description": "description test",
-          ":metricsScript": "<script></script>",
           ":lastUpdatedAt": now.toISOString(),
           ":updatedAt": now.toISOString(),
           ":userId": user.userId,

--- a/backend/src/lib/repositories/homepage-repo.ts
+++ b/backend/src/lib/repositories/homepage-repo.ts
@@ -40,7 +40,6 @@ class HomepageRepository extends BaseRepository {
   public async updateHomepage(
     title: string,
     description: string,
-    metricsScript: string,
     lastUpdatedAt: string,
     user: User
   ) {
@@ -52,13 +51,12 @@ class HomepageRepository extends BaseRepository {
           sk: "Homepage",
         },
         UpdateExpression:
-          "set #title = :title, #description = :description, #metricsScript = :metricsScript, #type = :type, #updatedAt = :updatedAt, #updatedBy = :userId",
+          "set #title = :title, #description = :description, #type = :type, #updatedAt = :updatedAt, #updatedBy = :userId",
         ConditionExpression:
           "attribute_not_exists(#updatedAt) or #updatedAt <= :lastUpdatedAt",
         ExpressionAttributeValues: {
           ":title": title,
           ":description": description,
-          ":metricsScript": metricsScript,
           ":lastUpdatedAt": lastUpdatedAt,
           ":updatedAt": new Date().toISOString(),
           ":userId": user.userId,
@@ -67,7 +65,6 @@ class HomepageRepository extends BaseRepository {
         ExpressionAttributeNames: {
           "#title": "title",
           "#description": "description",
-          "#metricsScript": "metricsScript",
           "#updatedBy": "updatedBy",
           "#updatedAt": "updatedAt",
           "#type": "type",


### PR DESCRIPTION
## Description

GTT-1938: Adds backend support for analytics collection by allowing admins to store an analytics tracking ID and reverts previous changes that relied on a script.

## Testing

* Unit tests.
* Postman.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
