### PR TITLE
Contrast issue in RadioButtonsTile component has been addressed

### DIFF
--- a/frontend/src/components/RadioButtonsTile.module.scss
+++ b/frontend/src/components/RadioButtonsTile.module.scss
@@ -1,0 +1,12 @@
+@import "../styles/base";
+
+.radio {
+    &:hover, &:active, &:checked {
+        & + [class*=__label]{
+            @include u-bg("base-lighter", "!important");
+        }
+        &:not([disabled]):focus {
+            outline: 0.25rem solid color("primary") !important;
+        }
+    }
+}

--- a/frontend/src/components/RadioButtonsTile.tsx
+++ b/frontend/src/components/RadioButtonsTile.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import styles from "./RadioButtonsTile.module.scss";
 
 interface Option {
   id: string;
@@ -22,7 +23,7 @@ function RadioButtonsTile(props: Props) {
       <div className="usa-radio" role="contentinfo" key={index}>
         <div className="tablet:grid-col">
           <input
-            className="usa-radio__input usa-radio__input--tile"
+            className={`usa-radio__input usa-radio__input--tile ${styles.radio}`}
             id={option.id}
             value={option.value}
             type="radio"

--- a/frontend/src/components/__tests__/__snapshots__/ChooseData.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/ChooseData.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`renders the ChooseData component 1`] = `
             >
               <input
                 aria-describedby="staticDataset-description"
-                class="usa-radio__input usa-radio__input--tile"
+                class="usa-radio__input usa-radio__input--tile radio"
                 data-testid="staticDatasetRadioButton"
                 id="staticDataset"
                 name="datasetType"
@@ -99,7 +99,7 @@ exports[`renders the ChooseData component 1`] = `
             >
               <input
                 aria-describedby="dynamicDataset-description"
-                class="usa-radio__input usa-radio__input--tile"
+                class="usa-radio__input usa-radio__input--tile radio"
                 data-testid="dynamicDatasetRadioButton"
                 id="dynamicDataset"
                 name="datasetType"

--- a/frontend/src/containers/__tests__/__snapshots__/AddContent.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/AddContent.test.tsx.snap
@@ -92,7 +92,7 @@ Object {
                   >
                     <input
                       aria-describedby="text-description"
-                      class="usa-radio__input usa-radio__input--tile"
+                      class="usa-radio__input usa-radio__input--tile radio"
                       data-testid="textRadioButton"
                       id="text"
                       name="widgetType"
@@ -122,7 +122,7 @@ Object {
                   >
                     <input
                       aria-describedby="metrics-description"
-                      class="usa-radio__input usa-radio__input--tile"
+                      class="usa-radio__input usa-radio__input--tile radio"
                       data-testid="metricsRadioButton"
                       id="metrics"
                       name="widgetType"
@@ -152,7 +152,7 @@ Object {
                   >
                     <input
                       aria-describedby="chart-description"
-                      class="usa-radio__input usa-radio__input--tile"
+                      class="usa-radio__input usa-radio__input--tile radio"
                       data-testid="chartRadioButton"
                       id="chart"
                       name="widgetType"
@@ -182,7 +182,7 @@ Object {
                   >
                     <input
                       aria-describedby="table-description"
-                      class="usa-radio__input usa-radio__input--tile"
+                      class="usa-radio__input usa-radio__input--tile radio"
                       data-testid="tableRadioButton"
                       id="table"
                       name="widgetType"
@@ -212,7 +212,7 @@ Object {
                   >
                     <input
                       aria-describedby="image-description"
-                      class="usa-radio__input usa-radio__input--tile"
+                      class="usa-radio__input usa-radio__input--tile radio"
                       data-testid="imageRadioButton"
                       id="image"
                       name="widgetType"
@@ -242,7 +242,7 @@ Object {
                   >
                     <input
                       aria-describedby="section-description"
-                      class="usa-radio__input usa-radio__input--tile"
+                      class="usa-radio__input usa-radio__input--tile radio"
                       data-testid="sectionRadioButton"
                       id="section"
                       name="widgetType"
@@ -375,7 +375,7 @@ Object {
                 >
                   <input
                     aria-describedby="text-description"
-                    class="usa-radio__input usa-radio__input--tile"
+                    class="usa-radio__input usa-radio__input--tile radio"
                     data-testid="textRadioButton"
                     id="text"
                     name="widgetType"
@@ -405,7 +405,7 @@ Object {
                 >
                   <input
                     aria-describedby="metrics-description"
-                    class="usa-radio__input usa-radio__input--tile"
+                    class="usa-radio__input usa-radio__input--tile radio"
                     data-testid="metricsRadioButton"
                     id="metrics"
                     name="widgetType"
@@ -435,7 +435,7 @@ Object {
                 >
                   <input
                     aria-describedby="chart-description"
-                    class="usa-radio__input usa-radio__input--tile"
+                    class="usa-radio__input usa-radio__input--tile radio"
                     data-testid="chartRadioButton"
                     id="chart"
                     name="widgetType"
@@ -465,7 +465,7 @@ Object {
                 >
                   <input
                     aria-describedby="table-description"
-                    class="usa-radio__input usa-radio__input--tile"
+                    class="usa-radio__input usa-radio__input--tile radio"
                     data-testid="tableRadioButton"
                     id="table"
                     name="widgetType"
@@ -495,7 +495,7 @@ Object {
                 >
                   <input
                     aria-describedby="image-description"
-                    class="usa-radio__input usa-radio__input--tile"
+                    class="usa-radio__input usa-radio__input--tile radio"
                     data-testid="imageRadioButton"
                     id="image"
                     name="widgetType"
@@ -525,7 +525,7 @@ Object {
                 >
                   <input
                     aria-describedby="section-description"
-                    class="usa-radio__input usa-radio__input--tile"
+                    class="usa-radio__input usa-radio__input--tile radio"
                     data-testid="sectionRadioButton"
                     id="section"
                     name="widgetType"


### PR DESCRIPTION
## Description

The radio button focus indicator section when activated had a contrast ratio below 3.00:1 in `add-content` and `changerole` pages. Solution:
* `outline color` set to `#005ea2`
* `background-color` set to `#dfe1e2`
* `contrast ratio` increased to `5.12: 1`
![image](https://user-images.githubusercontent.com/111308971/192916653-ffff1225-d4f6-47e6-91ec-3d0ea1bfbd75.png)
![image](https://user-images.githubusercontent.com/111308971/192916962-5096e1f0-fd08-4a64-b168-f685a3f76aef.png)
![image](https://user-images.githubusercontent.com/111308971/192916996-e489426c-43c9-481a-88ef-f9e166557ecc.png)


## Testing

Describe how you tested your changes and/or give instructions to the reviewers on how they can verify them.

1. Go to https://d2zdyv8kmq5ffn.cloudfront.net/admin/dashboard/a2eb7bec-a8fc-4055-9d49-669dd178e540/add-content
2. Verify the background color of the radio button upon selection doesn't change to other color distinct to `white`.
3. Apply the same verification procedure to the `changerole` page.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
