### PR TITLE
Accessibility issues on Main, Footer and RadioButton components addressed.

### DIFF
--- a/frontend/src/components/RadioButtons.tsx
+++ b/frontend/src/components/RadioButtons.tsx
@@ -33,7 +33,7 @@ function RadioButtons(props: Props) {
   };
 
   return (
-    <div role="radiogroup" className={formGroupClassName}>
+    <div className={formGroupClassName}>
       <fieldset className="usa-fieldset" onChange={handleChange}>
         <legend className="usa-sr-only">{props.label}</legend>
         <span className="usa-label text-bold">{props.label}</span>

--- a/frontend/src/components/__tests__/__snapshots__/RadioButtons.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/RadioButtons.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`renders an error 1`] = `
 <div>
   <div
     class="usa-form-group usa-form-group--error"
-    role="radiogroup"
   >
     <fieldset
       class="usa-fieldset"
@@ -59,7 +58,6 @@ exports[`renders radio buttons 1`] = `
 <div>
   <div
     class="usa-form-group"
-    role="radiogroup"
   >
     <fieldset
       class="usa-fieldset"

--- a/frontend/src/components/__tests__/__snapshots__/VisualizeChart.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/VisualizeChart.test.tsx.snap
@@ -66,7 +66,6 @@ exports[`renders the VisualizeChart component 1`] = `
           </div>
           <div
             class="usa-form-group"
-            role="radiogroup"
           >
             <fieldset
               class="usa-fieldset"
@@ -603,7 +602,6 @@ exports[`renders the VisualizeChart component without horizontal scrolling 1`] =
           </div>
           <div
             class="usa-form-group"
-            role="radiogroup"
           >
             <fieldset
               class="usa-fieldset"

--- a/frontend/src/containers/__tests__/__snapshots__/FourZeroFour.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/FourZeroFour.test.tsx.snap
@@ -31,9 +31,7 @@ exports[`renders a FourZeroFour component 1`] = `
       .
     </p>
   </div>
-  <footer
-    aria-label="Footer"
-  >
+  <footer>
     <div
       class="grid-container margin-bottom-9 text-base font-sans-sm"
     >

--- a/frontend/src/layouts/Admin.tsx
+++ b/frontend/src/layouts/Admin.tsx
@@ -166,7 +166,7 @@ function AdminLayout(props: LayoutProps) {
           </nav>
         </div>
       </Header>
-      <main className="padding-y-3" aria-label={t("ARIA.Main")}>
+      <main className="padding-y-3">
         <div id="main" tabIndex={-1}></div>
         {(!hasRole || isPublic) && <Redirect to="/403/access-denied" />}
         <div className="grid-container">{props.children}</div>

--- a/frontend/src/layouts/Footer.tsx
+++ b/frontend/src/layouts/Footer.tsx
@@ -8,7 +8,7 @@ function Footer() {
   const { t } = useTranslation();
 
   return (
-    <footer aria-label={t("ARIA.Footer")}>
+    <footer>
       <div className="grid-container margin-bottom-9 text-base font-sans-sm">
         {loadingSettings ? (
           ""

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1031,9 +1031,7 @@
   "CloseMenu": "Close Menu",
   "ARIA": {
     "Header": "Header",
-    "Main": "Main",
     "Logo": "Logo",
-    "Footer": "Footer",
     "OpenInNewTab": "(opens in a new tab)",
     "DraftDashboardActions": "Draft dashboard actions",
     "ViewDraftHistory": "View draft dashboard's history",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -1022,9 +1022,7 @@
   "CloseMenu": "Cerrar menú",
   "ARIA": {
     "Header": "Encabezado",
-    "Main": "Principal",
     "Logo": "Logotipo",
-    "Footer": "Pie de página",
     "OpenInNewTab": "(se abre en una pestaña nueva)",
     "DraftDashboardActions": "Borrador de acciones del panel",
     "ViewDraftHistory": "Ver historial del borrador del panel",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -1022,9 +1022,7 @@
   "CloseMenu": "Fechar menu",
   "ARIA": {
     "Header": "Cabeçalho",
-    "Main": "Principal",
     "Logo": "Logotipo",
-    "Footer": "Rodapé",
     "OpenInNewTab": "(abre em uma nova guia)",
     "DraftDashboardActions": "Rascunhar ações do painel",
     "ViewDraftHistory": "Visualizar o histórico do painel de rascunho",


### PR DESCRIPTION


## Description

a. Main and Footer

Main and footer elements with redundant accessible names. The information of "Main" and "Footer" is already given by these elements' implicit roles. Remove the aria-label attributes from these elements.

b. RadioButton

Radio buttons - Unnecessary `<div role="radiogroup">`. `<fieldset>` with a first child of a non-empty `<legend>` element is sufficient to communicate the grouping information, so `role="radiogroup"` is not necessary.

## Testing

Describe how you tested your changes and/or give instructions to the reviewers on how they can verify them.

a. Main and Footer

1. Go to https://d2zdyv8kmq5ffn.cloudfront.net/admin
2. Inspect the `<main>` and `<footer>` elements and verify that the `aria-label` attributes have been removed.

b. RadioButton

1. Go to https://d2zdyv8kmq5ffn.cloudfront.net/admin/dashboard/a2eb7bec-a8fc-4055-9d49-669dd178e540/edit-chart/0828b98e-6fca-496d-8716-7f4a9b09ffd6
2. Inspect the "RadioButton" component under chart type section and verify the `<div class="usa-form-group">` element doesn’t have the `role="radiogroup"` attribute attached to it.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
