### PR TITLE
Miguel.abreu/gtt 1954 table sort button contrast

### DIFF
--- a/cdk/lib/pipeline-stack.ts
+++ b/cdk/lib/pipeline-stack.ts
@@ -53,7 +53,7 @@ export class PipelineStack extends cdk.Stack {
 
     const build = new codebuild.PipelineProject(this, "Build", {
       environment: {
-        buildImage: codebuild.LinuxBuildImage.AMAZON_LINUX_2_2,
+        buildImage: codebuild.LinuxBuildImage.STANDARD_5_0,
         computeType: codebuild.ComputeType.LARGE,
       },
       environmentVariables: {

--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useMemo, useState, MouseEvent } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faChevronDown, faChevronUp } from "@fortawesome/free-solid-svg-icons";
+import {
+  faChevronCircleDown,
+  faChevronCircleUp,
+  faChevronDown,
+} from "@fortawesome/free-solid-svg-icons";
 import {
   useTable,
   useSortBy,
@@ -300,13 +304,12 @@ function Table(props: Props) {
                       type="button"
                     >
                       <FontAwesomeIcon
-                        className={`hover:text-base ${
-                          column.isSorted ? "text-base-darker" : "text-base"
-                        }`}
                         icon={
-                          column.isSorted && column.isSortedDesc
+                          !column.isSorted
                             ? faChevronDown
-                            : faChevronUp
+                            : column.isSortedDesc
+                            ? faChevronCircleDown
+                            : faChevronCircleUp
                         }
                       />
                     </button>

--- a/frontend/src/components/TopicareasTable.tsx
+++ b/frontend/src/components/TopicareasTable.tsx
@@ -1,7 +1,11 @@
 import React, { useState } from "react";
 import { useSettings } from "../hooks";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faChevronDown, faChevronUp } from "@fortawesome/free-solid-svg-icons";
+import {
+  faChevronDown,
+  faChevronCircleUp,
+  faChevronCircleDown,
+} from "@fortawesome/free-solid-svg-icons";
 import { TopicArea } from "../models";
 import Button from "./Button";
 import { useTranslation } from "react-i18next";
@@ -57,58 +61,58 @@ function TopicareasTable(props: Props) {
         <tr>
           <th></th>
           <th>
-            <span className="font-sans-xs">{t("TopicArea")}</span>
             <Button
               variant="unstyled"
-              className={`margin-left-1 hover:text-base-light ${
-                sortedBy === "name" ? "text-base-darker" : "text-white"
-              }`}
+              className="margin-left-1 hover:text-base-darker font-sans-md text-bold text-no-underline"
               onClick={() => sortBy("name")}
               ariaLabel={t("SortTopicAreaName")}
             >
+              <span className="margin-1">{t("TopicArea")}</span>
               <FontAwesomeIcon
                 icon={
-                  sortedBy === "name" && direction === "up"
-                    ? faChevronUp
-                    : faChevronDown
+                  sortedBy !== "name"
+                    ? faChevronDown
+                    : direction === "up"
+                    ? faChevronCircleUp
+                    : faChevronCircleDown
                 }
               />
             </Button>
           </th>
           <th>
-            <span className="font-sans-xs">{t("Dashboards")}</span>
             <Button
               variant="unstyled"
-              className={`margin-left-1 hover:text-base-light ${
-                sortedBy === "dashboards" ? "text-base-darker" : "text-white"
-              }`}
+              className="margin-left-1 hover:text-base-darker font-sans-md text-bold text-no-underline"
               onClick={() => sortBy("dashboards")}
               ariaLabel={t("SortDashboards")}
             >
+              <span className="margin-1">{t("Dashboards")}</span>
               <FontAwesomeIcon
                 icon={
-                  sortedBy === "dashboards" && direction === "up"
-                    ? faChevronUp
-                    : faChevronDown
+                  sortedBy !== "dashboards"
+                    ? faChevronDown
+                    : direction === "up"
+                    ? faChevronCircleUp
+                    : faChevronCircleDown
                 }
               />
             </Button>
           </th>
           <th>
-            <span className="font-sans-xs">{t("CreatedBy")}</span>
             <Button
               variant="unstyled"
-              className={`margin-left-1 hover:text-base-light ${
-                sortedBy === "createdBy" ? "text-base-darker" : "text-white"
-              }`}
+              className="margin-left-1 hover:text-base-darker font-sans-md text-bold text-no-underline"
               onClick={() => sortBy("createdBy")}
               ariaLabel={t("SortCreatedBy")}
             >
+              <span className="margin-1">{t("CreatedBy")}</span>
               <FontAwesomeIcon
                 icon={
-                  sortedBy === "createdBy" && direction === "up"
-                    ? faChevronUp
-                    : faChevronDown
+                  sortedBy !== "createdBy"
+                    ? faChevronDown
+                    : direction === "up"
+                    ? faChevronCircleUp
+                    : faChevronCircleDown
                 }
               />
             </Button>

--- a/frontend/src/components/__tests__/__snapshots__/CheckData.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/CheckData.test.tsx.snap
@@ -151,8 +151,8 @@ exports[`renders the CheckData component 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                    data-icon="chevron-up"
+                    class="svg-inline--fa fa-chevron-down fa-w-14 "
+                    data-icon="chevron-down"
                     data-prefix="fas"
                     focusable="false"
                     role="img"
@@ -160,7 +160,7 @@ exports[`renders the CheckData component 1`] = `
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
-                      d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                      d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                       fill="currentColor"
                     />
                   </svg>
@@ -185,8 +185,8 @@ exports[`renders the CheckData component 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                    data-icon="chevron-up"
+                    class="svg-inline--fa fa-chevron-down fa-w-14 "
+                    data-icon="chevron-down"
                     data-prefix="fas"
                     focusable="false"
                     role="img"
@@ -194,7 +194,7 @@ exports[`renders the CheckData component 1`] = `
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
-                      d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                      d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                       fill="currentColor"
                     />
                   </svg>
@@ -219,8 +219,8 @@ exports[`renders the CheckData component 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                    data-icon="chevron-up"
+                    class="svg-inline--fa fa-chevron-down fa-w-14 "
+                    data-icon="chevron-down"
                     data-prefix="fas"
                     focusable="false"
                     role="img"
@@ -228,7 +228,7 @@ exports[`renders the CheckData component 1`] = `
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
-                      d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                      d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                       fill="currentColor"
                     />
                   </svg>

--- a/frontend/src/components/__tests__/__snapshots__/ChooseData.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/ChooseData.test.tsx.snap
@@ -329,8 +329,8 @@ exports[`renders the ChooseData component 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                      data-icon="chevron-up"
+                      class="svg-inline--fa fa-chevron-down fa-w-14 "
+                      data-icon="chevron-down"
                       data-prefix="fas"
                       focusable="false"
                       role="img"
@@ -338,7 +338,7 @@ exports[`renders the ChooseData component 1`] = `
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                        d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                         fill="currentColor"
                       />
                     </svg>
@@ -363,16 +363,16 @@ exports[`renders the ChooseData component 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="svg-inline--fa fa-chevron-down fa-w-14 hover:text-base text-base-darker"
-                      data-icon="chevron-down"
+                      class="svg-inline--fa fa-chevron-circle-down fa-w-16 "
+                      data-icon="chevron-circle-down"
                       data-prefix="fas"
                       focusable="false"
                       role="img"
-                      viewBox="0 0 448 512"
+                      viewBox="0 0 512 512"
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
+                        d="M504 256c0 137-111 248-248 248S8 393 8 256 119 8 256 8s248 111 248 248zM273 369.9l135.5-135.5c9.4-9.4 9.4-24.6 0-33.9l-17-17c-9.4-9.4-24.6-9.4-33.9 0L256 285.1 154.4 183.5c-9.4-9.4-24.6-9.4-33.9 0l-17 17c-9.4 9.4-9.4 24.6 0 33.9L239 369.9c9.4 9.4 24.6 9.4 34 0z"
                         fill="currentColor"
                       />
                     </svg>
@@ -397,8 +397,8 @@ exports[`renders the ChooseData component 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                      data-icon="chevron-up"
+                      class="svg-inline--fa fa-chevron-down fa-w-14 "
+                      data-icon="chevron-down"
                       data-prefix="fas"
                       focusable="false"
                       role="img"
@@ -406,7 +406,7 @@ exports[`renders the ChooseData component 1`] = `
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                        d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                         fill="currentColor"
                       />
                     </svg>
@@ -431,8 +431,8 @@ exports[`renders the ChooseData component 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                      data-icon="chevron-up"
+                      class="svg-inline--fa fa-chevron-down fa-w-14 "
+                      data-icon="chevron-down"
                       data-prefix="fas"
                       focusable="false"
                       role="img"
@@ -440,7 +440,7 @@ exports[`renders the ChooseData component 1`] = `
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                        d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                         fill="currentColor"
                       />
                     </svg>

--- a/frontend/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -62,8 +62,8 @@ exports[`renders a Data Table element 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                data-icon="chevron-up"
+                class="svg-inline--fa fa-chevron-down fa-w-14 "
+                data-icon="chevron-down"
                 data-prefix="fas"
                 focusable="false"
                 role="img"
@@ -71,7 +71,7 @@ exports[`renders a Data Table element 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                   fill="currentColor"
                 />
               </svg>
@@ -96,8 +96,8 @@ exports[`renders a Data Table element 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                data-icon="chevron-up"
+                class="svg-inline--fa fa-chevron-down fa-w-14 "
+                data-icon="chevron-down"
                 data-prefix="fas"
                 focusable="false"
                 role="img"
@@ -105,7 +105,7 @@ exports[`renders a Data Table element 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                   fill="currentColor"
                 />
               </svg>
@@ -130,8 +130,8 @@ exports[`renders a Data Table element 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                data-icon="chevron-up"
+                class="svg-inline--fa fa-chevron-down fa-w-14 "
+                data-icon="chevron-down"
                 data-prefix="fas"
                 focusable="false"
                 role="img"
@@ -139,7 +139,7 @@ exports[`renders a Data Table element 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                   fill="currentColor"
                 />
               </svg>
@@ -278,8 +278,8 @@ exports[`renders a Data Table element on mobile 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                data-icon="chevron-up"
+                class="svg-inline--fa fa-chevron-down fa-w-14 "
+                data-icon="chevron-down"
                 data-prefix="fas"
                 focusable="false"
                 role="img"
@@ -287,7 +287,7 @@ exports[`renders a Data Table element on mobile 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                   fill="currentColor"
                 />
               </svg>
@@ -312,8 +312,8 @@ exports[`renders a Data Table element on mobile 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                data-icon="chevron-up"
+                class="svg-inline--fa fa-chevron-down fa-w-14 "
+                data-icon="chevron-down"
                 data-prefix="fas"
                 focusable="false"
                 role="img"
@@ -321,7 +321,7 @@ exports[`renders a Data Table element on mobile 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                   fill="currentColor"
                 />
               </svg>
@@ -346,8 +346,8 @@ exports[`renders a Data Table element on mobile 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                data-icon="chevron-up"
+                class="svg-inline--fa fa-chevron-down fa-w-14 "
+                data-icon="chevron-down"
                 data-prefix="fas"
                 focusable="false"
                 role="img"
@@ -355,7 +355,7 @@ exports[`renders a Data Table element on mobile 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                   fill="currentColor"
                 />
               </svg>

--- a/frontend/src/components/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/Table.test.tsx.snap
@@ -32,8 +32,8 @@ exports[`renders a basic table 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                data-icon="chevron-up"
+                class="svg-inline--fa fa-chevron-down fa-w-14 "
+                data-icon="chevron-down"
                 data-prefix="fas"
                 focusable="false"
                 role="img"
@@ -41,7 +41,7 @@ exports[`renders a basic table 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                   fill="currentColor"
                 />
               </svg>
@@ -66,8 +66,8 @@ exports[`renders a basic table 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                data-icon="chevron-up"
+                class="svg-inline--fa fa-chevron-down fa-w-14 "
+                data-icon="chevron-down"
                 data-prefix="fas"
                 focusable="false"
                 role="img"
@@ -75,7 +75,7 @@ exports[`renders a basic table 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                   fill="currentColor"
                 />
               </svg>
@@ -100,8 +100,8 @@ exports[`renders a basic table 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                data-icon="chevron-up"
+                class="svg-inline--fa fa-chevron-down fa-w-14 "
+                data-icon="chevron-down"
                 data-prefix="fas"
                 focusable="false"
                 role="img"
@@ -109,7 +109,7 @@ exports[`renders a basic table 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                   fill="currentColor"
                 />
               </svg>
@@ -218,8 +218,8 @@ exports[`renders a basic table with mobile navigation 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                data-icon="chevron-up"
+                class="svg-inline--fa fa-chevron-down fa-w-14 "
+                data-icon="chevron-down"
                 data-prefix="fas"
                 focusable="false"
                 role="img"
@@ -227,7 +227,7 @@ exports[`renders a basic table with mobile navigation 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                   fill="currentColor"
                 />
               </svg>
@@ -252,8 +252,8 @@ exports[`renders a basic table with mobile navigation 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                data-icon="chevron-up"
+                class="svg-inline--fa fa-chevron-down fa-w-14 "
+                data-icon="chevron-down"
                 data-prefix="fas"
                 focusable="false"
                 role="img"
@@ -261,7 +261,7 @@ exports[`renders a basic table with mobile navigation 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                   fill="currentColor"
                 />
               </svg>
@@ -286,8 +286,8 @@ exports[`renders a basic table with mobile navigation 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                data-icon="chevron-up"
+                class="svg-inline--fa fa-chevron-down fa-w-14 "
+                data-icon="chevron-down"
                 data-prefix="fas"
                 focusable="false"
                 role="img"
@@ -295,7 +295,7 @@ exports[`renders a basic table with mobile navigation 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                   fill="currentColor"
                 />
               </svg>
@@ -404,8 +404,8 @@ exports[`renders a basic table without pagination 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                data-icon="chevron-up"
+                class="svg-inline--fa fa-chevron-down fa-w-14 "
+                data-icon="chevron-down"
                 data-prefix="fas"
                 focusable="false"
                 role="img"
@@ -413,7 +413,7 @@ exports[`renders a basic table without pagination 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                   fill="currentColor"
                 />
               </svg>
@@ -438,8 +438,8 @@ exports[`renders a basic table without pagination 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                data-icon="chevron-up"
+                class="svg-inline--fa fa-chevron-down fa-w-14 "
+                data-icon="chevron-down"
                 data-prefix="fas"
                 focusable="false"
                 role="img"
@@ -447,7 +447,7 @@ exports[`renders a basic table without pagination 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                   fill="currentColor"
                 />
               </svg>
@@ -472,8 +472,8 @@ exports[`renders a basic table without pagination 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                data-icon="chevron-up"
+                class="svg-inline--fa fa-chevron-down fa-w-14 "
+                data-icon="chevron-down"
                 data-prefix="fas"
                 focusable="false"
                 role="img"
@@ -481,7 +481,7 @@ exports[`renders a basic table without pagination 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                   fill="currentColor"
                 />
               </svg>
@@ -605,8 +605,8 @@ exports[`sorting buttons are clickable 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                data-icon="chevron-up"
+                class="svg-inline--fa fa-chevron-down fa-w-14 "
+                data-icon="chevron-down"
                 data-prefix="fas"
                 focusable="false"
                 role="img"
@@ -614,7 +614,7 @@ exports[`sorting buttons are clickable 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                   fill="currentColor"
                 />
               </svg>
@@ -639,8 +639,8 @@ exports[`sorting buttons are clickable 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                data-icon="chevron-up"
+                class="svg-inline--fa fa-chevron-down fa-w-14 "
+                data-icon="chevron-down"
                 data-prefix="fas"
                 focusable="false"
                 role="img"
@@ -648,7 +648,7 @@ exports[`sorting buttons are clickable 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                   fill="currentColor"
                 />
               </svg>
@@ -673,16 +673,16 @@ exports[`sorting buttons are clickable 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base-darker"
-                data-icon="chevron-up"
+                class="svg-inline--fa fa-chevron-circle-up fa-w-16 "
+                data-icon="chevron-circle-up"
                 data-prefix="fas"
                 focusable="false"
                 role="img"
-                viewBox="0 0 448 512"
+                viewBox="0 0 512 512"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  d="M8 256C8 119 119 8 256 8s248 111 248 248-111 248-248 248S8 393 8 256zm231-113.9L103.5 277.6c-9.4 9.4-9.4 24.6 0 33.9l17 17c9.4 9.4 24.6 9.4 33.9 0L256 226.9l101.6 101.6c9.4 9.4 24.6 9.4 33.9 0l17-17c9.4-9.4 9.4-24.6 0-33.9L273 142.1c-9.4-9.4-24.6-9.4-34 0z"
                   fill="currentColor"
                 />
               </svg>
@@ -833,8 +833,8 @@ exports[`sorting buttons are clickable 2`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                data-icon="chevron-up"
+                class="svg-inline--fa fa-chevron-down fa-w-14 "
+                data-icon="chevron-down"
                 data-prefix="fas"
                 focusable="false"
                 role="img"
@@ -842,7 +842,7 @@ exports[`sorting buttons are clickable 2`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                   fill="currentColor"
                 />
               </svg>
@@ -867,8 +867,8 @@ exports[`sorting buttons are clickable 2`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                data-icon="chevron-up"
+                class="svg-inline--fa fa-chevron-down fa-w-14 "
+                data-icon="chevron-down"
                 data-prefix="fas"
                 focusable="false"
                 role="img"
@@ -876,7 +876,7 @@ exports[`sorting buttons are clickable 2`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                   fill="currentColor"
                 />
               </svg>
@@ -901,16 +901,16 @@ exports[`sorting buttons are clickable 2`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-chevron-down fa-w-14 hover:text-base text-base-darker"
-                data-icon="chevron-down"
+                class="svg-inline--fa fa-chevron-circle-down fa-w-16 "
+                data-icon="chevron-circle-down"
                 data-prefix="fas"
                 focusable="false"
                 role="img"
-                viewBox="0 0 448 512"
+                viewBox="0 0 512 512"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
+                  d="M504 256c0 137-111 248-248 248S8 393 8 256 119 8 256 8s248 111 248 248zM273 369.9l135.5-135.5c9.4-9.4 9.4-24.6 0-33.9l-17-17c-9.4-9.4-24.6-9.4-33.9 0L256 285.1 154.4 183.5c-9.4-9.4-24.6-9.4-33.9 0l-17 17c-9.4 9.4-9.4 24.6 0 33.9L239 369.9c9.4 9.4 24.6 9.4 34 0z"
                   fill="currentColor"
                 />
               </svg>

--- a/frontend/src/components/__tests__/__snapshots__/TableWidget.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/TableWidget.test.tsx.snap
@@ -49,8 +49,8 @@ exports[`table preview should match snapshot 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                  data-icon="chevron-up"
+                  class="svg-inline--fa fa-chevron-down fa-w-14 "
+                  data-icon="chevron-down"
                   data-prefix="fas"
                   focusable="false"
                   role="img"
@@ -58,7 +58,7 @@ exports[`table preview should match snapshot 1`] = `
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
-                    d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                    d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                     fill="currentColor"
                   />
                 </svg>
@@ -83,8 +83,8 @@ exports[`table preview should match snapshot 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                  data-icon="chevron-up"
+                  class="svg-inline--fa fa-chevron-down fa-w-14 "
+                  data-icon="chevron-down"
                   data-prefix="fas"
                   focusable="false"
                   role="img"
@@ -92,7 +92,7 @@ exports[`table preview should match snapshot 1`] = `
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
-                    d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                    d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                     fill="currentColor"
                   />
                 </svg>
@@ -117,8 +117,8 @@ exports[`table preview should match snapshot 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                  data-icon="chevron-up"
+                  class="svg-inline--fa fa-chevron-down fa-w-14 "
+                  data-icon="chevron-down"
                   data-prefix="fas"
                   focusable="false"
                   role="img"
@@ -126,7 +126,7 @@ exports[`table preview should match snapshot 1`] = `
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
-                    d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                    d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                     fill="currentColor"
                   />
                 </svg>

--- a/frontend/src/components/__tests__/__snapshots__/TopicareasTable.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/TopicareasTable.test.tsx.snap
@@ -10,15 +10,15 @@ exports[`renders a table with topic areas 1`] = `
       <tr>
         <th />
         <th>
-          <span
-            class="font-sans-xs"
-          >
-            Topic area
-          </span>
           <button
             aria-label="Sort by topic area name"
-            class="usa-button usa-button--unstyled margin-left-1 hover:text-base-light text-white"
+            class="usa-button usa-button--unstyled margin-left-1 hover:text-base-darker font-sans-md text-bold text-no-underline"
           >
+            <span
+              class="margin-1"
+            >
+              Topic area
+            </span>
             <svg
               aria-hidden="true"
               class="svg-inline--fa fa-chevron-down fa-w-14 "
@@ -37,42 +37,42 @@ exports[`renders a table with topic areas 1`] = `
           </button>
         </th>
         <th>
-          <span
-            class="font-sans-xs"
-          >
-            Dashboards
-          </span>
           <button
             aria-label="Sort by dashboard name"
-            class="usa-button usa-button--unstyled margin-left-1 hover:text-base-light text-base-darker"
+            class="usa-button usa-button--unstyled margin-left-1 hover:text-base-darker font-sans-md text-bold text-no-underline"
           >
+            <span
+              class="margin-1"
+            >
+              Dashboards
+            </span>
             <svg
               aria-hidden="true"
-              class="svg-inline--fa fa-chevron-down fa-w-14 "
-              data-icon="chevron-down"
+              class="svg-inline--fa fa-chevron-circle-down fa-w-16 "
+              data-icon="chevron-circle-down"
               data-prefix="fas"
               focusable="false"
               role="img"
-              viewBox="0 0 448 512"
+              viewBox="0 0 512 512"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
+                d="M504 256c0 137-111 248-248 248S8 393 8 256 119 8 256 8s248 111 248 248zM273 369.9l135.5-135.5c9.4-9.4 9.4-24.6 0-33.9l-17-17c-9.4-9.4-24.6-9.4-33.9 0L256 285.1 154.4 183.5c-9.4-9.4-24.6-9.4-33.9 0l-17 17c-9.4 9.4-9.4 24.6 0 33.9L239 369.9c9.4 9.4 24.6 9.4 34 0z"
                 fill="currentColor"
               />
             </svg>
           </button>
         </th>
         <th>
-          <span
-            class="font-sans-xs"
-          >
-            Created by
-          </span>
           <button
             aria-label="Sort by created by name"
-            class="usa-button usa-button--unstyled margin-left-1 hover:text-base-light text-white"
+            class="usa-button usa-button--unstyled margin-left-1 hover:text-base-darker font-sans-md text-bold text-no-underline"
           >
+            <span
+              class="margin-1"
+            >
+              Created by
+            </span>
             <svg
               aria-hidden="true"
               class="svg-inline--fa fa-chevron-down fa-w-14 "
@@ -143,15 +143,15 @@ exports[`renders an empty table 1`] = `
       <tr>
         <th />
         <th>
-          <span
-            class="font-sans-xs"
-          >
-            Topic area
-          </span>
           <button
             aria-label="Sort by topic area name"
-            class="usa-button usa-button--unstyled margin-left-1 hover:text-base-light text-white"
+            class="usa-button usa-button--unstyled margin-left-1 hover:text-base-darker font-sans-md text-bold text-no-underline"
           >
+            <span
+              class="margin-1"
+            >
+              Topic area
+            </span>
             <svg
               aria-hidden="true"
               class="svg-inline--fa fa-chevron-down fa-w-14 "
@@ -170,42 +170,42 @@ exports[`renders an empty table 1`] = `
           </button>
         </th>
         <th>
-          <span
-            class="font-sans-xs"
-          >
-            Dashboards
-          </span>
           <button
             aria-label="Sort by dashboard name"
-            class="usa-button usa-button--unstyled margin-left-1 hover:text-base-light text-base-darker"
+            class="usa-button usa-button--unstyled margin-left-1 hover:text-base-darker font-sans-md text-bold text-no-underline"
           >
+            <span
+              class="margin-1"
+            >
+              Dashboards
+            </span>
             <svg
               aria-hidden="true"
-              class="svg-inline--fa fa-chevron-down fa-w-14 "
-              data-icon="chevron-down"
+              class="svg-inline--fa fa-chevron-circle-down fa-w-16 "
+              data-icon="chevron-circle-down"
               data-prefix="fas"
               focusable="false"
               role="img"
-              viewBox="0 0 448 512"
+              viewBox="0 0 512 512"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
+                d="M504 256c0 137-111 248-248 248S8 393 8 256 119 8 256 8s248 111 248 248zM273 369.9l135.5-135.5c9.4-9.4 9.4-24.6 0-33.9l-17-17c-9.4-9.4-24.6-9.4-33.9 0L256 285.1 154.4 183.5c-9.4-9.4-24.6-9.4-33.9 0l-17 17c-9.4 9.4-9.4 24.6 0 33.9L239 369.9c9.4 9.4 24.6 9.4 34 0z"
                 fill="currentColor"
               />
             </svg>
           </button>
         </th>
         <th>
-          <span
-            class="font-sans-xs"
-          >
-            Created by
-          </span>
           <button
             aria-label="Sort by created by name"
-            class="usa-button usa-button--unstyled margin-left-1 hover:text-base-light text-white"
+            class="usa-button usa-button--unstyled margin-left-1 hover:text-base-darker font-sans-md text-bold text-no-underline"
           >
+            <span
+              class="margin-1"
+            >
+              Created by
+            </span>
             <svg
               aria-hidden="true"
               class="svg-inline--fa fa-chevron-down fa-w-14 "

--- a/frontend/src/components/__tests__/__snapshots__/VisualizeTable.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/VisualizeTable.test.tsx.snap
@@ -317,8 +317,8 @@ exports[`renders the VisualizeTable component 1`] = `
                     >
                       <svg
                         aria-hidden="true"
-                        class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                        data-icon="chevron-up"
+                        class="svg-inline--fa fa-chevron-down fa-w-14 "
+                        data-icon="chevron-down"
                         data-prefix="fas"
                         focusable="false"
                         role="img"
@@ -326,7 +326,7 @@ exports[`renders the VisualizeTable component 1`] = `
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                          d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                           fill="currentColor"
                         />
                       </svg>
@@ -351,8 +351,8 @@ exports[`renders the VisualizeTable component 1`] = `
                     >
                       <svg
                         aria-hidden="true"
-                        class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                        data-icon="chevron-up"
+                        class="svg-inline--fa fa-chevron-down fa-w-14 "
+                        data-icon="chevron-down"
                         data-prefix="fas"
                         focusable="false"
                         role="img"
@@ -360,7 +360,7 @@ exports[`renders the VisualizeTable component 1`] = `
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                          d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                           fill="currentColor"
                         />
                       </svg>
@@ -385,8 +385,8 @@ exports[`renders the VisualizeTable component 1`] = `
                     >
                       <svg
                         aria-hidden="true"
-                        class="svg-inline--fa fa-chevron-up fa-w-14 hover:text-base text-base"
-                        data-icon="chevron-up"
+                        class="svg-inline--fa fa-chevron-down fa-w-14 "
+                        data-icon="chevron-down"
                         data-prefix="fas"
                         focusable="false"
                         role="img"
@@ -394,7 +394,7 @@ exports[`renders the VisualizeTable component 1`] = `
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                          d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
                           fill="currentColor"
                         />
                       </svg>

--- a/frontend/src/containers/TopicareaListing.tsx
+++ b/frontend/src/containers/TopicareaListing.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import Search from "../components/Search";
 import { LocationState, TopicArea } from "../models";
 import Button from "../components/Button";
 import TopicareasTable from "../components/TopicareasTable";

--- a/frontend/src/containers/__tests__/__snapshots__/TopicareaSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/TopicareaSettings.test.tsx.snap
@@ -295,15 +295,15 @@ exports[`topic area settings should match snapshot 1`] = `
               <tr>
                 <th />
                 <th>
-                  <span
-                    class="font-sans-xs"
-                  >
-                    Topic area
-                  </span>
                   <button
                     aria-label="Sort by topic area name"
-                    class="usa-button usa-button--unstyled margin-left-1 hover:text-base-light text-white"
+                    class="usa-button usa-button--unstyled margin-left-1 hover:text-base-darker font-sans-md text-bold text-no-underline"
                   >
+                    <span
+                      class="margin-1"
+                    >
+                      Topic area
+                    </span>
                     <svg
                       aria-hidden="true"
                       class="svg-inline--fa fa-chevron-down fa-w-14 "
@@ -322,42 +322,42 @@ exports[`topic area settings should match snapshot 1`] = `
                   </button>
                 </th>
                 <th>
-                  <span
-                    class="font-sans-xs"
-                  >
-                    Dashboards
-                  </span>
                   <button
                     aria-label="Sort by dashboard name"
-                    class="usa-button usa-button--unstyled margin-left-1 hover:text-base-light text-base-darker"
+                    class="usa-button usa-button--unstyled margin-left-1 hover:text-base-darker font-sans-md text-bold text-no-underline"
                   >
+                    <span
+                      class="margin-1"
+                    >
+                      Dashboards
+                    </span>
                     <svg
                       aria-hidden="true"
-                      class="svg-inline--fa fa-chevron-down fa-w-14 "
-                      data-icon="chevron-down"
+                      class="svg-inline--fa fa-chevron-circle-down fa-w-16 "
+                      data-icon="chevron-circle-down"
                       data-prefix="fas"
                       focusable="false"
                       role="img"
-                      viewBox="0 0 448 512"
+                      viewBox="0 0 512 512"
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
+                        d="M504 256c0 137-111 248-248 248S8 393 8 256 119 8 256 8s248 111 248 248zM273 369.9l135.5-135.5c9.4-9.4 9.4-24.6 0-33.9l-17-17c-9.4-9.4-24.6-9.4-33.9 0L256 285.1 154.4 183.5c-9.4-9.4-24.6-9.4-33.9 0l-17 17c-9.4 9.4-9.4 24.6 0 33.9L239 369.9c9.4 9.4 24.6 9.4 34 0z"
                         fill="currentColor"
                       />
                     </svg>
                   </button>
                 </th>
                 <th>
-                  <span
-                    class="font-sans-xs"
-                  >
-                    Created by
-                  </span>
                   <button
                     aria-label="Sort by created by name"
-                    class="usa-button usa-button--unstyled margin-left-1 hover:text-base-light text-white"
+                    class="usa-button usa-button--unstyled margin-left-1 hover:text-base-darker font-sans-md text-bold text-no-underline"
                   >
+                    <span
+                      class="margin-1"
+                    >
+                      Created by
+                    </span>
                     <svg
                       aria-hidden="true"
                       class="svg-inline--fa fa-chevron-down fa-w-14 "


### PR DESCRIPTION
## Description
Fix contrast for sorting buttons in tables

![image](https://user-images.githubusercontent.com/6969135/191330940-53c17403-3770-493c-b4ef-bdb5deb154b5.png)

## Testing

Describe how you tested your changes and/or give instructions to the reviewers on how they can verify them.

1- Go to https://d2h803e1awe3zo.cloudfront.net/admin/settings
2- Check the new style for sorting buttons
3- Verify title text also toggles the sorting
4- Active sorting should use inverted icon

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
