### PR TITLE
Accessibility issues in Topic Area listing table actions were addressed

### DIFF
--- a/frontend/src/components/MarkdownRender.tsx
+++ b/frontend/src/components/MarkdownRender.tsx
@@ -10,15 +10,7 @@ type MarkdownRenderProps = {
 const MarkdownRender = (props: MarkdownRenderProps) => {
   return (
     <ReactMarkdown
-      allowedTypes={[
-        "link",
-        "list",
-        "listItem",
-        "paragraph",
-        "strong",
-        "text",
-        "heading",
-      ]}
+      allowedTypes={["link", "list", "listItem", "paragraph", "strong", "text"]}
       linkTarget="_blank"
       className={`Markdown ${props.className}`}
       source={props.source || ""}

--- a/frontend/src/containers/EditDashboard.tsx
+++ b/frontend/src/containers/EditDashboard.tsx
@@ -230,21 +230,17 @@ function EditDashboard() {
           </div>
           <div className="grid-col-6 padding-left-05">
             <span data-for="publish" data-tip="">
-              <Button variant="base" onClick={onPublishDashboard}>
+              <Button
+                variant="base"
+                aria-describedby="publish-desc"
+                onClick={onPublishDashboard}
+              >
                 {t("PublishButton")}
               </Button>
+              <span id="publish-desc" className="usa-sr-only">
+                {t("PrepareDashboardForPublishing")}
+              </span>
             </span>
-            <Tooltip
-              id="publish"
-              place="bottom"
-              effect="solid"
-              offset={{ bottom: 8 }}
-              getContent={() => (
-                <div className="font-sans-sm">
-                  {t("PrepareDashboardForPublishing")}
-                </div>
-              )}
-            />
           </div>
         </div>
       )}
@@ -258,21 +254,17 @@ function EditDashboard() {
             {t("PreviewButton")}
           </Button>
           <span data-for="publish" data-tip="">
-            <Button variant="base" onClick={onPublishDashboard}>
+            <Button
+              variant="base"
+              aria-describedby="publish-desc"
+              onClick={onPublishDashboard}
+            >
               {t("PublishButton")}
             </Button>
+            <span id="publish-desc" className="usa-sr-only">
+              {t("PrepareDashboardForPublishing")}
+            </span>
           </span>
-          <Tooltip
-            id="publish"
-            place="bottom"
-            effect="solid"
-            offset={{ bottom: 8 }}
-            getContent={() => (
-              <div className="font-sans-sm">
-                {t("PrepareDashboardForPublishing")}
-              </div>
-            )}
-          />
         </>
       )}
     </>

--- a/frontend/src/containers/MarkdownSyntax.tsx
+++ b/frontend/src/containers/MarkdownSyntax.tsx
@@ -10,27 +10,6 @@ const MarkdownSyntax = () => {
       <h1>{t("MarkdownSyntax.Label")}</h1>
       <p className="font-sans-lg">{t("MarkdownSyntax.Description")}</p>
 
-      <h2 className="margin-top-5">{t("MarkdownSyntax.Heading")}</h2>
-      <p>{t("MarkdownSyntax.HeadingDescription")}</p>
-      <table className="usa-table usa-table--borderless" width="100%">
-        <thead>
-          <tr>
-            <th style={{ width: "50%" }}>{t("MarkdownSyntax.Markdown")}</th>
-            <th style={{ width: "50%" }}>
-              {t("MarkdownSyntax.RenderedOutput")}
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>{t("MarkdownSyntax.ILoveHeadingText")}</td>
-            <td>
-              <MarkdownRender source={t("MarkdownSyntax.ILoveHeadingText")} />
-            </td>
-          </tr>
-        </tbody>
-      </table>
-
       <h2 className="margin-top-5">{t("MarkdownSyntax.Bold")}</h2>
       <p>{t("MarkdownSyntax.BoldDescription")}</p>
       <table className="usa-table usa-table--borderless" width="100%">

--- a/frontend/src/containers/TopicareaListing.tsx
+++ b/frontend/src/containers/TopicareaListing.tsx
@@ -8,7 +8,9 @@ import { useHistory } from "react-router-dom";
 import Tooltip from "../components/Tooltip";
 import { useSettings } from "../hooks";
 import { useTranslation } from "react-i18next";
+import DropdownMenu from "../components/DropdownMenu";
 
+const MenuItem = DropdownMenu.MenuItem;
 interface Props {
   topicareas: Array<TopicArea>;
   reloadTopicAreas: Function;
@@ -107,43 +109,34 @@ function TopicareaListing(props: Props) {
       <h2 id="section-heading-h3">{`${t("TopicArea", {
         count: props.topicareas.length,
       })} (${props.topicareas.length})`}</h2>
+      <div className="font-sans-sm">
+        <p className="margin-y-0">{t("TopicAreaListingDescription")}</p>
+      </div>
       <div className="grid-row margin-y-3">
         <div className="tablet:grid-col-12 text-right">
-          <span
-            className="text-underline"
-            data-for="delete"
-            data-tip=""
-            data-border={true}
-          >
-            <span>
-              <Button
-                variant="outline"
+          <span>
+            <DropdownMenu
+              buttonText={t("Actions")}
+              variant="outline"
+              ariaLabel={t("ARIA.TopicAreaListingActions")}
+            >
+              <MenuItem
+                onSelect={() => onDeleteTopicArea()}
                 disabled={!selected || selected.dashboardCount > 0}
-                onClick={() => onDeleteTopicArea()}
+                aria-label={t("ARIA.TopicAreaListingDelete")}
               >
                 {t("Delete")}
-              </Button>
-            </span>
-          </span>
-          {selected && selected.dashboardCount > 0 && (
-            <Tooltip
-              id="delete"
-              place="bottom"
-              effect="solid"
-              offset={{ bottom: 8 }}
-              getContent={() => (
-                <div className="font-sans-sm">
-                  <p className="margin-y-0">
-                    {t("OnlyEmptyTopicAreasCanBeDeleted")}
-                  </p>
-                </div>
-              )}
-            />
-          )}
-          <span>
-            <Button variant="outline" disabled={!selected} onClick={onEdit}>
-              {t("Edit")}
-            </Button>
+              </MenuItem>
+
+              <MenuItem
+                onSelect={onEdit}
+                disabled={!selected}
+                title={t("Edit")}
+                aria-label={t("ARIA.TopicAreaListingEdit")}
+              >
+                {t("Edit")}
+              </MenuItem>
+            </DropdownMenu>
           </span>
           <span>
             <Button testid={"createtopicarea"} onClick={createTopicArea}>

--- a/frontend/src/containers/__tests__/TopicareaListing.test.tsx
+++ b/frontend/src/containers/__tests__/TopicareaListing.test.tsx
@@ -1,19 +1,36 @@
 import React from "react";
-import { render, fireEvent, act } from "@testing-library/react";
+import { render, fireEvent, act, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import TopicareaListing from "../TopicareaListing";
+import userEvent from "@testing-library/user-event";
+import BackendService from "../../services/BackendService";
 
 jest.mock("../../hooks");
+jest.mock("../../services/BackendService");
 
-test("renders a button to delete", async () => {
-  const { getByRole } = render(
-    <TopicareaListing topicareas={[]} reloadTopicAreas={() => {}} />,
-    {
-      wrapper: MemoryRouter,
-    }
-  );
-  const button = getByRole("button", { name: "Delete" });
-  expect(button).toBeInTheDocument();
+test("renders the dropdown menu", () => {
+  render(<TopicareaListing topicareas={[]} reloadTopicAreas={() => {}} />, {
+    wrapper: MemoryRouter,
+  });
+  expect(screen.getByText("Actions")).toBeInTheDocument();
+});
+
+test("dropdown menu expands when clicked", () => {
+  render(<TopicareaListing topicareas={[]} reloadTopicAreas={() => {}} />, {
+    wrapper: MemoryRouter,
+  });
+  userEvent.click(screen.getByText("Actions"));
+  expect(screen.getByText("Delete")).toBeInTheDocument();
+  expect(screen.getByText("Edit")).toBeInTheDocument();
+});
+
+test("dropdown menu options are disabled when there is no selection", () => {
+  render(<TopicareaListing topicareas={[]} reloadTopicAreas={() => {}} />, {
+    wrapper: MemoryRouter,
+  });
+  userEvent.click(screen.getByText("Actions"));
+  expect(screen.getByText("Delete")).toHaveAttribute("aria-disabled", "true");
+  expect(screen.getByText("Edit")).toHaveAttribute("aria-disabled", "true");
 });
 
 test("renders a button to create topic area", async () => {
@@ -56,4 +73,68 @@ test("renders a topic area table", async () => {
 
   const topicarea2 = getByLabelText("Topic Area Grapes");
   expect(topicarea2).toBeInTheDocument();
+});
+
+test("dropdown menu delete option deletes a selected topic area without dashboards", async () => {
+  const { getByLabelText } = render(
+    <TopicareaListing
+      topicareas={[
+        {
+          id: "123456789",
+          name: "Topic Area Bananas",
+          createdBy: "test user 1",
+          dashboardCount: 0,
+        },
+      ]}
+      reloadTopicAreas={() => {}}
+    />,
+    {
+      wrapper: MemoryRouter,
+    }
+  );
+  // First select user from the table
+  const checkbox = screen.getByRole("radio", { name: "Topic Area Bananas" });
+  fireEvent.click(checkbox);
+
+  // Click remove users button
+  userEvent.click(screen.getByText("Actions"));
+  userEvent.click(screen.getByText("Delete"));
+
+  // Wait for confirmation modal to show
+  await screen.findByText("Are you sure you want to delete this topic area?");
+  const deleteButton = screen.getByRole("button", { name: "Delete" });
+  await act(async () => {
+    fireEvent.click(deleteButton);
+  });
+
+  //  Verify backend service gets called
+  expect(BackendService.deleteTopicArea).toBeCalledWith("123456789");
+});
+
+test("dropdown menu delete option is disabled when the selected topic area has at least one dashboard", async () => {
+  const { getByLabelText } = render(
+    <TopicareaListing
+      topicareas={[
+        {
+          id: "123456789",
+          name: "Topic Area Bananas",
+          createdBy: "test user 1",
+          dashboardCount: 1,
+        },
+      ]}
+      reloadTopicAreas={() => {}}
+    />,
+    {
+      wrapper: MemoryRouter,
+    }
+  );
+  // First select user from the table
+  const checkbox = screen.getByRole("radio", { name: "Topic Area Bananas" });
+  fireEvent.click(checkbox);
+
+  userEvent.click(screen.getByText("Actions"));
+  expect(screen.getByText("Delete")).toHaveAttribute("aria-disabled", "true");
+
+  //  Verify backend service gets called
+  expect(BackendService.deleteTopicArea).toBeCalledTimes(0);
 });

--- a/frontend/src/containers/__tests__/TopicareaSettings.test.tsx
+++ b/frontend/src/containers/__tests__/TopicareaSettings.test.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { render, fireEvent, act, getByText } from "@testing-library/react";
+import {
+  render,
+  fireEvent,
+  act,
+  getByText,
+  screen,
+} from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import TopicareaSettings from "../TopicareaSettings";
 
@@ -57,13 +63,12 @@ test("render single topic area name header", async () => {
   expect(getByText("Single topic area name")).toBeInTheDocument();
 });
 
-test("renders two edit buttons, one for the topci area label, another for the topic areas", async () => {
+test("renders an edit button for the topci area label", async () => {
   const { getAllByRole } = render(<TopicareaSettings />, {
     wrapper: MemoryRouter,
   });
   const button = getAllByRole("button", { name: "Edit" });
   expect(button[0]).toBeInTheDocument();
-  expect(button[1]).toBeInTheDocument();
 });
 
 test("render multiple topic areas name header", async () => {
@@ -73,12 +78,11 @@ test("render multiple topic areas name header", async () => {
   expect(getByText("Multiple topic areas name")).toBeInTheDocument();
 });
 
-test("renders a button to delete", async () => {
+test("renders the dropdown menu", async () => {
   const { getByRole } = render(<TopicareaSettings />, {
     wrapper: MemoryRouter,
   });
-  const button = getByRole("button", { name: "Delete" });
-  expect(button).toBeInTheDocument();
+  expect(screen.getByText("Actions")).toBeInTheDocument();
 });
 
 test("renders a button to create topic area", async () => {

--- a/frontend/src/containers/__tests__/__snapshots__/MarkdownSyntax.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/MarkdownSyntax.test.tsx.snap
@@ -13,49 +13,6 @@ exports[`renders the markdown syntax component 1`] = `
   <h2
     class="margin-top-5"
   >
-    Heading
-  </h2>
-  <p>
-    To create headings, add the number sign from one (#) up to six (######) ocurrences and space in front of the line.
-  </p>
-  <table
-    class="usa-table usa-table--borderless"
-    width="100%"
-  >
-    <thead>
-      <tr>
-        <th
-          style="width: 50%;"
-        >
-          Markdown
-        </th>
-        <th
-          style="width: 50%;"
-        >
-          Rendered output
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>
-          ### I love heading text
-        </td>
-        <td>
-          <div
-            class="Markdown undefined"
-          >
-            <h3>
-              I love heading text
-            </h3>
-          </div>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-  <h2
-    class="margin-top-5"
-  >
     Bold
   </h2>
   <p>

--- a/frontend/src/containers/__tests__/__snapshots__/TopicareaSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/TopicareaSettings.test.tsx.snap
@@ -249,32 +249,46 @@ exports[`topic area settings should match snapshot 1`] = `
             Topic areas (2)
           </h2>
           <div
+            class="font-sans-sm"
+          >
+            <p
+              class="margin-y-0"
+            >
+              These are all of the topic areas. You can add, edit and delete it, but you can only delete topic areas without dashboards.
+            </p>
+          </div>
+          <div
             class="grid-row margin-y-3"
           >
             <div
               class="tablet:grid-col-12 text-right"
             >
-              <span
-                class="text-underline"
-                data-border="true"
-                data-for="delete"
-                data-tip=""
-              >
-                <span>
-                  <button
-                    class="usa-button usa-button--outline"
-                    disabled=""
-                  >
-                    Delete
-                  </button>
-                </span>
-              </span>
               <span>
                 <button
+                  aria-controls="menu--57"
+                  aria-haspopup="true"
+                  aria-label="Topic area listing actions"
                   class="usa-button usa-button--outline"
-                  disabled=""
+                  data-reach-menu-button=""
+                  id="menu-button--menu--57"
+                  type="button"
                 >
-                  Edit
+                  Actions
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-caret-down fa-w-10 margin-left-1"
+                    data-icon="caret-down"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 320 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      fill="currentColor"
+                    />
+                  </svg>
                 </button>
               </span>
               <span>

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -880,9 +880,6 @@
   "MarkdownSyntax": {
     "Label": "Markdown Syntax",
     "Description": "Supported Markdown is limited to bold, hyperlinks and single-level unordered lists. All other text and markdown will be rendered as plain text.",
-    "Heading": "Heading",
-    "HeadingDescription": "To create headings, add the number sign from one (#) up to six (######) ocurrences and space in front of the line.",
-    "ILoveHeadingText": "### I love heading text",
     "Bold": "Bold",
     "BoldDescription": "To bold text, add two asterisks or underscores before and after a word or phrase. To bold the middle of a word for emphasis, add two asterisks without spaces around the letters.",
     "Markdown": "Markdown",
@@ -1031,7 +1028,7 @@
   "SortTopicAreaName": "Sort by topic area name",
   "DeleteTopicArea": "Delete {{name}} topic area?",
   "ConfirmDeleteTopicArea": "Are you sure you want to delete this topic area?",
-  "OnlyEmptyTopicAreasCanBeDeleted": "You can only delete topic areas without dashboards.",
+  "TopicAreaListingDescription": "These are all of the topic areas. You can add, edit and delete it, but you can only delete topic areas without dashboards.",
   "CloseMenu": "Close Menu",
   "ARIA": {
     "Header": "Header",
@@ -1061,7 +1058,10 @@
     "MoveUp": "Move {{metric}} up",
     "MoveDown": "Move {{metric}} down",
     "PreviewDashboard": "Preview dashboard",
-    "DataTableActions": "Data table actions"
+    "DataTableActions": "Data table actions",
+    "TopicAreaListingActions": "Topic area listing actions",
+    "TopicAreaListingDelete": "Delete topic area",
+    "TopicAreaListingEdit": "Edit topic area"
   },
   "percentage": "{{pct}}%",
   "Search": {


### PR DESCRIPTION
## Description

a. Topic area listing table actions.
 * The layout was upgraded to a `DropdownMenu` component to group the actions. `Unit tests` were included.
 * The on hovering tooltip attached to the disable `Delete` button was removed in lieu of a descriptive tex always visible under the `Topic Areas` table's title.

b. On hover tooltip on `Publish` button.
* The on hovering tooltip attached to the `Publish` button was removed in lieu of a screen reader only text upon an offline synch up with `Tanner`and `Miguel` because of the button text it's self-descriptive.

c. Heading markup ability was removed from the `MarkdownRender` component.
* Synched offline with `Miguel` we decided to rollback it.


## Testing

Describe how you tested your changes and/or give instructions to the reviewers on how they can verify them.

a. Topic area listing table actions.

1. Go to https://d2zdyv8kmq5ffn.cloudfront.net/admin/settings/topicarea
2. Review the correct rendering of the table actions and the descriptive text in the web browser.

b. On hover tooltip on `Publish` button.

1. Go to https://d2zdyv8kmq5ffn.cloudfront.net/admin/dashboard/edit/a2eb7bec-a8fc-4055-9d49-669dd178e540
2. Confirm that the on hovering tooltip attached to the `Publish` button has been removed

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
