### PR TITLE
fix: convert percent div into a span

### DIFF
--- a/frontend/src/components/DonutChartWidget.tsx
+++ b/frontend/src/components/DonutChartWidget.tsx
@@ -226,7 +226,8 @@ const DonutChartWidget = (props: Props) => {
         <span className="margin-left-05 font-sans-md text-bottom">
           {RenderLegendText(value.toLocaleString(), entry)}
         </span>
-        <div className="margin-left-4 margin-bottom-1 text-base-darker text-bold">
+        <br />
+        <span className="margin-left-5 margin-bottom-1 text-base-darker text-bold">
           {value && value !== "null" ? (
             TickFormatter.format(
               Number(
@@ -242,7 +243,7 @@ const DonutChartWidget = (props: Props) => {
           ) : (
             <br />
           )}
-        </div>
+        </span>
       </span>
     );
   };

--- a/frontend/src/components/PartWholeChartWidget.tsx
+++ b/frontend/src/components/PartWholeChartWidget.tsx
@@ -110,7 +110,8 @@ const PartWholeChartWidget = (props: Props) => {
         <span className="margin-left-05 font-sans-md text-bottom">
           {RenderLegendText(label.toLocaleString(), entry)}
         </span>
-        <div className="margin-left-4 margin-bottom-1 text-base-darker text-bold">
+        <br />
+        <span className="margin-left-5 margin-bottom-1 text-base-darker text-bold">
           {amount && amount !== "null" ? (
             TickFormatter.format(
               Number(amount),
@@ -123,7 +124,7 @@ const PartWholeChartWidget = (props: Props) => {
           ) : (
             <br />
           )}
-        </div>
+        </span>
       </span>
     );
   };

--- a/frontend/src/components/PieChartWidget.tsx
+++ b/frontend/src/components/PieChartWidget.tsx
@@ -201,7 +201,8 @@ const PieChartWidget = (props: Props) => {
         <span className="margin-left-05 font-sans-md text-bottom">
           {RenderLegendText(value.toLocaleString(), entry)}
         </span>
-        <div className="margin-left-4 margin-bottom-1 text-base-darker text-bold">
+        <br />
+        <span className="margin-left-5 margin-bottom-1 text-base-darker text-bold">
           {value && value !== "null" ? (
             TickFormatter.format(
               Number(
@@ -217,7 +218,7 @@ const PieChartWidget = (props: Props) => {
           ) : (
             <br />
           )}
-        </div>
+        </span>
       </span>
     );
   };


### PR DESCRIPTION
## Description

Fix HTML for pie charts percentages

<img width="802" alt="image" src="https://user-images.githubusercontent.com/6969135/192900986-3952b17c-bc49-4d4a-aa47-688b0813f27b.png">

## Testing

Describe how you tested your changes and/or give instructions to the reviewers on how they can verify them.

1. Go to https://d2h803e1awe3zo.cloudfront.net/example-dashboard2#section-e88280c8
2. Verify that percent is using a span element
3. Repeat for Part of a Whole chart
4. Repeat for Donuts chart

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
