### PR TITLE
Miguel.abreu/gtt 2013 fix aria preview button

### DIFF
--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -29,6 +29,8 @@ interface Props {
     | "location"
     | "date"
     | undefined;
+  ariaExpanded?: boolean;
+  ariaControls?: string;
   disabledToolTip?: string;
 }
 
@@ -65,6 +67,8 @@ const Button = React.forwardRef<HTMLButtonElement, Props>((props, ref) => {
       data-testid={props.testid}
       aria-label={props.ariaLabel}
       aria-current={props.ariaCurrent}
+      aria-expanded={props.ariaExpanded}
+      aria-controls={props.ariaControls}
       className={`usa-button${variantClassName}${additionalClasses}`}
       disabled={props.disabled}
       ref={ref}

--- a/frontend/src/components/VisualizeChart.tsx
+++ b/frontend/src/components/VisualizeChart.tsx
@@ -35,6 +35,7 @@ interface Props {
   fileLoading: boolean;
   processingWidget: boolean;
   fullPreviewButton: JSX.Element;
+  previewPanelId: string;
   fullPreview: boolean;
   submitButtonLabel: string;
   sortByColumn?: string;
@@ -391,161 +392,163 @@ function VisualizeChart(props: Props) {
           }`}
         >
           {isMobile ? <br /> : props.fullPreviewButton}
-          {props.datasetLoading ? (
-            <Spinner
-              className="text-center margin-top-6"
-              label={t("LoadingSpinnerLabel")}
-            />
-          ) : (
-            <>
-              {showAlert &&
-              props.datasetType === DatasetType.StaticDataset &&
-              props.csvJson.length ? (
-                <Alert
-                  type="info"
-                  message={
-                    <div className="grid-row margin-left-6">
-                      <div className="grid-col-11">
-                        {t("VisualizeChartComponent.ChartCorrectDisplay")}{" "}
-                        <Link to="/admin/formatting" target="_blank" external>
-                          {t("LearnHowToFormatCSV")}
-                        </Link>
-                      </div>
-                      <div className="grid-col-1">
-                        <div className="margin-1">
-                          <Button
-                            variant="unstyled"
-                            className="margin-0-important text-base-dark hover:text-base-darker active:text-base-darkest"
-                            onClick={() => setShowAlert(false)}
-                            type="button"
-                            ariaLabel={t("GlobalClose")}
-                          >
-                            <FontAwesomeIcon icon={faTimes} size="sm" />
-                          </Button>
+          <div id={props.previewPanelId}>
+            {props.datasetLoading ? (
+              <Spinner
+                className="text-center margin-top-6"
+                label={t("LoadingSpinnerLabel")}
+              />
+            ) : (
+              <>
+                {showAlert &&
+                props.datasetType === DatasetType.StaticDataset &&
+                props.csvJson.length ? (
+                  <Alert
+                    type="info"
+                    message={
+                      <div className="grid-row margin-left-6">
+                        <div className="grid-col-11">
+                          {t("VisualizeChartComponent.ChartCorrectDisplay")}{" "}
+                          <Link to="/admin/formatting" target="_blank" external>
+                            {t("LearnHowToFormatCSV")}
+                          </Link>
+                        </div>
+                        <div className="grid-col-1">
+                          <div className="margin-1">
+                            <Button
+                              variant="unstyled"
+                              className="margin-0-important text-base-dark hover:text-base-darker active:text-base-darkest"
+                              onClick={() => setShowAlert(false)}
+                              type="button"
+                              ariaLabel={t("GlobalClose")}
+                            >
+                              <FontAwesomeIcon icon={faTimes} size="sm" />
+                            </Button>
+                          </div>
                         </div>
                       </div>
-                    </div>
-                  }
-                  slim
-                />
-              ) : (
-                ""
-              )}
-              {props.chartType === ChartType.LineChart && (
-                <LineChartWidget
-                  title={props.showTitle ? props.title : ""}
-                  downloadTitle={props.title}
-                  summary={props.summary}
-                  lines={
-                    props.json.length
-                      ? (Object.keys(props.json[0]) as Array<string>)
-                      : []
-                  }
-                  data={props.json}
-                  summaryBelow={props.summaryBelow}
-                  isPreview={!props.fullPreview}
-                  horizontalScroll={props.horizontalScroll}
-                  setWidthPercent={setWidthPercent}
-                  significantDigitLabels={props.significantDigitLabels}
-                  columnsMetadata={props.columnsMetadata}
-                />
-              )}
-              {props.chartType === ChartType.ColumnChart && (
-                <ColumnChartWidget
-                  title={props.showTitle ? props.title : ""}
-                  downloadTitle={props.title}
-                  summary={props.summary}
-                  columns={
-                    props.json.length
-                      ? (Object.keys(props.json[0]) as Array<string>)
-                      : []
-                  }
-                  data={props.json}
-                  summaryBelow={props.summaryBelow}
-                  isPreview={!props.fullPreview}
-                  horizontalScroll={props.horizontalScroll}
-                  stackedChart={props.stackedChart}
-                  setWidthPercent={setWidthPercent}
-                  significantDigitLabels={props.significantDigitLabels}
-                  columnsMetadata={props.columnsMetadata || []}
-                  hideDataLabels={!props.dataLabels}
-                />
-              )}
-              {props.chartType === ChartType.BarChart && (
-                <BarChartWidget
-                  title={props.showTitle ? props.title : ""}
-                  downloadTitle={props.title}
-                  summary={props.summary}
-                  bars={
-                    props.json.length
-                      ? (Object.keys(props.json[0]) as Array<string>)
-                      : []
-                  }
-                  data={props.json}
-                  summaryBelow={props.summaryBelow}
-                  significantDigitLabels={props.significantDigitLabels}
-                  columnsMetadata={props.columnsMetadata || []}
-                  hideDataLabels={!props.dataLabels}
-                  stackedChart={props.stackedChart}
-                />
-              )}
-              {props.chartType === ChartType.PartWholeChart && (
-                <PartWholeChartWidget
-                  title={props.showTitle ? props.title : ""}
-                  downloadTitle={props.title}
-                  summary={props.summary}
-                  parts={
-                    props.json.length
-                      ? (Object.keys(props.json[0]) as Array<string>)
-                      : []
-                  }
-                  data={props.json}
-                  summaryBelow={props.summaryBelow}
-                  significantDigitLabels={props.significantDigitLabels}
-                  columnsMetadata={props.columnsMetadata}
-                />
-              )}
-              {props.chartType === ChartType.PieChart && (
-                <PieChartWidget
-                  title={props.showTitle ? props.title : ""}
-                  downloadTitle={props.title}
-                  summary={props.summary}
-                  parts={
-                    props.json.length
-                      ? (Object.keys(props.json[0]) as Array<string>)
-                      : []
-                  }
-                  data={props.json}
-                  summaryBelow={props.summaryBelow}
-                  significantDigitLabels={props.significantDigitLabels}
-                  hideDataLabels={!props.dataLabels}
-                  isPreview={!props.fullPreview}
-                  columnsMetadata={props.columnsMetadata}
-                  computePercentages={props.computePercentages}
-                />
-              )}
-              {props.chartType === ChartType.DonutChart && (
-                <DonutChartWidget
-                  title={props.showTitle ? props.title : ""}
-                  downloadTitle={props.title}
-                  summary={props.summary}
-                  parts={
-                    props.json.length
-                      ? (Object.keys(props.json[0]) as Array<string>)
-                      : []
-                  }
-                  data={props.json}
-                  summaryBelow={props.summaryBelow}
-                  significantDigitLabels={props.significantDigitLabels}
-                  hideDataLabels={!props.dataLabels}
-                  showTotal={props.showTotal}
-                  isPreview={!props.fullPreview}
-                  columnsMetadata={props.columnsMetadata}
-                  computePercentages={props.computePercentages}
-                />
-              )}
-            </>
-          )}
+                    }
+                    slim
+                  />
+                ) : (
+                  ""
+                )}
+                {props.chartType === ChartType.LineChart && (
+                  <LineChartWidget
+                    title={props.showTitle ? props.title : ""}
+                    downloadTitle={props.title}
+                    summary={props.summary}
+                    lines={
+                      props.json.length
+                        ? (Object.keys(props.json[0]) as Array<string>)
+                        : []
+                    }
+                    data={props.json}
+                    summaryBelow={props.summaryBelow}
+                    isPreview={!props.fullPreview}
+                    horizontalScroll={props.horizontalScroll}
+                    setWidthPercent={setWidthPercent}
+                    significantDigitLabels={props.significantDigitLabels}
+                    columnsMetadata={props.columnsMetadata}
+                  />
+                )}
+                {props.chartType === ChartType.ColumnChart && (
+                  <ColumnChartWidget
+                    title={props.showTitle ? props.title : ""}
+                    downloadTitle={props.title}
+                    summary={props.summary}
+                    columns={
+                      props.json.length
+                        ? (Object.keys(props.json[0]) as Array<string>)
+                        : []
+                    }
+                    data={props.json}
+                    summaryBelow={props.summaryBelow}
+                    isPreview={!props.fullPreview}
+                    horizontalScroll={props.horizontalScroll}
+                    stackedChart={props.stackedChart}
+                    setWidthPercent={setWidthPercent}
+                    significantDigitLabels={props.significantDigitLabels}
+                    columnsMetadata={props.columnsMetadata || []}
+                    hideDataLabels={!props.dataLabels}
+                  />
+                )}
+                {props.chartType === ChartType.BarChart && (
+                  <BarChartWidget
+                    title={props.showTitle ? props.title : ""}
+                    downloadTitle={props.title}
+                    summary={props.summary}
+                    bars={
+                      props.json.length
+                        ? (Object.keys(props.json[0]) as Array<string>)
+                        : []
+                    }
+                    data={props.json}
+                    summaryBelow={props.summaryBelow}
+                    significantDigitLabels={props.significantDigitLabels}
+                    columnsMetadata={props.columnsMetadata || []}
+                    hideDataLabels={!props.dataLabels}
+                    stackedChart={props.stackedChart}
+                  />
+                )}
+                {props.chartType === ChartType.PartWholeChart && (
+                  <PartWholeChartWidget
+                    title={props.showTitle ? props.title : ""}
+                    downloadTitle={props.title}
+                    summary={props.summary}
+                    parts={
+                      props.json.length
+                        ? (Object.keys(props.json[0]) as Array<string>)
+                        : []
+                    }
+                    data={props.json}
+                    summaryBelow={props.summaryBelow}
+                    significantDigitLabels={props.significantDigitLabels}
+                    columnsMetadata={props.columnsMetadata}
+                  />
+                )}
+                {props.chartType === ChartType.PieChart && (
+                  <PieChartWidget
+                    title={props.showTitle ? props.title : ""}
+                    downloadTitle={props.title}
+                    summary={props.summary}
+                    parts={
+                      props.json.length
+                        ? (Object.keys(props.json[0]) as Array<string>)
+                        : []
+                    }
+                    data={props.json}
+                    summaryBelow={props.summaryBelow}
+                    significantDigitLabels={props.significantDigitLabels}
+                    hideDataLabels={!props.dataLabels}
+                    isPreview={!props.fullPreview}
+                    columnsMetadata={props.columnsMetadata}
+                    computePercentages={props.computePercentages}
+                  />
+                )}
+                {props.chartType === ChartType.DonutChart && (
+                  <DonutChartWidget
+                    title={props.showTitle ? props.title : ""}
+                    downloadTitle={props.title}
+                    summary={props.summary}
+                    parts={
+                      props.json.length
+                        ? (Object.keys(props.json[0]) as Array<string>)
+                        : []
+                    }
+                    data={props.json}
+                    summaryBelow={props.summaryBelow}
+                    significantDigitLabels={props.significantDigitLabels}
+                    hideDataLabels={!props.dataLabels}
+                    showTotal={props.showTotal}
+                    isPreview={!props.fullPreview}
+                    columnsMetadata={props.columnsMetadata}
+                    computePercentages={props.computePercentages}
+                  />
+                )}
+              </>
+            )}
+          </div>
         </div>
       </section>
     </div>

--- a/frontend/src/components/VisualizeTable.tsx
+++ b/frontend/src/components/VisualizeTable.tsx
@@ -30,6 +30,7 @@ interface Props {
   processingWidget: boolean;
   fullPreviewButton: JSX.Element;
   fullPreview: boolean;
+  previewPanelId: string;
   submitButtonLabel: string;
   sortByColumn?: string;
   sortByDesc?: boolean;
@@ -249,59 +250,61 @@ function VisualizeTable(props: Props) {
           }`}
         >
           {isMobile ? <br /> : props.fullPreviewButton}
-          {props.datasetLoading ? (
-            <Spinner
-              className="text-center margin-top-6"
-              label={t("LoadingSpinnerLabel")}
-            />
-          ) : (
-            <>
-              {showAlert &&
-              props.datasetType === DatasetType.StaticDataset &&
-              props.csvJson.length ? (
-                <Alert
-                  type="info"
-                  message={
-                    <div className="grid-row margin-left-6">
-                      <div className="grid-col-11">
-                        {t("VisualizeTableComponent.TableCorrectDisplay")}{" "}
-                        <Link to="/admin/formatting" target="_blank" external>
-                          {t("LearnHowToFormatCSV")}
-                        </Link>
-                      </div>
-                      <div className="grid-col-1">
-                        <div className="margin-1">
-                          <Button
-                            variant="unstyled"
-                            className="margin-0-important text-base-dark hover:text-base-darker active:text-base-darkest"
-                            onClick={() => setShowAlert(false)}
-                            type="button"
-                            ariaLabel={t("GlobalClose")}
-                          >
-                            <FontAwesomeIcon icon={faTimes} size="sm" />
-                          </Button>
+          <div id={props.previewPanelId}>
+            {props.datasetLoading ? (
+              <Spinner
+                className="text-center margin-top-6"
+                label={t("LoadingSpinnerLabel")}
+              />
+            ) : (
+              <>
+                {showAlert &&
+                props.datasetType === DatasetType.StaticDataset &&
+                props.csvJson.length ? (
+                  <Alert
+                    type="info"
+                    message={
+                      <div className="grid-row margin-left-6">
+                        <div className="grid-col-11">
+                          {t("VisualizeTableComponent.TableCorrectDisplay")}{" "}
+                          <Link to="/admin/formatting" target="_blank" external>
+                            {t("LearnHowToFormatCSV")}
+                          </Link>
+                        </div>
+                        <div className="grid-col-1">
+                          <div className="margin-1">
+                            <Button
+                              variant="unstyled"
+                              className="margin-0-important text-base-dark hover:text-base-darker active:text-base-darkest"
+                              onClick={() => setShowAlert(false)}
+                              type="button"
+                              ariaLabel={t("GlobalClose")}
+                            >
+                              <FontAwesomeIcon icon={faTimes} size="sm" />
+                            </Button>
+                          </div>
                         </div>
                       </div>
-                    </div>
-                  }
-                  slim
+                    }
+                    slim
+                  />
+                ) : (
+                  ""
+                )}
+                <TableWidget
+                  title={props.showTitle ? props.title : ""}
+                  summary={props.summary}
+                  summaryBelow={props.summaryBelow}
+                  data={props.json}
+                  columnsMetadata={props.columnsMetadata}
+                  sortByColumn={props.sortByColumn}
+                  sortByDesc={props.sortByDesc}
+                  significantDigitLabels={props.significantDigitLabels}
+                  displayWithPages={props.displayWithPages}
                 />
-              ) : (
-                ""
-              )}
-              <TableWidget
-                title={props.showTitle ? props.title : ""}
-                summary={props.summary}
-                summaryBelow={props.summaryBelow}
-                data={props.json}
-                columnsMetadata={props.columnsMetadata}
-                sortByColumn={props.sortByColumn}
-                sortByDesc={props.sortByDesc}
-                significantDigitLabels={props.significantDigitLabels}
-                displayWithPages={props.displayWithPages}
-              />
-            </>
-          )}
+              </>
+            )}
+          </div>
         </div>
       </section>
     </div>

--- a/frontend/src/components/__tests__/__snapshots__/VisualizeChart.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/VisualizeChart.test.tsx.snap
@@ -475,63 +475,65 @@ exports[`renders the VisualizeChart component 1`] = `
         >
           Full preview
         </button>
-        
-        <div
-          aria-label="title"
-          class="overflow-x-hidden overflow-y-hidden"
-          tabindex="-1"
-        >
-          <h2
-            class="margin-bottom-1"
-          >
-            title
-          </h2>
+        <div>
+          
           <div
-            class="Markdown usa-prose margin-top-0 margin-bottom-4 chartSummaryAbove textOrSummary"
+            aria-label="title"
+            class="overflow-x-hidden overflow-y-hidden"
+            tabindex="-1"
           >
-            <p>
-              summary
-            </p>
-          </div>
-          <div
-            aria-hidden="true"
-          >
-            <div
-              class="recharts-responsive-container"
-              id="title"
-              style="width: 100%; height: 300px;"
-            />
-          </div>
-          <div>
-            <div
-              class="text-right margin-right-05"
+            <h2
+              class="margin-bottom-1"
             >
-              <button
-                aria-controls="menu--1"
-                aria-haspopup="true"
-                aria-label="Data table actions"
-                class="usa-button usa-button--unstyled text-base"
-                data-reach-menu-button=""
-                id="menu-button--menu--1"
-                type="button"
+              title
+            </h2>
+            <div
+              class="Markdown usa-prose margin-top-0 margin-bottom-4 chartSummaryAbove textOrSummary"
+            >
+              <p>
+                summary
+              </p>
+            </div>
+            <div
+              aria-hidden="true"
+            >
+              <div
+                class="recharts-responsive-container"
+                id="title"
+                style="width: 100%; height: 300px;"
+              />
+            </div>
+            <div>
+              <div
+                class="text-right margin-right-05"
               >
-                Actions
-                <svg
-                  aria-hidden="true"
-                  class="svg-inline--fa fa-caret-down fa-w-10 margin-left-1"
-                  data-icon="caret-down"
-                  data-prefix="fas"
-                  focusable="false"
-                  role="img"
-                  viewBox="0 0 320 512"
-                  xmlns="http://www.w3.org/2000/svg"
+                <button
+                  aria-controls="menu--1"
+                  aria-haspopup="true"
+                  aria-label="Data table actions"
+                  class="usa-button usa-button--unstyled text-base"
+                  data-reach-menu-button=""
+                  id="menu-button--menu--1"
+                  type="button"
                 >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </button>
+                  Actions
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-caret-down fa-w-10 margin-left-1"
+                    data-icon="caret-down"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 320 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -1015,63 +1017,65 @@ exports[`renders the VisualizeChart component without horizontal scrolling 1`] =
         >
           Full preview
         </button>
-        
-        <div
-          aria-label="title"
-          class="overflow-x-hidden overflow-y-hidden"
-          tabindex="-1"
-        >
-          <h2
-            class="margin-bottom-1"
-          >
-            title
-          </h2>
+        <div>
+          
           <div
-            class="Markdown usa-prose margin-top-0 margin-bottom-4 chartSummaryAbove textOrSummary"
+            aria-label="title"
+            class="overflow-x-hidden overflow-y-hidden"
+            tabindex="-1"
           >
-            <p>
-              summary
-            </p>
-          </div>
-          <div
-            aria-hidden="true"
-          >
-            <div
-              class="recharts-responsive-container"
-              id="title"
-              style="width: 100%; height: 300px;"
-            />
-          </div>
-          <div>
-            <div
-              class="text-right margin-right-05"
+            <h2
+              class="margin-bottom-1"
             >
-              <button
-                aria-controls="menu--7"
-                aria-haspopup="true"
-                aria-label="Data table actions"
-                class="usa-button usa-button--unstyled text-base"
-                data-reach-menu-button=""
-                id="menu-button--menu--7"
-                type="button"
+              title
+            </h2>
+            <div
+              class="Markdown usa-prose margin-top-0 margin-bottom-4 chartSummaryAbove textOrSummary"
+            >
+              <p>
+                summary
+              </p>
+            </div>
+            <div
+              aria-hidden="true"
+            >
+              <div
+                class="recharts-responsive-container"
+                id="title"
+                style="width: 100%; height: 300px;"
+              />
+            </div>
+            <div>
+              <div
+                class="text-right margin-right-05"
               >
-                Actions
-                <svg
-                  aria-hidden="true"
-                  class="svg-inline--fa fa-caret-down fa-w-10 margin-left-1"
-                  data-icon="caret-down"
-                  data-prefix="fas"
-                  focusable="false"
-                  role="img"
-                  viewBox="0 0 320 512"
-                  xmlns="http://www.w3.org/2000/svg"
+                <button
+                  aria-controls="menu--7"
+                  aria-haspopup="true"
+                  aria-label="Data table actions"
+                  class="usa-button usa-button--unstyled text-base"
+                  data-reach-menu-button=""
+                  id="menu-button--menu--7"
+                  type="button"
                 >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </button>
+                  Actions
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-caret-down fa-w-10 margin-left-1"
+                    data-icon="caret-down"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 320 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/src/components/__tests__/__snapshots__/VisualizeTable.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/VisualizeTable.test.tsx.snap
@@ -274,242 +274,244 @@ exports[`renders the VisualizeTable component 1`] = `
         >
           Full preview
         </button>
-        
-        <div
-          aria-label="Test"
-          class="overflow-x-hidden overflow-y-hidden"
-          tabindex="-1"
-        >
-          <h2
-            class="margin-bottom-1"
-          >
-            Test
-          </h2>
+        <div>
+          
           <div
-            class="Markdown usa-prose margin-top-0 margin-bottom-3 tableSummaryAbove textOrSummary"
-          />
-          <div
+            aria-label="Test"
             class="overflow-x-hidden overflow-y-hidden"
+            tabindex="-1"
           >
-            <table
-              class="usa-table usa-table--borderless"
-              role="table"
+            <h2
+              class="margin-bottom-1"
             >
-              <thead>
-                <tr
-                  role="row"
-                >
-                  <th
-                    aria-sort="none"
-                    colspan="1"
-                    role="columnheader"
-                    scope="col"
-                    style="min-width: 150px;"
-                  >
-                    <span>
-                      id
-                    </span>
-                    <button
-                      aria-label="Toggle SortBy: id"
-                      class="margin-left-1 usa-button usa-button--unstyled"
-                      style="cursor: pointer;"
-                      title="Toggle SortBy: id"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="svg-inline--fa fa-chevron-down fa-w-14 "
-                        data-icon="chevron-down"
-                        data-prefix="fas"
-                        focusable="false"
-                        role="img"
-                        viewBox="0 0 448 512"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                    </button>
-                  </th>
-                  <th
-                    aria-sort="none"
-                    colspan="1"
-                    role="columnheader"
-                    scope="col"
-                    style="min-width: 150px;"
-                  >
-                    <span>
-                      name
-                    </span>
-                    <button
-                      aria-label="Toggle SortBy: name"
-                      class="margin-left-1 usa-button usa-button--unstyled"
-                      style="cursor: pointer;"
-                      title="Toggle SortBy: name"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="svg-inline--fa fa-chevron-down fa-w-14 "
-                        data-icon="chevron-down"
-                        data-prefix="fas"
-                        focusable="false"
-                        role="img"
-                        viewBox="0 0 448 512"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                    </button>
-                  </th>
-                  <th
-                    aria-sort="none"
-                    colspan="1"
-                    role="columnheader"
-                    scope="col"
-                    style="min-width: 150px;"
-                  >
-                    <span>
-                      updatedAt
-                    </span>
-                    <button
-                      aria-label="Toggle SortBy: updatedAt"
-                      class="margin-left-1 usa-button usa-button--unstyled"
-                      style="cursor: pointer;"
-                      title="Toggle SortBy: updatedAt"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="svg-inline--fa fa-chevron-down fa-w-14 "
-                        data-icon="chevron-down"
-                        data-prefix="fas"
-                        focusable="false"
-                        role="img"
-                        viewBox="0 0 448 512"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                    </button>
-                  </th>
-                </tr>
-              </thead>
-              <tbody
-                role="rowgroup"
-              >
-                <tr
-                  role="row"
-                >
-                  <th
-                    role="cell"
-                    scope="row"
-                  >
-                    1
-                  </th>
-                  <td
-                    role="cell"
-                  >
-                    Banana
-                  </td>
-                  <td
-                    role="cell"
-                  >
-                    2021-11-11
-                  </td>
-                </tr>
-                <tr
-                  role="row"
-                >
-                  <th
-                    role="cell"
-                    scope="row"
-                  >
-                    2
-                  </th>
-                  <td
-                    role="cell"
-                  >
-                    Chocolate
-                  </td>
-                  <td
-                    role="cell"
-                  >
-                    2020-11-11
-                  </td>
-                </tr>
-                <tr
-                  role="row"
-                >
-                  <th
-                    role="cell"
-                    scope="row"
-                  >
-                    3
-                  </th>
-                  <td
-                    role="cell"
-                  >
-                    Vanilla
-                  </td>
-                  <td
-                    role="cell"
-                  >
-                    2019-11-11
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+              Test
+            </h2>
             <div
-              class="grid-row text-base-darker text-italic padding-y-05 padding-right-1"
+              class="Markdown usa-prose margin-top-0 margin-bottom-3 tableSummaryAbove textOrSummary"
+            />
+            <div
+              class="overflow-x-hidden overflow-y-hidden"
             >
+              <table
+                class="usa-table usa-table--borderless"
+                role="table"
+              >
+                <thead>
+                  <tr
+                    role="row"
+                  >
+                    <th
+                      aria-sort="none"
+                      colspan="1"
+                      role="columnheader"
+                      scope="col"
+                      style="min-width: 150px;"
+                    >
+                      <span>
+                        id
+                      </span>
+                      <button
+                        aria-label="Toggle SortBy: id"
+                        class="margin-left-1 usa-button usa-button--unstyled"
+                        style="cursor: pointer;"
+                        title="Toggle SortBy: id"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="svg-inline--fa fa-chevron-down fa-w-14 "
+                          data-icon="chevron-down"
+                          data-prefix="fas"
+                          focusable="false"
+                          role="img"
+                          viewBox="0 0 448 512"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      colspan="1"
+                      role="columnheader"
+                      scope="col"
+                      style="min-width: 150px;"
+                    >
+                      <span>
+                        name
+                      </span>
+                      <button
+                        aria-label="Toggle SortBy: name"
+                        class="margin-left-1 usa-button usa-button--unstyled"
+                        style="cursor: pointer;"
+                        title="Toggle SortBy: name"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="svg-inline--fa fa-chevron-down fa-w-14 "
+                          data-icon="chevron-down"
+                          data-prefix="fas"
+                          focusable="false"
+                          role="img"
+                          viewBox="0 0 448 512"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      colspan="1"
+                      role="columnheader"
+                      scope="col"
+                      style="min-width: 150px;"
+                    >
+                      <span>
+                        updatedAt
+                      </span>
+                      <button
+                        aria-label="Toggle SortBy: updatedAt"
+                        class="margin-left-1 usa-button usa-button--unstyled"
+                        style="cursor: pointer;"
+                        title="Toggle SortBy: updatedAt"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="svg-inline--fa fa-chevron-down fa-w-14 "
+                          data-icon="chevron-down"
+                          data-prefix="fas"
+                          focusable="false"
+                          role="img"
+                          viewBox="0 0 448 512"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  role="rowgroup"
+                >
+                  <tr
+                    role="row"
+                  >
+                    <th
+                      role="cell"
+                      scope="row"
+                    >
+                      1
+                    </th>
+                    <td
+                      role="cell"
+                    >
+                      Banana
+                    </td>
+                    <td
+                      role="cell"
+                    >
+                      2021-11-11
+                    </td>
+                  </tr>
+                  <tr
+                    role="row"
+                  >
+                    <th
+                      role="cell"
+                      scope="row"
+                    >
+                      2
+                    </th>
+                    <td
+                      role="cell"
+                    >
+                      Chocolate
+                    </td>
+                    <td
+                      role="cell"
+                    >
+                      2020-11-11
+                    </td>
+                  </tr>
+                  <tr
+                    role="row"
+                  >
+                    <th
+                      role="cell"
+                      scope="row"
+                    >
+                      3
+                    </th>
+                    <td
+                      role="cell"
+                    >
+                      Vanilla
+                    </td>
+                    <td
+                      role="cell"
+                    >
+                      2019-11-11
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
               <div
-                class="grid-col-6 text-left"
+                class="grid-row text-base-darker text-italic padding-y-05 padding-right-1"
               >
                 <div
-                  style="display: inline-flex;"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="svg-inline--fa fa-download fa-w-16 fa-xs margin-right-1"
-                    data-icon="download"
-                    data-prefix="fas"
-                    focusable="false"
-                    role="img"
-                    viewBox="0 0 512 512"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M216 0h80c13.3 0 24 10.7 24 24v168h87.7c17.8 0 26.7 21.5 14.1 34.1L269.7 378.3c-7.5 7.5-19.8 7.5-27.3 0L90.1 226.1c-12.6-12.6-3.7-34.1 14.1-34.1H192V24c0-13.3 10.7-24 24-24zm296 376v112c0 13.3-10.7 24-24 24H24c-13.3 0-24-10.7-24-24V376c0-13.3 10.7-24 24-24h146.7l49 49c20.1 20.1 52.5 20.1 72.6 0l49-49H488c13.3 0 24 10.7 24 24zm-124 88c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20zm64 0c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                </div>
-                <div
-                  style="display: inline-flex;"
+                  class="grid-col-6 text-left"
                 >
                   <div
-                    class="margin-right-05"
+                    style="display: inline-flex;"
                   >
-                    <a
-                      class="text-base-darker"
-                      download="Test"
-                      href="data:text/csv;charset=utf-8,﻿\\"id\\",\\"name\\",\\"updatedAt\\"
+                    <svg
+                      aria-hidden="true"
+                      class="svg-inline--fa fa-download fa-w-16 fa-xs margin-right-1"
+                      data-icon="download"
+                      data-prefix="fas"
+                      focusable="false"
+                      role="img"
+                      viewBox="0 0 512 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M216 0h80c13.3 0 24 10.7 24 24v168h87.7c17.8 0 26.7 21.5 14.1 34.1L269.7 378.3c-7.5 7.5-19.8 7.5-27.3 0L90.1 226.1c-12.6-12.6-3.7-34.1 14.1-34.1H192V24c0-13.3 10.7-24 24-24zm296 376v112c0 13.3-10.7 24-24 24H24c-13.3 0-24-10.7-24-24V376c0-13.3 10.7-24 24-24h146.7l49 49c20.1 20.1 52.5 20.1 72.6 0l49-49H488c13.3 0 24 10.7 24 24zm-124 88c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20zm64 0c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    style="display: inline-flex;"
+                  >
+                    <div
+                      class="margin-right-05"
+                    >
+                      <a
+                        class="text-base-darker"
+                        download="Test"
+                        href="data:text/csv;charset=utf-8,﻿\\"id\\",\\"name\\",\\"updatedAt\\"
 \\"1\\",\\"Banana\\",\\"2021-11-11\\"
 \\"2\\",\\"Chocolate\\",\\"2020-11-11\\"
 \\"3\\",\\"Vanilla\\",\\"2019-11-11\\""
-                      target="_self"
-                    >
-                      Download table
-                    </a>
+                        target="_self"
+                      >
+                        Download table
+                      </a>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/frontend/src/containers/AddChart.tsx
+++ b/frontend/src/containers/AddChart.tsx
@@ -95,7 +95,8 @@ function AddChart() {
     undefined
   );
   const [sortByDesc, setSortByDesc] = useState<boolean | undefined>(undefined);
-  const { fullPreviewButton, fullPreview } = useFullPreview();
+  const previewPanelId = "preview-chart-panel";
+  const { fullPreviewButton, fullPreview } = useFullPreview(previewPanelId);
   const [dataTypes, setDataTypes] = useState<Map<string, ColumnDataType>>(
     new Map<string, ColumnDataType>()
   );
@@ -518,6 +519,7 @@ function AddChart() {
                 processingWidget={creatingWidget}
                 fullPreviewButton={fullPreviewButton}
                 fullPreview={fullPreview}
+                previewPanelId={previewPanelId}
                 submitButtonLabel={t("AddChartScreen.AddChart")}
                 sortByColumn={sortByColumn}
                 sortByDesc={sortByDesc}

--- a/frontend/src/containers/AddImage.tsx
+++ b/frontend/src/containers/AddImage.tsx
@@ -54,7 +54,8 @@ function AddImage() {
 
   const supportedImageFileTypes = Object.values(StorageService.imageFileTypes);
 
-  const { fullPreview, fullPreviewButton } = useFullPreview();
+  const previewPanelId = "preview-image-panel";
+  const { fullPreview, fullPreviewButton } = useFullPreview(previewPanelId);
   const windowSize = useWindowSize();
   const isMobile = windowSize.width <= 600;
 
@@ -338,14 +339,16 @@ function AddImage() {
         >
           <div className="sticky-preview">
             {isMobile ? <br /> : fullPreviewButton}
-            <ImageWidget
-              title={showTitle ? title : ""}
-              summary={summary}
-              file={imageFile && imageFile[0]}
-              summaryBelow={summaryBelow}
-              altText={altText}
-              scalePct={scalePct}
-            />
+            <div id={previewPanelId}>
+              <ImageWidget
+                title={showTitle ? title : ""}
+                summary={summary}
+                file={imageFile && imageFile[0]}
+                summaryBelow={summaryBelow}
+                altText={altText}
+                scalePct={scalePct}
+              />
+            </div>
           </div>
         </section>
       </div>

--- a/frontend/src/containers/AddMetrics.tsx
+++ b/frontend/src/containers/AddMetrics.tsx
@@ -107,7 +107,8 @@ function AddMetrics() {
     }
   }, [datasetError, datasetType, metrics]);
 
-  const { fullPreview, fullPreviewButton } = useFullPreview();
+  const previewPanelId = "preview-metrics-panel";
+  const { fullPreview, fullPreviewButton } = useFullPreview(previewPanelId);
   const [oldStep, setOldStep] = useState<number>(-1);
   const title = watch("title");
   const showTitle = watch("showTitle");
@@ -682,13 +683,15 @@ function AddMetrics() {
                 >
                   <div className="sticky-preview">
                     {isMobile ? <br /> : fullPreviewButton}
-                    <MetricsWidget
-                      title={showTitle ? title : ""}
-                      metrics={metrics}
-                      metricPerRow={oneMetricPerRow ? 1 : 3}
-                      significantDigitLabels={significantDigitLabels}
-                      metricsCenterAlign={metricsCenterAlign}
-                    />
+                    <div id={previewPanelId}>
+                      <MetricsWidget
+                        title={showTitle ? title : ""}
+                        metrics={metrics}
+                        metricPerRow={oneMetricPerRow ? 1 : 3}
+                        significantDigitLabels={significantDigitLabels}
+                        metricsCenterAlign={metricsCenterAlign}
+                      />
+                    </div>
                   </div>
                 </section>
               </div>

--- a/frontend/src/containers/AddSection.tsx
+++ b/frontend/src/containers/AddSection.tsx
@@ -44,7 +44,8 @@ function AddSection() {
   const [summary, setSummary] = useState("");
   const [showWithTabs, setShowWithTabs] = useState(false);
   const [horizontally, setHorizontally] = useState("horizontally");
-  const { fullPreview, fullPreviewButton } = useFullPreview();
+  const previewPanelId = "preview-section-panel";
+  const { fullPreview, fullPreviewButton } = useFullPreview(previewPanelId);
   const windowSize = useWindowSize();
   const isMobile = windowSize.width <= 600;
 
@@ -286,21 +287,23 @@ function AddSection() {
             >
               <div>
                 {isMobile ? <br /> : fullPreviewButton}
-                {showTitle ? (
-                  <h2 className="margin-top-3 margin-left-2px">{title}</h2>
-                ) : (
-                  ""
-                )}
-                {summary ? (
-                  <div className="padding-left-05">
-                    <MarkdownRender
-                      className="usa-prose textOrSummary"
-                      source={summary}
-                    />
-                  </div>
-                ) : (
-                  ""
-                )}
+                <div id={previewPanelId}>
+                  {showTitle ? (
+                    <h2 className="margin-top-3 margin-left-2px">{title}</h2>
+                  ) : (
+                    ""
+                  )}
+                  {summary ? (
+                    <div className="padding-left-05">
+                      <MarkdownRender
+                        className="usa-prose textOrSummary"
+                        source={summary}
+                      />
+                    </div>
+                  ) : (
+                    ""
+                  )}
+                </div>
               </div>
             </section>
           </div>

--- a/frontend/src/containers/AddTable.tsx
+++ b/frontend/src/containers/AddTable.tsx
@@ -88,7 +88,8 @@ function AddTable() {
     undefined
   );
   const [sortByDesc, setSortByDesc] = useState<boolean | undefined>(undefined);
-  const { fullPreview, fullPreviewButton } = useFullPreview();
+  const previewPanelId = "preview-table-panel";
+  const { fullPreview, fullPreviewButton } = useFullPreview(previewPanelId);
   const [dataTypes, setDataTypes] = useState<Map<string, ColumnDataType>>(
     new Map<string, ColumnDataType>()
   );
@@ -447,6 +448,7 @@ function AddTable() {
               processingWidget={creatingWidget}
               fullPreviewButton={fullPreviewButton}
               fullPreview={fullPreview}
+              previewPanelId={previewPanelId}
               submitButtonLabel={t("AddTableScreen.AddTable")}
               sortByColumn={sortByColumn}
               sortByDesc={sortByDesc}

--- a/frontend/src/containers/AddText.tsx
+++ b/frontend/src/containers/AddText.tsx
@@ -39,7 +39,8 @@ function AddText() {
   const [title, setTitle] = useState("");
   const [text, setText] = useState("");
   const [showTitle, setShowTitle] = useState(true);
-  const { fullPreview, fullPreviewButton } = useFullPreview();
+  const previewPanelId = "preview-text-panel";
+  const { fullPreview, fullPreviewButton } = useFullPreview(previewPanelId);
   const windowSize = useWindowSize();
   const isMobile = windowSize.width <= 600;
 
@@ -215,21 +216,23 @@ function AddText() {
               aria-label={t("ContentPreview")}
             >
               {isMobile ? <br /> : fullPreviewButton}
-              {showTitle ? (
-                <h2 className="margin-top-3 margin-left-2px">{title}</h2>
-              ) : (
-                ""
-              )}
-              {text ? (
-                <div className="padding-left-05">
-                  <MarkdownRender
-                    className="usa-prose textOrSummary"
-                    source={text}
-                  />
-                </div>
-              ) : (
-                ""
-              )}
+              <div id={previewPanelId}>
+                {showTitle ? (
+                  <h2 className="margin-top-3 margin-left-2px">{title}</h2>
+                ) : (
+                  ""
+                )}
+                {text ? (
+                  <div className="padding-left-05">
+                    <MarkdownRender
+                      className="usa-prose textOrSummary"
+                      source={text}
+                    />
+                  </div>
+                ) : (
+                  ""
+                )}
+              </div>
             </section>
           </div>
         </>

--- a/frontend/src/containers/EditChart.tsx
+++ b/frontend/src/containers/EditChart.tsx
@@ -101,7 +101,9 @@ function EditChart() {
     setDynamicJson,
     setCsvJson,
   } = useWidget(dashboardId, widgetId);
-  const { fullPreviewButton, fullPreview } = useFullPreview();
+
+  const previewPanelId = "preview-chart-panel";
+  const { fullPreviewButton, fullPreview } = useFullPreview(previewPanelId);
 
   const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(
     new Set<string>()
@@ -729,6 +731,7 @@ function EditChart() {
                   showTitle={showTitle}
                   fullPreviewButton={fullPreviewButton}
                   fullPreview={fullPreview}
+                  previewPanelId={previewPanelId}
                   submitButtonLabel={t("Save")}
                   sortByColumn={sortByColumn}
                   sortByDesc={sortByDesc}

--- a/frontend/src/containers/EditDetails.tsx
+++ b/frontend/src/containers/EditDetails.tsx
@@ -40,7 +40,8 @@ function EditDetails() {
   const { dashboardId } = useParams<PathParams>();
   const { dashboard, loading } = useDashboard(dashboardId);
   const [activeWidgetId, setActiveWidgetId] = useState("");
-  const { fullPreview, fullPreviewButton } = useFullPreview();
+  const previewPanelId = "preview-details-panel";
+  const { fullPreview, fullPreviewButton } = useFullPreview(previewPanelId);
   const { register, errors, handleSubmit, watch, reset } =
     useForm<FormValues>();
   const windowSize = useWindowSize();
@@ -266,7 +267,7 @@ function EditDetails() {
           aria-label={t("ContentPreview")}
         >
           {isMobile ? <br /> : fullPreviewButton}
-          <div className="margin-top-2">
+          <div id={previewPanelId} className="margin-top-2">
             <DashboardHeader
               name={name}
               topicAreaName={getTopicAreaName(topicAreaId)}

--- a/frontend/src/containers/EditImage.tsx
+++ b/frontend/src/containers/EditImage.tsx
@@ -51,7 +51,8 @@ function EditImage() {
 
   const supportedImageFileTypes = Object.values(StorageService.imageFileTypes);
 
-  const { fullPreview, fullPreviewButton } = useFullPreview();
+  const previewPanelId = "preview-image-panel";
+  const { fullPreview, fullPreviewButton } = useFullPreview(previewPanelId);
   const windowSize = useWindowSize();
   const isMobile = windowSize.width <= 600;
 
@@ -428,21 +429,23 @@ function EditImage() {
             >
               <div hidden={false} className="sticky-preview">
                 {isMobile ? <br /> : fullPreviewButton}
-                {loadingFile ? (
-                  <Spinner
-                    className="text-center margin-top-6"
-                    label={t("LoadingSpinnerLabel")}
-                  />
-                ) : (
-                  <ImageWidget
-                    title={widget.showTitle ? widget.content.title : ""}
-                    summary={widget.content.summary}
-                    file={newImageFile ? newImageFile : file}
-                    summaryBelow={widget.content.summaryBelow}
-                    altText={widget.content.imageAltText}
-                    scalePct={widget.content.scalePct}
-                  />
-                )}
+                <div id={previewPanelId}>
+                  {loadingFile ? (
+                    <Spinner
+                      className="text-center margin-top-6"
+                      label={t("LoadingSpinnerLabel")}
+                    />
+                  ) : (
+                    <ImageWidget
+                      title={widget.showTitle ? widget.content.title : ""}
+                      summary={widget.content.summary}
+                      file={newImageFile ? newImageFile : file}
+                      summaryBelow={widget.content.summaryBelow}
+                      altText={widget.content.imageAltText}
+                      scalePct={widget.content.scalePct}
+                    />
+                  )}
+                </div>
               </div>
             </section>
           </div>

--- a/frontend/src/containers/EditMetrics.tsx
+++ b/frontend/src/containers/EditMetrics.tsx
@@ -59,7 +59,8 @@ function EditMetrics() {
   const [submittedMetricsNum, setSubmittedMetricsNum] = useState<
     number | undefined
   >();
-  const { fullPreview, fullPreviewButton } = useFullPreview();
+  const previewPanelId = "preview-metrics-panel";
+  const { fullPreview, fullPreviewButton } = useFullPreview(previewPanelId);
   const windowSize = useWindowSize();
   const isMobile = windowSize.width <= 600;
 
@@ -402,13 +403,15 @@ function EditMetrics() {
           >
             <div hidden={false} className="sticky-preview">
               {isMobile ? <br /> : fullPreviewButton}
-              <MetricsWidget
-                title={showTitle ? title : ""}
-                metrics={metrics}
-                metricPerRow={oneMetricPerRow ? 1 : 3}
-                significantDigitLabels={significantDigitLabels}
-                metricsCenterAlign={metricsCenterAlign}
-              />
+              <div id={previewPanelId}>
+                <MetricsWidget
+                  title={showTitle ? title : ""}
+                  metrics={metrics}
+                  metricPerRow={oneMetricPerRow ? 1 : 3}
+                  significantDigitLabels={significantDigitLabels}
+                  metricsCenterAlign={metricsCenterAlign}
+                />
+              </div>
             </div>
           </section>
         </div>

--- a/frontend/src/containers/EditSection.tsx
+++ b/frontend/src/containers/EditSection.tsx
@@ -41,7 +41,8 @@ function EditSection() {
   const { t } = useTranslation();
   const [editingWidget, setEditingWidget] = useState(false);
   const { widget, setWidget } = useWidget(dashboardId, widgetId);
-  const { fullPreview, fullPreviewButton } = useFullPreview();
+  const previewPanelId = "preview-section-panel";
+  const { fullPreview, fullPreviewButton } = useFullPreview(previewPanelId);
   const windowSize = useWindowSize();
   const isMobile = windowSize.width <= 600;
 
@@ -292,23 +293,25 @@ function EditSection() {
               aria-label={t("ContentPreview")}
             >
               {isMobile ? <br /> : fullPreviewButton}
-              {widget.showTitle ? (
-                <h2 className="margin-top-3 margin-left-2px">
-                  {widget.content.title}
-                </h2>
-              ) : (
-                ""
-              )}
-              {widget.content.summary ? (
-                <div className="padding-left-05">
-                  <MarkdownRender
-                    className="usa-prose textOrSummary"
-                    source={widget.content.summary}
-                  />
-                </div>
-              ) : (
-                ""
-              )}
+              <div id={previewPanelId}>
+                {widget.showTitle ? (
+                  <h2 className="margin-top-3 margin-left-2px">
+                    {widget.content.title}
+                  </h2>
+                ) : (
+                  ""
+                )}
+                {widget.content.summary ? (
+                  <div className="padding-left-05">
+                    <MarkdownRender
+                      className="usa-prose textOrSummary"
+                      source={widget.content.summary}
+                    />
+                  </div>
+                ) : (
+                  ""
+                )}
+              </div>
             </section>
           </div>
         </>

--- a/frontend/src/containers/EditTable.tsx
+++ b/frontend/src/containers/EditTable.tsx
@@ -92,7 +92,8 @@ function EditTable() {
     setDynamicJson,
     setCsvJson,
   } = useWidget(dashboardId, widgetId);
-  const { fullPreview, fullPreviewButton } = useFullPreview();
+  const previewPanelId = "preview-table-panel";
+  const { fullPreview, fullPreviewButton } = useFullPreview(previewPanelId);
 
   const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(
     new Set<string>()
@@ -649,6 +650,7 @@ function EditTable() {
                   processingWidget={editingWidget}
                   fullPreviewButton={fullPreviewButton}
                   fullPreview={fullPreview}
+                  previewPanelId={previewPanelId}
                   submitButtonLabel={t("Save")}
                   title={title}
                   summary={summary}

--- a/frontend/src/containers/EditText.tsx
+++ b/frontend/src/containers/EditText.tsx
@@ -38,7 +38,8 @@ function EditText() {
   const { t } = useTranslation();
   const [editingWidget, setEditingWidget] = useState(false);
   const { widget, setWidget } = useWidget(dashboardId, widgetId);
-  const { fullPreview, fullPreviewButton } = useFullPreview();
+  const previewPanelId = "preview-text-panel";
+  const { fullPreview, fullPreviewButton } = useFullPreview(previewPanelId);
   const windowSize = useWindowSize();
   const isMobile = windowSize.width <= 600;
 
@@ -231,16 +232,18 @@ function EditText() {
               ) : (
                 ""
               )}
-              {widget.content.text ? (
-                <div className="padding-left-05">
-                  <MarkdownRender
-                    className="usa-prose textOrSummary"
-                    source={widget.content.text}
-                  />
-                </div>
-              ) : (
-                ""
-              )}
+              <div id={previewPanelId}>
+                {widget.content.text ? (
+                  <div className="padding-left-05">
+                    <MarkdownRender
+                      className="usa-prose textOrSummary"
+                      source={widget.content.text}
+                    />
+                  </div>
+                ) : (
+                  ""
+                )}
+              </div>
             </section>
           </div>
         </>

--- a/frontend/src/hooks/dashboard-preview-hooks.tsx
+++ b/frontend/src/hooks/dashboard-preview-hooks.tsx
@@ -4,9 +4,8 @@ import { faPlusSquare, faMinusSquare } from "@fortawesome/free-solid-svg-icons";
 import Button from "../components/Button";
 import { useTranslation } from "react-i18next";
 
-export function useFullPreview() {
+export function useFullPreview(previewPanelId: string) {
   const [fullPreview, setFullPreview] = useState(false);
-  const [ariaControls, setAriaControls] = useState<string>();
   const { t } = useTranslation();
 
   const fullPreviewToggle = () => {
@@ -20,7 +19,7 @@ export function useFullPreview() {
       type="button"
       className="margin-top-1"
       ariaExpanded={true}
-      ariaControls={ariaControls}
+      ariaControls={previewPanelId}
     >
       <FontAwesomeIcon icon={faMinusSquare} className={"margin-right-1"} />
       {t("ClosePreview")}
@@ -31,12 +30,12 @@ export function useFullPreview() {
       variant="outline"
       type="button"
       ariaExpanded={false}
-      ariaControls={ariaControls}
+      ariaControls={previewPanelId}
     >
       <FontAwesomeIcon icon={faPlusSquare} className={"margin-right-1"} />
       {t("ExpandPreview")}
     </Button>
   );
 
-  return { fullPreviewToggle, fullPreviewButton, fullPreview, setAriaControls };
+  return { fullPreviewToggle, fullPreviewButton, fullPreview };
 }

--- a/frontend/src/hooks/dashboard-preview-hooks.tsx
+++ b/frontend/src/hooks/dashboard-preview-hooks.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 
 export function useFullPreview() {
   const [fullPreview, setFullPreview] = useState(false);
+  const [ariaControls, setAriaControls] = useState<string>();
   const { t } = useTranslation();
 
   const fullPreviewToggle = () => {
@@ -18,16 +19,24 @@ export function useFullPreview() {
       variant="outline"
       type="button"
       className="margin-top-1"
+      ariaExpanded={true}
+      ariaControls={ariaControls}
     >
       <FontAwesomeIcon icon={faMinusSquare} className={"margin-right-1"} />
       {t("ClosePreview")}
     </Button>
   ) : (
-    <Button onClick={fullPreviewToggle} variant="outline" type="button">
+    <Button
+      onClick={fullPreviewToggle}
+      variant="outline"
+      type="button"
+      ariaExpanded={false}
+      ariaControls={ariaControls}
+    >
       <FontAwesomeIcon icon={faPlusSquare} className={"margin-right-1"} />
       {t("ExpandPreview")}
     </Button>
   );
 
-  return { fullPreviewToggle, fullPreviewButton, fullPreview };
+  return { fullPreviewToggle, fullPreviewButton, fullPreview, setAriaControls };
 }


### PR DESCRIPTION
## Description

Assign correct ARIA attributes to Preview buttons

![image](https://user-images.githubusercontent.com/6969135/192647751-7fd74f19-8379-4dad-95f8-fa49e38edf20.png)

## Testing

Describe how you tested your changes and/or give instructions to the reviewers on how they can verify them.

1- Go to https://d2h803e1awe3zo.cloudfront.net/admin/dashboard/edit/efd10a19-517d-42c2-932d-db8b1be9b451
2- Add new widget of each type and verify the aria attributes are set for the "Preview" button
3- The correct values when Full screen preview is closed are: aria-expanded="false", aria-controls="{id-preview-panel}"
4- The correct values when Full screen preview is opened are: aria-expanded="true" aria-controls="{id-preview-panel}"
5- Check the same for each Edit view

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
