### PR TITLE
Accessibility issues on Card components addressed

### DIFF
--- a/frontend/src/components/MetricsCardGroup.tsx
+++ b/frontend/src/components/MetricsCardGroup.tsx
@@ -53,10 +53,7 @@ function MetricsCardGroup(props: Props) {
                     className={`grid-col-${12 / props.metricPerRow} padding-05`}
                     key={j}
                   >
-                    <div
-                      className="display-flex flex-column border-base-lightest border-2px height-card padding-1 overflow-x-auto overflow-y-auto"
-                      tabIndex={0}
-                    >
+                    <div className="display-flex flex-column border-base-lightest border-2px height-card padding-1 overflow-x-auto overflow-y-auto">
                       <div className="flex-5">
                         <p className="text-base-darker text-bold margin-0 text-no-wrap">
                           {metric.title}
@@ -67,8 +64,8 @@ function MetricsCardGroup(props: Props) {
                         data-position="bottom"
                         title={metric.value ? metric.value.toString() : ""}
                       >
-                        <h1
-                          className="margin-0 text-no-wrap"
+                        <span
+                          className="margin-0 text-no-wrap font-sans-xl text-bold"
                           style={{ color: primaryColor }}
                         >
                           {TickFormatter.formatNumber(
@@ -79,7 +76,7 @@ function MetricsCardGroup(props: Props) {
                             metric.percentage,
                             metric.currency
                           )}
-                        </h1>
+                        </span>
                       </div>
                       <div className="flex-2">
                         {metric.changeOverTime && (

--- a/frontend/src/components/Tooltip.tsx
+++ b/frontend/src/components/Tooltip.tsx
@@ -32,6 +32,7 @@ function Tooltip(props: Props) {
       globalEventOff="click"
       className="padding-x-2-important cursor-default shadow-3"
       borderColor="#dfe1e2"
+      role="tooltip"
     />
   );
 }

--- a/frontend/src/components/__tests__/__snapshots__/MetricsWidget.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/MetricsWidget.test.tsx.snap
@@ -27,7 +27,6 @@ exports[`metrics preview should match snapshot 1`] = `
             >
               <div
                 class="display-flex flex-column border-base-lightest border-2px height-card padding-1 overflow-x-auto overflow-y-auto"
-                tabindex="0"
               >
                 <div
                   class="flex-5"
@@ -43,12 +42,12 @@ exports[`metrics preview should match snapshot 1`] = `
                   data-position="bottom"
                   title="1"
                 >
-                  <h1
-                    class="margin-0 text-no-wrap"
+                  <span
+                    class="margin-0 text-no-wrap font-sans-xl text-bold"
                     style="color: rgb(41, 180, 187);"
                   >
                     1
-                  </h1>
+                  </span>
                 </div>
                 <div
                   class="flex-2"

--- a/frontend/src/components/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`renders a tooltip at the bottom 1`] = `
     class="__react_component_tooltip test place-bottom type-dark"
     data-id="tooltip"
     id="test"
+    role="tooltip"
   >
     <style
       aria-hidden="true"
@@ -96,6 +97,7 @@ exports[`renders a tooltip at the left 1`] = `
     class="__react_component_tooltip test place-left type-dark"
     data-id="tooltip"
     id="test"
+    role="tooltip"
   >
     <style
       aria-hidden="true"
@@ -186,6 +188,7 @@ exports[`renders a tooltip at the right 1`] = `
     class="__react_component_tooltip test place-right type-dark"
     data-id="tooltip"
     id="test"
+    role="tooltip"
   >
     <style
       aria-hidden="true"
@@ -276,6 +279,7 @@ exports[`renders a tooltip at the top (default) 1`] = `
     class="__react_component_tooltip test place-top type-dark"
     data-id="tooltip"
     id="test"
+    role="tooltip"
   >
     <style
       aria-hidden="true"


### PR DESCRIPTION
## Description

a. Card 
  * Cards are not interactive, they should not be focusable. Removed the `tab-index` attribute from their containers.
  * Numbers in cards use heading markup but do not function as headings. Only text that functions as a heading can use heading markup. Converted this content to `<span>` element.

b. Tooltip
  * Ensure custom controls provide proper textual name, role, and state information. Added the `role="tooltip"` to the tooltip that appears on hovering "delete" disabled button.

## Testing

Describe how you tested your changes and/or give instructions to the reviewers on how they can verify them.

a. Card
 1. Go to https://d2zdyv8kmq5ffn.cloudfront.net/example-dashboard
 2. Inspect any card element and check the changes described in the description above.

b. Tooltip
 1. Go to https://d2zdyv8kmq5ffn.cloudfront.net/admin/settings/topicarea
 2. Inspect the tooltip element close to the `delete` button and check the changes described in the description above.
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
