### PR TITLE
Denis/gtt 1987 edit chart

### DIFF
--- a/frontend/src/components/ChooseData.tsx
+++ b/frontend/src/components/ChooseData.tsx
@@ -79,14 +79,14 @@ function ChooseData(props: Props) {
           className={`usa-hint ${isMobile ? "grid-col-12" : "grid-col-6"}`}
         >
           <label className="usa-label text-bold">{t("Data")}</label>
-          <div className="usa-hint">
+          <span className="usa-hint">
             {t("ChooseDataDescription", {
               widgetType: props.widgetType,
             })}{" "}
             <Link to="/admin/apihelp" target="_blank" external>
               {t("HowDoIAddDatasets")}
             </Link>
-          </div>
+          </span>
         </legend>
 
         <div className="grid-row">

--- a/frontend/src/components/RadioButtonsTile.tsx
+++ b/frontend/src/components/RadioButtonsTile.tsx
@@ -41,7 +41,6 @@ function RadioButtonsTile(props: Props) {
               {option.description}
             </span>
           </label>
-          
         </div>
       </div>
     );

--- a/frontend/src/components/RadioButtonsTile.tsx
+++ b/frontend/src/components/RadioButtonsTile.tsx
@@ -34,13 +34,14 @@ function RadioButtonsTile(props: Props) {
           />
           <label className="usa-radio__label" htmlFor={option.id}>
             {option.label}
-            <p
+            <span
               className="text-base usa-prose usa-checkbox__label-description"
               id={`${option.id}-description`}
             >
               {option.description}
-            </p>
+            </span>
           </label>
+          
         </div>
       </div>
     );

--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -133,7 +133,7 @@ function Table(props: Props) {
         hooks.visibleColumns.push((columns) => [
           {
             id: "selection",
-            Header: ({}) => <div></div>,
+            Header: ({}) => <></>,
             Cell: ({ row }) => (
               <div>
                 <IndeterminateRadio

--- a/frontend/src/components/__tests__/__snapshots__/ChooseData.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/ChooseData.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`renders the ChooseData component 1`] = `
       >
         Data
       </label>
-      <div
+      <span
         class="usa-hint"
       >
         Choose an existing dataset or create a new one to populate this chart.
@@ -44,7 +44,7 @@ exports[`renders the ChooseData component 1`] = `
             />
           </svg>
         </a>
-      </div>
+      </span>
     </legend>
     <div
       class="grid-row"
@@ -77,12 +77,12 @@ exports[`renders the ChooseData component 1`] = `
                 for="staticDataset"
               >
                 Static dataset
-                <p
+                <span
                   class="text-base usa-prose usa-checkbox__label-description"
                   id="staticDataset-description"
                 >
                   Upload a new dataset from file or elect an existing dataset.
-                </p>
+                </span>
               </label>
             </div>
           </div>
@@ -111,12 +111,12 @@ exports[`renders the ChooseData component 1`] = `
                 for="dynamicDataset"
               >
                 Dynamic dataset
-                <p
+                <span
                   class="text-base usa-prose usa-checkbox__label-description"
                   id="dynamicDataset-description"
                 >
                   Choose from a list of continuously updated datasets.
-                </p>
+                </span>
               </label>
             </div>
           </div>
@@ -308,9 +308,7 @@ exports[`renders the ChooseData component 1`] = `
                   scope="col"
                   style="padding: 0.5rem 1rem;"
                 >
-                  <span>
-                    <div />
-                  </span>
+                  <span />
                 </th>
                 <th
                   aria-sort="none"

--- a/frontend/src/containers/EditChart.tsx
+++ b/frontend/src/containers/EditChart.tsx
@@ -538,14 +538,12 @@ function EditChart() {
         role="tablist"
         aria-labelledby={`editChartFormHeader_${suffix}`}
       >
-        <li
-          id={`editChartFormHeaderStep1_${suffix}`}
-          className="usa-button-group__item"
-          role="tab"
-          aria-selected={step === 0}
-          aria-controls="panel1"
-        >
+        <li className="usa-button-group__item">
           <button
+            id={`editChartFormHeaderStep1_${suffix}`}
+            role="tab"
+            aria-selected={step === 0}
+            aria-controls="panel1"
             className={`usa-button tabSelector ${
               step !== 0 ? "usa-button--outline" : ""
             }`}
@@ -556,14 +554,12 @@ function EditChart() {
             {t("EditChartScreen.ChooseData")}
           </button>
         </li>
-        <li
-          id={`editChartFormHeaderStep2_${suffix}`}
-          className="usa-button-group__item"
-          role="tab"
-          aria-selected={step === 1}
-          aria-controls="panel2"
-        >
+        <li className="usa-button-group__item">
           <button
+            id={`editChartFormHeaderStep2_${suffix}`}
+            role="tab"
+            aria-selected={step === 1}
+            aria-controls="panel2"
             className={`usa-button tabSelector ${
               step !== 1 ? "usa-button--outline" : ""
             }`}
@@ -575,14 +571,12 @@ function EditChart() {
             {t("EditChartScreen.CheckData")}
           </button>
         </li>
-        <li
-          id={`editChartFormHeaderStep3_${suffix}`}
-          className="usa-button-group__item"
-          role="tab"
-          aria-selected={step === 2}
-          aria-controls="panel3"
-        >
+        <li className="usa-button-group__item">
           <button
+            id={`editChartFormHeaderStep3_${suffix}`}
+            role="tab"
+            aria-selected={step === 2}
+            aria-controls="panel3"
             className={`usa-button tabSelector ${
               step !== 2 ? "usa-button--outline" : ""
             }`}

--- a/frontend/src/containers/EditChart.tsx
+++ b/frontend/src/containers/EditChart.tsx
@@ -528,17 +528,18 @@ function EditChart() {
     });
   }
 
-  const configHeader = (
+  const configHeader = (suffix: string) => (
     <div>
-      <h1 id="editChartFormHeader" className="margin-top-0">
+      <h1 id={`editChartFormHeader_${suffix}`} className="margin-top-0">
         {t("EditChartScreen.EditChart")}
       </h1>
       <ul
         className="usa-button-group usa-button-group--segmented"
         role="tablist"
+        aria-labelledby={`editChartFormHeader_${suffix}`}
       >
         <li
-          id="editChartFormHeaderStep1"
+          id={`editChartFormHeaderStep1_${suffix}`}
           className="usa-button-group__item"
           role="tab"
           aria-selected={step === 0}
@@ -556,7 +557,7 @@ function EditChart() {
           </button>
         </li>
         <li
-          id="editChartFormHeaderStep2"
+          id={`editChartFormHeaderStep2_${suffix}`}
           className="usa-button-group__item"
           role="tab"
           aria-selected={step === 1}
@@ -575,7 +576,7 @@ function EditChart() {
           </button>
         </li>
         <li
-          id="editChartFormHeaderStep3"
+          id={`editChartFormHeaderStep3_${suffix}`}
           className="usa-button-group__item"
           role="tab"
           aria-selected={step === 2}
@@ -617,19 +618,19 @@ function EditChart() {
       ) : (
         <div className="grid-row">
           <div className="grid-col-12">
-            <form
-              onSubmit={handleSubmit(onSubmit)}
-              aria-labelledby="editChartFormHeader"
+            <div
+              id="panel1"
+              hidden={step !== 0}
+              role="tabpanel"
+              tabIndex={0}
+              aria-labelledby="editChartFormHeaderStep1_chooseDdata"
             >
-              <div
-                id="panel1"
-                hidden={step !== 0}
-                role="tabpanel"
-                tabIndex={0}
-                aria-labelledby="editChartFormHeaderStep1"
+              <form
+                onSubmit={handleSubmit(onSubmit)}
+                aria-labelledby="editChartFormHeader_chooseDdata"
               >
                 <PrimaryActionBar>
-                  {configHeader}
+                  {configHeader("chooseDdata")}
                   <div className="margin-y-3" hidden={!showColumnHeaderAlert}>
                     <Alert
                       type="error"
@@ -665,16 +666,21 @@ function EditChart() {
                     setShowNoDatasetTypeAlert={setShowNoDatasetTypeAlert}
                   />
                 </PrimaryActionBar>
-              </div>
-              <div
-                id="panel2"
-                hidden={step !== 1}
-                role="tabpanel"
-                tabIndex={0}
-                aria-labelledby="editChartFormHeaderStep2"
+              </form>
+            </div>
+            <div
+              id="panel2"
+              hidden={step !== 1}
+              role="tabpanel"
+              tabIndex={0}
+              aria-labelledby="editChartFormHeaderStep2_checkDdata"
+            >
+              <form
+                onSubmit={handleSubmit(onSubmit)}
+                aria-labelledby="editChartFormHeader_checkDdata"
               >
                 <PrimaryActionBar>
-                  {configHeader}
+                  {configHeader("checkDdata")}
                   <CheckData
                     data={displayedJson}
                     advanceStep={advanceStep}
@@ -696,13 +702,18 @@ function EditChart() {
                     widgetType={t("CheckDataDescriptionChart")}
                   />
                 </PrimaryActionBar>
-              </div>
-              <div
-                id="panel3"
-                hidden={step !== 2}
-                role="tabpanel"
-                tabIndex={0}
-                aria-labelledby="editChartFormHeaderStep3"
+              </form>
+            </div>
+            <div
+              id="panel3"
+              hidden={step !== 2}
+              role="tabpanel"
+              tabIndex={0}
+              aria-labelledby="editChartFormHeaderStep3_visualizeChart"
+            >
+              <form
+                onSubmit={handleSubmit(onSubmit)}
+                aria-labelledby="editChartFormHeader_visualizeChart"
               >
                 <VisualizeChart
                   errors={errors}
@@ -746,10 +757,10 @@ function EditChart() {
                     numberTypes,
                     currencyTypes
                   )}
-                  configHeader={configHeader}
+                  configHeader={configHeader("visualizeChart")}
                 />
-              </div>
-            </form>
+              </form>
+            </div>
           </div>
         </div>
       )}

--- a/frontend/src/containers/EditTable.tsx
+++ b/frontend/src/containers/EditTable.tsx
@@ -457,17 +457,18 @@ function EditTable() {
     });
   }
 
-  const configHeader = (
+  const configHeader = (suffix: string) => (
     <div>
-      <h1 id="editTableFormHeader" className="margin-top-0">
+      <h1 id={`editTableFormHeader_${suffix}`} className="margin-top-0">
         {t("EditTableScreen.EditTable")}
       </h1>
       <ul
         className="usa-button-group usa-button-group--segmented"
         role="tablist"
+        aria-labelledby={`editTableFormHeader_${suffix}`}
       >
         <li
-          id="editTableFormHeaderStep1"
+          id={`editTableFormHeaderStep1_${suffix}`}
           className="usa-button-group__item"
           role="tab"
           aria-selected={step === 0}
@@ -485,7 +486,7 @@ function EditTable() {
           </button>
         </li>
         <li
-          id="editTableFormHeaderStep2"
+          id={`editTableFormHeaderStep2_${suffix}`}
           className="usa-button-group__item"
           role="tab"
           aria-selected={step === 1}
@@ -504,7 +505,7 @@ function EditTable() {
           </button>
         </li>
         <li
-          id="editTableFormHeaderStep3"
+          id={`editTableFormHeaderStep3_${suffix}`}
           className="usa-button-group__item"
           role="tab"
           aria-selected={step === 2}
@@ -547,19 +548,19 @@ function EditTable() {
       ) : (
         <>
           <div className="grid-row">
-            <form
-              onSubmit={handleSubmit(onSubmit)}
-              aria-labelledby="editTableFormHeader"
+            <div
+              id="panel1"
+              hidden={step !== 0}
+              role="tabpanel"
+              tabIndex={0}
+              aria-labelledby="editTableFormHeaderStep1_chooseDdata"
             >
-              <div
-                id="panel1"
-                hidden={step !== 0}
-                role="tabpanel"
-                tabIndex={0}
-                aria-labelledby="editTableFormHeaderStep1"
+              <form
+                onSubmit={handleSubmit(onSubmit)}
+                aria-labelledby="editTableFormHeader_chooseDdata"
               >
                 <PrimaryActionBar>
-                  {configHeader}
+                  {configHeader("chooseDdata")}
                   <div className="margin-y-3" hidden={!showNoDatasetTypeAlert}>
                     <Alert
                       type="error"
@@ -588,17 +589,22 @@ function EditTable() {
                     setShowNoDatasetTypeAlert={setShowNoDatasetTypeAlert}
                   />
                 </PrimaryActionBar>
-              </div>
+              </form>
+            </div>
 
-              <div
-                id="panel2"
-                hidden={step !== 1}
-                role="tabpanel"
-                tabIndex={0}
-                aria-labelledby="editTableFormHeaderStep2"
+            <div
+              id="panel2"
+              hidden={step !== 1}
+              role="tabpanel"
+              tabIndex={0}
+              aria-labelledby="editTableFormHeaderStep2_checkDdata"
+            >
+              <form
+                onSubmit={handleSubmit(onSubmit)}
+                aria-labelledby="editTableFormHeader_checkDdata"
               >
                 <PrimaryActionBar>
-                  {configHeader}
+                  {configHeader("checkDdata")}
                   <CheckData
                     data={displayedJson}
                     advanceStep={advanceStep}
@@ -620,14 +626,19 @@ function EditTable() {
                     widgetType={t("CheckDataDescriptionTable")}
                   />
                 </PrimaryActionBar>
-              </div>
+              </form>
+            </div>
 
-              <div
-                id="panel3"
-                hidden={step !== 2}
-                role="tabpanel"
-                tabIndex={0}
-                aria-labelledby="editTableFormHeaderStep3"
+            <div
+              id="panel3"
+              hidden={step !== 2}
+              role="tabpanel"
+              tabIndex={0}
+              aria-labelledby="editTableFormHeaderStep3_visualize"
+            >
+              <form
+                onSubmit={handleSubmit(onSubmit)}
+                aria-labelledby="editTableFormHeader_visualize"
               >
                 <Visualize
                   errors={errors}
@@ -666,10 +677,10 @@ function EditTable() {
                     numberTypes,
                     currencyTypes
                   )}
-                  configHeader={configHeader}
+                  configHeader={configHeader("visualize")}
                 />
-              </div>
-            </form>
+              </form>
+            </div>
           </div>
         </>
       )}

--- a/frontend/src/containers/EditTable.tsx
+++ b/frontend/src/containers/EditTable.tsx
@@ -467,14 +467,12 @@ function EditTable() {
         role="tablist"
         aria-labelledby={`editTableFormHeader_${suffix}`}
       >
-        <li
-          id={`editTableFormHeaderStep1_${suffix}`}
-          className="usa-button-group__item"
-          role="tab"
-          aria-selected={step === 0}
-          aria-controls="panel1"
-        >
+        <li className="usa-button-group__item">
           <button
+            id={`editTableFormHeaderStep1_${suffix}`}
+            role="tab"
+            aria-selected={step === 0}
+            aria-controls="panel1"
             className={`usa-button tabSelector ${
               step !== 0 ? "usa-button--outline" : ""
             }`}
@@ -485,14 +483,12 @@ function EditTable() {
             {t("EditTableScreen.ChooseData")}
           </button>
         </li>
-        <li
-          id={`editTableFormHeaderStep2_${suffix}`}
-          className="usa-button-group__item"
-          role="tab"
-          aria-selected={step === 1}
-          aria-controls="panel2"
-        >
+        <li className="usa-button-group__item">
           <button
+            id={`editTableFormHeaderStep2_${suffix}`}
+            role="tab"
+            aria-selected={step === 1}
+            aria-controls="panel2"
             className={`usa-button tabSelector ${
               step !== 1 ? "usa-button--outline" : ""
             }`}
@@ -504,14 +500,12 @@ function EditTable() {
             {t("EditTableScreen.CheckData")}
           </button>
         </li>
-        <li
-          id={`editTableFormHeaderStep3_${suffix}`}
-          className="usa-button-group__item"
-          role="tab"
-          aria-selected={step === 2}
-          aria-controls="panel3"
-        >
+        <li className="usa-button-group__item">
           <button
+            id={`editTableFormHeaderStep3_${suffix}`}
+            role="tab"
+            aria-selected={step === 2}
+            aria-controls="panel3"
             className={`usa-button tabSelector ${
               step !== 2 ? "usa-button--outline" : ""
             }`}

--- a/frontend/src/containers/__tests__/EditChart.test.tsx
+++ b/frontend/src/containers/__tests__/EditChart.test.tsx
@@ -44,6 +44,6 @@ test("renders a textfield for chart title", async () => {
 test("renders a file upload input", async () => {
   render(<EditChart />, { wrapper: MemoryRouter });
   expect(
-    await screen.findByRole("button", { name: "Choose data" })
+    await screen.findByRole("tab", { name: "Choose data" })
   ).toBeInTheDocument();
 });

--- a/frontend/src/containers/__tests__/EditTable.test.tsx
+++ b/frontend/src/containers/__tests__/EditTable.test.tsx
@@ -36,6 +36,6 @@ test("renders a textfield for table title", async () => {
 test("renders a choose data button", async () => {
   render(<EditTable />, { wrapper: MemoryRouter });
   expect(
-    await screen.findByRole("button", { name: "Choose data" })
+    await screen.findByRole("tab", { name: "Choose data" })
   ).toBeInTheDocument();
 });

--- a/frontend/src/containers/__tests__/__snapshots__/AddContent.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/AddContent.test.tsx.snap
@@ -104,12 +104,12 @@ Object {
                       for="text"
                     >
                       Text
-                      <p
+                      <span
                         class="text-base usa-prose usa-checkbox__label-description"
                         id="text-description"
                       >
                         Add a formatted block of text. Input supports Markdown including links, bullets, bolding, and headings.
-                      </p>
+                      </span>
                     </label>
                   </div>
                 </div>
@@ -134,12 +134,12 @@ Object {
                       for="metrics"
                     >
                       Metrics
-                      <p
+                      <span
                         class="text-base usa-prose usa-checkbox__label-description"
                         id="metrics-description"
                       >
                         Add one or more metrics to show point-in-time numerical data and trends.
-                      </p>
+                      </span>
                     </label>
                   </div>
                 </div>
@@ -164,12 +164,12 @@ Object {
                       for="chart"
                     >
                       Chart
-                      <p
+                      <span
                         class="text-base usa-prose usa-checkbox__label-description"
                         id="chart-description"
                       >
                         Display data as a visualization, including line, bar, column and part-to-whole charts.
-                      </p>
+                      </span>
                     </label>
                   </div>
                 </div>
@@ -194,12 +194,12 @@ Object {
                       for="table"
                     >
                       Table
-                      <p
+                      <span
                         class="text-base usa-prose usa-checkbox__label-description"
                         id="table-description"
                       >
                         Display data formatted in rows and columns.
-                      </p>
+                      </span>
                     </label>
                   </div>
                 </div>
@@ -224,12 +224,12 @@ Object {
                       for="image"
                     >
                       Image
-                      <p
+                      <span
                         class="text-base usa-prose usa-checkbox__label-description"
                         id="image-description"
                       >
                         Upload an image to display.
-                      </p>
+                      </span>
                     </label>
                   </div>
                 </div>
@@ -254,12 +254,12 @@ Object {
                       for="section"
                     >
                       Section
-                      <p
+                      <span
                         class="text-base usa-prose usa-checkbox__label-description"
                         id="section-description"
                       >
                         Add a section to group similar content items in a list.
-                      </p>
+                      </span>
                     </label>
                   </div>
                 </div>
@@ -387,12 +387,12 @@ Object {
                     for="text"
                   >
                     Text
-                    <p
+                    <span
                       class="text-base usa-prose usa-checkbox__label-description"
                       id="text-description"
                     >
                       Add a formatted block of text. Input supports Markdown including links, bullets, bolding, and headings.
-                    </p>
+                    </span>
                   </label>
                 </div>
               </div>
@@ -417,12 +417,12 @@ Object {
                     for="metrics"
                   >
                     Metrics
-                    <p
+                    <span
                       class="text-base usa-prose usa-checkbox__label-description"
                       id="metrics-description"
                     >
                       Add one or more metrics to show point-in-time numerical data and trends.
-                    </p>
+                    </span>
                   </label>
                 </div>
               </div>
@@ -447,12 +447,12 @@ Object {
                     for="chart"
                   >
                     Chart
-                    <p
+                    <span
                       class="text-base usa-prose usa-checkbox__label-description"
                       id="chart-description"
                     >
                       Display data as a visualization, including line, bar, column and part-to-whole charts.
-                    </p>
+                    </span>
                   </label>
                 </div>
               </div>
@@ -477,12 +477,12 @@ Object {
                     for="table"
                   >
                     Table
-                    <p
+                    <span
                       class="text-base usa-prose usa-checkbox__label-description"
                       id="table-description"
                     >
                       Display data formatted in rows and columns.
-                    </p>
+                    </span>
                   </label>
                 </div>
               </div>
@@ -507,12 +507,12 @@ Object {
                     for="image"
                   >
                     Image
-                    <p
+                    <span
                       class="text-base usa-prose usa-checkbox__label-description"
                       id="image-description"
                     >
                       Upload an image to display.
-                    </p>
+                    </span>
                   </label>
                 </div>
               </div>
@@ -537,12 +537,12 @@ Object {
                     for="section"
                   >
                     Section
-                    <p
+                    <span
                       class="text-base usa-prose usa-checkbox__label-description"
                       id="section-description"
                     >
                       Add a section to group similar content items in a list.
-                    </p>
+                    </span>
                   </label>
                 </div>
               </div>


### PR DESCRIPTION
## Description

* Duplicated document elements IDs in `EditChart` and `EditTable` pages.
   * A string `suffix` was added to those duplicated Ids to get rid of the ID duplications.
* Improper element nesting in `EditChart` and `EditTable` pages.
   * `<div>` child of `<legend>` converted into  `<span>` as child of `<legend>`
   * `<p>` child of `<label>` converted into `<span>` as child of `<label>`
   * `<div>` child of `<span>` converted into  no `<div>` as child of `<span>`
* Tabs improper structure in `EditChart` and `EditTable` pages.
   * The accessible name  was added to the ` role="tablist"` elements.
   * The `role="tab"`  has been set to the `<button>` elements instead of the previous `<li>` elements.

## Testing

Describe how you tested your changes and/or give instructions to the reviewers on how they can verify them.

1. Go to `EditTable` page https://d2zdyv8kmq5ffn.cloudfront.net/admin/dashboard/a2eb7bec-a8fc-4055-9d49-669dd178e540/edit-table/cbb5920e-2d28-455c-b84e-89783fec5edc
2. Verify the changes stated above.
3. Repeat the same procedure in `EditChart` page https://d2zdyv8kmq5ffn.cloudfront.net/admin/dashboard/a2eb7bec-a8fc-4055-9d49-669dd178e540/edit-chart/8e6b659e-8361-4aeb-bb05-7304d58aface    
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
