### PR TITLE
Denis/gtt 2005 links state info

### DIFF
--- a/frontend/src/components/CheckData.tsx
+++ b/frontend/src/components/CheckData.tsx
@@ -200,168 +200,164 @@ function CheckData(props: Props) {
 
   return (
     <>
-      <fieldset className="usa-fieldset">
-        <legend
-          className={`usa-hint ${isMobile ? "grid-col-12" : "grid-col-6"}`}
-        >
-          {t("CheckDataDescription", { widgetType: props.widgetType })}
-        </legend>
+      <div className={`usa-hint ${isMobile ? "grid-col-12" : "grid-col-6"}`}>
+        {t("CheckDataDescription", { widgetType: props.widgetType })}
+      </div>
 
-        <div className="grid-col-12 margin-top-3 font-sans-md text-bold">
-          {t("IncludeInVisualization")}
-        </div>
+      <div className="grid-col-12 margin-top-3 font-sans-md text-bold">
+        {t("IncludeInVisualization")}
+      </div>
 
-        <div className="check-data-table grid-col-12">
-          <Table
-            selection="none"
-            rows={checkDataTableRows}
-            initialSortAscending={
-              props.sortByDesc !== undefined ? !props.sortByDesc : true
-            }
-            initialSortByField={props.sortByColumn}
-            pageSize={50}
-            disablePagination={false}
-            disableBorderless={true}
-            columns={checkDataTableColumns}
-            hiddenColumns={props.hiddenColumns}
-            addNumbersColumn={true}
-            sortByColumn={props.sortByColumn}
-            sortByDesc={props.sortByDesc}
-            setSortByColumn={props.setSortByColumn}
-            setSortByDesc={props.setSortByDesc}
-            reset={props.reset}
-            keepBorderBottom
-            mobileNavigation
-            settingTable={true}
-          />
-        </div>
-        <br />
+      <div className="check-data-table grid-col-12">
+        <Table
+          selection="none"
+          rows={checkDataTableRows}
+          initialSortAscending={
+            props.sortByDesc !== undefined ? !props.sortByDesc : true
+          }
+          initialSortByField={props.sortByColumn}
+          pageSize={50}
+          disablePagination={false}
+          disableBorderless={true}
+          columns={checkDataTableColumns}
+          hiddenColumns={props.hiddenColumns}
+          addNumbersColumn={true}
+          sortByColumn={props.sortByColumn}
+          sortByDesc={props.sortByDesc}
+          setSortByColumn={props.setSortByColumn}
+          setSortByDesc={props.setSortByDesc}
+          reset={props.reset}
+          keepBorderBottom
+          mobileNavigation
+          settingTable={true}
+        />
+      </div>
+      <br />
 
-        <div className="grid-col-12 margin-top-3 font-sans-md text-bold">
-          {t("FormatColumns")}
-        </div>
+      <div className="grid-col-12 margin-top-3 font-sans-md text-bold">
+        {t("FormatColumns")}
+      </div>
 
-        <div className="grid-col-12 font-sans-md font-sans-md text-bold">
-          {(props.data.length
-            ? (Object.keys(props.data[0]) as Array<string>)
-            : []
-          ).map((header: string) => {
-            return (
-              <div key={header} className="margin-top-4">
-                <span className="text-base">Column: {header}</span>
+      <div className="grid-col-12 font-sans-md font-sans-md text-bold">
+        {(props.data.length
+          ? (Object.keys(props.data[0]) as Array<string>)
+          : []
+        ).map((header: string) => {
+          return (
+            <div key={header} className="margin-top-4">
+              <span className="text-base">Column: {header}</span>
 
+              <div className={isMobile ? "grid-col-8" : "grid-col-4"}>
+                <Dropdown
+                  id={header}
+                  name="dataType"
+                  label={t("DataFormat")}
+                  options={[
+                    { value: "", label: t("SelectAnOption") },
+                    { value: ColumnDataType.Text, label: t("Text") },
+                    {
+                      value: ColumnDataType.Number,
+                      label: t("Number"),
+                    },
+                    {
+                      value: ColumnDataType.Date,
+                      label: t("Date"),
+                    },
+                  ]}
+                  value={props.dataTypes.get(header)}
+                  onChange={handleDataTypeChange}
+                  className="margin-top-2"
+                />
+              </div>
+
+              {props.dataTypes.get(header) === ColumnDataType.Number && (
                 <div className={isMobile ? "grid-col-8" : "grid-col-4"}>
                   <Dropdown
                     id={header}
-                    name="dataType"
-                    label={t("DataFormat")}
+                    name="numberType"
+                    label={t("NumberFormat")}
                     options={[
                       { value: "", label: t("SelectAnOption") },
-                      { value: ColumnDataType.Text, label: t("Text") },
                       {
-                        value: ColumnDataType.Number,
-                        label: t("Number"),
+                        value: NumberDataType.Percentage,
+                        label: t("Percentage"),
                       },
                       {
-                        value: ColumnDataType.Date,
-                        label: t("Date"),
+                        value: NumberDataType.Currency,
+                        label: t("Currency"),
+                      },
+                      {
+                        value: NumberDataType["With thousands separators"],
+                        label: t("WithThousandsSeparators"),
                       },
                     ]}
-                    value={props.dataTypes.get(header)}
-                    onChange={handleDataTypeChange}
-                    className="margin-top-2"
+                    value={props.numberTypes.get(header)}
+                    onChange={handleNumberTypeChange}
+                    className="margin-top-3"
                   />
                 </div>
+              )}
 
-                {props.dataTypes.get(header) === ColumnDataType.Number && (
+              {props.dataTypes.get(header) === ColumnDataType.Number &&
+                props.numberTypes.get(header) === NumberDataType.Currency && (
                   <div className={isMobile ? "grid-col-8" : "grid-col-4"}>
                     <Dropdown
                       id={header}
-                      name="numberType"
-                      label={t("NumberFormat")}
+                      name="currencyType"
+                      label={t("Currency")}
                       options={[
                         { value: "", label: t("SelectAnOption") },
                         {
-                          value: NumberDataType.Percentage,
-                          label: t("Percentage"),
+                          value: CurrencyDataType["Dollar $"],
+                          label: t("Dollar"),
                         },
                         {
-                          value: NumberDataType.Currency,
-                          label: t("Currency"),
+                          value: CurrencyDataType["Euro €"],
+                          label: t("Euro"),
                         },
                         {
-                          value: NumberDataType["With thousands separators"],
-                          label: t("WithThousandsSeparators"),
+                          value: CurrencyDataType["Pound £"],
+                          label: t("Pound"),
                         },
                       ]}
-                      value={props.numberTypes.get(header)}
-                      onChange={handleNumberTypeChange}
+                      value={props.currencyTypes.get(header)}
+                      onChange={handleCurrencyTypeChange}
                       className="margin-top-3"
                     />
                   </div>
                 )}
+              <br />
+              <hr />
+            </div>
+          );
+        })}
+      </div>
 
-                {props.dataTypes.get(header) === ColumnDataType.Number &&
-                  props.numberTypes.get(header) === NumberDataType.Currency && (
-                    <div className={isMobile ? "grid-col-8" : "grid-col-4"}>
-                      <Dropdown
-                        id={header}
-                        name="currencyType"
-                        label={t("Currency")}
-                        options={[
-                          { value: "", label: t("SelectAnOption") },
-                          {
-                            value: CurrencyDataType["Dollar $"],
-                            label: t("Dollar"),
-                          },
-                          {
-                            value: CurrencyDataType["Euro €"],
-                            label: t("Euro"),
-                          },
-                          {
-                            value: CurrencyDataType["Pound £"],
-                            label: t("Pound"),
-                          },
-                        ]}
-                        value={props.currencyTypes.get(header)}
-                        onChange={handleCurrencyTypeChange}
-                        className="margin-top-3"
-                      />
-                    </div>
-                  )}
-                <br />
-                <hr />
-              </div>
-            );
-          })}
-        </div>
-
-        <br />
-        <Button
-          variant="outline"
-          type="button"
-          onClick={props.backStep}
-          className="margin-top-1"
-        >
-          {t("BackButton")}
-        </Button>
-        <Button
-          type="button"
-          onClick={props.advanceStep}
-          disabled={!props.data.length}
-          className="margin-top-1"
-        >
-          {t("ContinueButton")}
-        </Button>
-        <Button
-          variant="unstyled"
-          className="text-base-dark hover:text-base-darker active:text-base-darkest margin-top-1"
-          type="button"
-          onClick={props.onCancel}
-        >
-          {t("Cancel")}
-        </Button>
-      </fieldset>
+      <br />
+      <Button
+        variant="outline"
+        type="button"
+        onClick={props.backStep}
+        className="margin-top-1"
+      >
+        {t("BackButton")}
+      </Button>
+      <Button
+        type="button"
+        onClick={props.advanceStep}
+        disabled={!props.data.length}
+        className="margin-top-1"
+      >
+        {t("ContinueButton")}
+      </Button>
+      <Button
+        variant="unstyled"
+        className="text-base-dark hover:text-base-darker active:text-base-darkest margin-top-1"
+        type="button"
+        onClick={props.onCancel}
+      >
+        {t("Cancel")}
+      </Button>
     </>
   );
 }

--- a/frontend/src/components/RadioButtonsTile.tsx
+++ b/frontend/src/components/RadioButtonsTile.tsx
@@ -20,7 +20,7 @@ interface Props {
 function RadioButtonsTile(props: Props) {
   const getUsaRatio = (option: Option, index: number) => {
     return (
-      <div className="usa-radio" role="contentinfo" key={index}>
+      <div className="usa-radio" role="radio" key={index}>
         <div className="tablet:grid-col">
           <input
             className={`usa-radio__input usa-radio__input--tile ${styles.radio}`}

--- a/frontend/src/components/__tests__/__snapshots__/CheckData.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/CheckData.test.tsx.snap
@@ -2,534 +2,530 @@
 
 exports[`renders the CheckData component 1`] = `
 <div>
-  <fieldset
-    class="usa-fieldset"
+  <div
+    class="usa-hint grid-col-6"
   >
-    <legend
-      class="usa-hint grid-col-6"
-    >
-      Please make sure that the system formats your data correctly. Select columns to format as numbers, dates, or text. Also select columns to hide or show from the chart.
-    </legend>
+    Please make sure that the system formats your data correctly. Select columns to format as numbers, dates, or text. Also select columns to hide or show from the chart.
+  </div>
+  <div
+    class="grid-col-12 margin-top-3 font-sans-md text-bold"
+  >
+    Include in visualization
+  </div>
+  <div
+    class="check-data-table grid-col-12"
+  >
     <div
-      class="grid-col-12 margin-top-3 font-sans-md text-bold"
+      class="overflow-x-hidden overflow-y-hidden"
     >
-      Include in visualization
-    </div>
-    <div
-      class="check-data-table grid-col-12"
-    >
-      <div
-        class="overflow-x-hidden overflow-y-hidden"
+      <table
+        class="usa-table"
+        role="table"
       >
-        <table
-          class="usa-table"
-          role="table"
-        >
-          <thead>
-            <tr
-              role="row"
-            >
-              <th
-                aria-sort="none"
-                colspan="1"
-                role="columnheader"
-                scope="col"
-                style="min-width: 0;"
-              >
-                <span>
-                   
-                </span>
-              </th>
-              <th
-                aria-sort="none"
-                colspan="1"
-                role="columnheader"
-                scope="col"
-              >
-                <span>
-                  <span
-                    class="text-center usa-checkbox margin-bottom-1"
-                  >
-                    <input
-                      aria-label="id CheckBox"
-                      checked=""
-                      class="usa-checkbox__input"
-                      id="checkbox-header-0"
-                      name="id"
-                      type="checkbox"
-                    />
-                    <label
-                      class="usa-checkbox__label"
-                      for="checkbox-header-0"
-                    />
-                  </span>
-                </span>
-              </th>
-              <th
-                aria-sort="none"
-                colspan="1"
-                role="columnheader"
-                scope="col"
-              >
-                <span>
-                  <span
-                    class="text-center usa-checkbox margin-bottom-1"
-                  >
-                    <input
-                      aria-label="name CheckBox"
-                      checked=""
-                      class="usa-checkbox__input"
-                      id="checkbox-header-1"
-                      name="name"
-                      type="checkbox"
-                    />
-                    <label
-                      class="usa-checkbox__label"
-                      for="checkbox-header-1"
-                    />
-                  </span>
-                </span>
-              </th>
-              <th
-                aria-sort="none"
-                colspan="1"
-                role="columnheader"
-                scope="col"
-              >
-                <span>
-                  <span
-                    class="text-center usa-checkbox margin-bottom-1"
-                  >
-                    <input
-                      aria-label="updatedAt CheckBox"
-                      checked=""
-                      class="usa-checkbox__input"
-                      id="checkbox-header-2"
-                      name="updatedAt"
-                      type="checkbox"
-                    />
-                    <label
-                      class="usa-checkbox__label"
-                      for="checkbox-header-2"
-                    />
-                  </span>
-                </span>
-              </th>
-            </tr>
-            <tr
-              role="row"
-            >
-              <th
-                aria-sort="none"
-                colspan="1"
-                role="columnheader"
-                scope="col"
-                style="min-width: 0;"
-              >
-                <span>
-                  <div>
-                    1
-                  </div>
-                </span>
-              </th>
-              <th
-                aria-sort="none"
-                colspan="1"
-                role="columnheader"
-                scope="col"
-                style="min-width: 150px;"
-              >
-                <span>
-                  id
-                </span>
-                <button
-                  aria-label="Toggle SortBy: id"
-                  class="margin-left-1 usa-button usa-button--unstyled"
-                  style="cursor: pointer;"
-                  title="Toggle SortBy: id"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="svg-inline--fa fa-chevron-down fa-w-14 "
-                    data-icon="chevron-down"
-                    data-prefix="fas"
-                    focusable="false"
-                    role="img"
-                    viewBox="0 0 448 512"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                </button>
-              </th>
-              <th
-                aria-sort="none"
-                colspan="1"
-                role="columnheader"
-                scope="col"
-                style="min-width: 150px;"
-              >
-                <span>
-                  name
-                </span>
-                <button
-                  aria-label="Toggle SortBy: name"
-                  class="margin-left-1 usa-button usa-button--unstyled"
-                  style="cursor: pointer;"
-                  title="Toggle SortBy: name"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="svg-inline--fa fa-chevron-down fa-w-14 "
-                    data-icon="chevron-down"
-                    data-prefix="fas"
-                    focusable="false"
-                    role="img"
-                    viewBox="0 0 448 512"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                </button>
-              </th>
-              <th
-                aria-sort="none"
-                colspan="1"
-                role="columnheader"
-                scope="col"
-                style="min-width: 150px;"
-              >
-                <span>
-                  updatedAt
-                </span>
-                <button
-                  aria-label="Toggle SortBy: updatedAt"
-                  class="margin-left-1 usa-button usa-button--unstyled"
-                  style="cursor: pointer;"
-                  title="Toggle SortBy: updatedAt"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="svg-inline--fa fa-chevron-down fa-w-14 "
-                    data-icon="chevron-down"
-                    data-prefix="fas"
-                    focusable="false"
-                    role="img"
-                    viewBox="0 0 448 512"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                </button>
-              </th>
-            </tr>
-          </thead>
-          <tbody
-            role="rowgroup"
+        <thead>
+          <tr
+            role="row"
           >
-            <tr
-              role="row"
+            <th
+              aria-sort="none"
+              colspan="1"
+              role="columnheader"
+              scope="col"
+              style="min-width: 0;"
             >
-              <th
-                role="cell"
-                scope="row"
-                style="background-color: rgb(240, 240, 240);"
-              >
-                <div>
-                  2
-                </div>
-              </th>
-              <td
-                role="cell"
-              >
-                1
-              </td>
-              <td
-                role="cell"
-              >
-                Banana
-              </td>
-              <td
-                role="cell"
-              >
-                2021-11-11
-              </td>
-            </tr>
-            <tr
-              role="row"
+              <span>
+                 
+              </span>
+            </th>
+            <th
+              aria-sort="none"
+              colspan="1"
+              role="columnheader"
+              scope="col"
             >
-              <th
-                role="cell"
-                scope="row"
-                style="background-color: rgb(240, 240, 240);"
-              >
+              <span>
+                <span
+                  class="text-center usa-checkbox margin-bottom-1"
+                >
+                  <input
+                    aria-label="id CheckBox"
+                    checked=""
+                    class="usa-checkbox__input"
+                    id="checkbox-header-0"
+                    name="id"
+                    type="checkbox"
+                  />
+                  <label
+                    class="usa-checkbox__label"
+                    for="checkbox-header-0"
+                  />
+                </span>
+              </span>
+            </th>
+            <th
+              aria-sort="none"
+              colspan="1"
+              role="columnheader"
+              scope="col"
+            >
+              <span>
+                <span
+                  class="text-center usa-checkbox margin-bottom-1"
+                >
+                  <input
+                    aria-label="name CheckBox"
+                    checked=""
+                    class="usa-checkbox__input"
+                    id="checkbox-header-1"
+                    name="name"
+                    type="checkbox"
+                  />
+                  <label
+                    class="usa-checkbox__label"
+                    for="checkbox-header-1"
+                  />
+                </span>
+              </span>
+            </th>
+            <th
+              aria-sort="none"
+              colspan="1"
+              role="columnheader"
+              scope="col"
+            >
+              <span>
+                <span
+                  class="text-center usa-checkbox margin-bottom-1"
+                >
+                  <input
+                    aria-label="updatedAt CheckBox"
+                    checked=""
+                    class="usa-checkbox__input"
+                    id="checkbox-header-2"
+                    name="updatedAt"
+                    type="checkbox"
+                  />
+                  <label
+                    class="usa-checkbox__label"
+                    for="checkbox-header-2"
+                  />
+                </span>
+              </span>
+            </th>
+          </tr>
+          <tr
+            role="row"
+          >
+            <th
+              aria-sort="none"
+              colspan="1"
+              role="columnheader"
+              scope="col"
+              style="min-width: 0;"
+            >
+              <span>
                 <div>
-                  3
+                  1
                 </div>
-              </th>
-              <td
-                role="cell"
+              </span>
+            </th>
+            <th
+              aria-sort="none"
+              colspan="1"
+              role="columnheader"
+              scope="col"
+              style="min-width: 150px;"
+            >
+              <span>
+                id
+              </span>
+              <button
+                aria-label="Toggle SortBy: id"
+                class="margin-left-1 usa-button usa-button--unstyled"
+                style="cursor: pointer;"
+                title="Toggle SortBy: id"
+                type="button"
               >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-chevron-down fa-w-14 "
+                  data-icon="chevron-down"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              colspan="1"
+              role="columnheader"
+              scope="col"
+              style="min-width: 150px;"
+            >
+              <span>
+                name
+              </span>
+              <button
+                aria-label="Toggle SortBy: name"
+                class="margin-left-1 usa-button usa-button--unstyled"
+                style="cursor: pointer;"
+                title="Toggle SortBy: name"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-chevron-down fa-w-14 "
+                  data-icon="chevron-down"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+            </th>
+            <th
+              aria-sort="none"
+              colspan="1"
+              role="columnheader"
+              scope="col"
+              style="min-width: 150px;"
+            >
+              <span>
+                updatedAt
+              </span>
+              <button
+                aria-label="Toggle SortBy: updatedAt"
+                class="margin-left-1 usa-button usa-button--unstyled"
+                style="cursor: pointer;"
+                title="Toggle SortBy: updatedAt"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-chevron-down fa-w-14 "
+                  data-icon="chevron-down"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          role="rowgroup"
+        >
+          <tr
+            role="row"
+          >
+            <th
+              role="cell"
+              scope="row"
+              style="background-color: rgb(240, 240, 240);"
+            >
+              <div>
                 2
-              </td>
-              <td
-                role="cell"
-              >
-                Chocolate
-              </td>
-              <td
-                role="cell"
-              >
-                2020-11-11
-              </td>
-            </tr>
-            <tr
-              role="row"
+              </div>
+            </th>
+            <td
+              role="cell"
             >
-              <th
-                role="cell"
-                scope="row"
-                style="background-color: rgb(240, 240, 240);"
-              >
-                <div>
-                  4
-                </div>
-              </th>
-              <td
-                role="cell"
-              >
+              1
+            </td>
+            <td
+              role="cell"
+            >
+              Banana
+            </td>
+            <td
+              role="cell"
+            >
+              2021-11-11
+            </td>
+          </tr>
+          <tr
+            role="row"
+          >
+            <th
+              role="cell"
+              scope="row"
+              style="background-color: rgb(240, 240, 240);"
+            >
+              <div>
                 3
-              </td>
-              <td
-                role="cell"
-              >
-                Vanilla
-              </td>
-              <td
-                role="cell"
-              >
-                2019-11-11
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+              </div>
+            </th>
+            <td
+              role="cell"
+            >
+              2
+            </td>
+            <td
+              role="cell"
+            >
+              Chocolate
+            </td>
+            <td
+              role="cell"
+            >
+              2020-11-11
+            </td>
+          </tr>
+          <tr
+            role="row"
+          >
+            <th
+              role="cell"
+              scope="row"
+              style="background-color: rgb(240, 240, 240);"
+            >
+              <div>
+                4
+              </div>
+            </th>
+            <td
+              role="cell"
+            >
+              3
+            </td>
+            <td
+              role="cell"
+            >
+              Vanilla
+            </td>
+            <td
+              role="cell"
+            >
+              2019-11-11
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
-    <br />
+  </div>
+  <br />
+  <div
+    class="grid-col-12 margin-top-3 font-sans-md text-bold"
+  >
+    Format columns
+  </div>
+  <div
+    class="grid-col-12 font-sans-md font-sans-md text-bold"
+  >
     <div
-      class="grid-col-12 margin-top-3 font-sans-md text-bold"
+      class="margin-top-4"
     >
-      Format columns
+      <span
+        class="text-base"
+      >
+        Column: 
+        id
+      </span>
+      <div
+        class="grid-col-4"
+      >
+        <div
+          class="usa-form-group margin-top-2"
+          role="contentinfo"
+        >
+          <label
+            class="usa-label text-bold"
+            for="id"
+          >
+            Data format
+          </label>
+          <div
+            class="usa-hint"
+            id="id-description"
+          />
+          <select
+            aria-describedby="id-description"
+            class="usa-select"
+            id="id"
+            name="dataType"
+          >
+            <option
+              value=""
+            >
+              Select an option
+            </option>
+            <option
+              value="Text"
+            >
+              Text
+            </option>
+            <option
+              value="Number"
+            >
+              Number
+            </option>
+            <option
+              value="Date"
+            >
+              Date
+            </option>
+          </select>
+        </div>
+      </div>
+      <br />
+      <hr />
     </div>
     <div
-      class="grid-col-12 font-sans-md font-sans-md text-bold"
+      class="margin-top-4"
     >
-      <div
-        class="margin-top-4"
+      <span
+        class="text-base"
       >
-        <span
-          class="text-base"
-        >
-          Column: 
-          id
-        </span>
-        <div
-          class="grid-col-4"
-        >
-          <div
-            class="usa-form-group margin-top-2"
-            role="contentinfo"
-          >
-            <label
-              class="usa-label text-bold"
-              for="id"
-            >
-              Data format
-            </label>
-            <div
-              class="usa-hint"
-              id="id-description"
-            />
-            <select
-              aria-describedby="id-description"
-              class="usa-select"
-              id="id"
-              name="dataType"
-            >
-              <option
-                value=""
-              >
-                Select an option
-              </option>
-              <option
-                value="Text"
-              >
-                Text
-              </option>
-              <option
-                value="Number"
-              >
-                Number
-              </option>
-              <option
-                value="Date"
-              >
-                Date
-              </option>
-            </select>
-          </div>
-        </div>
-        <br />
-        <hr />
-      </div>
+        Column: 
+        name
+      </span>
       <div
-        class="margin-top-4"
+        class="grid-col-4"
       >
-        <span
-          class="text-base"
-        >
-          Column: 
-          name
-        </span>
         <div
-          class="grid-col-4"
+          class="usa-form-group margin-top-2"
+          role="contentinfo"
         >
-          <div
-            class="usa-form-group margin-top-2"
-            role="contentinfo"
+          <label
+            class="usa-label text-bold"
+            for="name"
           >
-            <label
-              class="usa-label text-bold"
-              for="name"
-            >
-              Data format
-            </label>
-            <div
-              class="usa-hint"
-              id="name-description"
-            />
-            <select
-              aria-describedby="name-description"
-              class="usa-select"
-              id="name"
-              name="dataType"
-            >
-              <option
-                value=""
-              >
-                Select an option
-              </option>
-              <option
-                value="Text"
-              >
-                Text
-              </option>
-              <option
-                value="Number"
-              >
-                Number
-              </option>
-              <option
-                value="Date"
-              >
-                Date
-              </option>
-            </select>
-          </div>
-        </div>
-        <br />
-        <hr />
-      </div>
-      <div
-        class="margin-top-4"
-      >
-        <span
-          class="text-base"
-        >
-          Column: 
-          updatedAt
-        </span>
-        <div
-          class="grid-col-4"
-        >
+            Data format
+          </label>
           <div
-            class="usa-form-group margin-top-2"
-            role="contentinfo"
+            class="usa-hint"
+            id="name-description"
+          />
+          <select
+            aria-describedby="name-description"
+            class="usa-select"
+            id="name"
+            name="dataType"
           >
-            <label
-              class="usa-label text-bold"
-              for="updatedAt"
+            <option
+              value=""
             >
-              Data format
-            </label>
-            <div
-              class="usa-hint"
-              id="updatedAt-description"
-            />
-            <select
-              aria-describedby="updatedAt-description"
-              class="usa-select"
-              id="updatedAt"
-              name="dataType"
+              Select an option
+            </option>
+            <option
+              value="Text"
             >
-              <option
-                value=""
-              >
-                Select an option
-              </option>
-              <option
-                value="Text"
-              >
-                Text
-              </option>
-              <option
-                value="Number"
-              >
-                Number
-              </option>
-              <option
-                value="Date"
-              >
-                Date
-              </option>
-            </select>
-          </div>
+              Text
+            </option>
+            <option
+              value="Number"
+            >
+              Number
+            </option>
+            <option
+              value="Date"
+            >
+              Date
+            </option>
+          </select>
         </div>
-        <br />
-        <hr />
       </div>
+      <br />
+      <hr />
     </div>
-    <br />
-    <button
-      class="usa-button usa-button--outline margin-top-1"
-      type="button"
+    <div
+      class="margin-top-4"
     >
-      Back
-    </button>
-    <button
-      class="usa-button usa-button--base margin-top-1"
-      type="button"
-    >
-      Continue
-    </button>
-    <button
-      class="usa-button usa-button--unstyled text-base-dark hover:text-base-darker active:text-base-darkest margin-top-1"
-      type="button"
-    >
-      Cancel
-    </button>
-  </fieldset>
+      <span
+        class="text-base"
+      >
+        Column: 
+        updatedAt
+      </span>
+      <div
+        class="grid-col-4"
+      >
+        <div
+          class="usa-form-group margin-top-2"
+          role="contentinfo"
+        >
+          <label
+            class="usa-label text-bold"
+            for="updatedAt"
+          >
+            Data format
+          </label>
+          <div
+            class="usa-hint"
+            id="updatedAt-description"
+          />
+          <select
+            aria-describedby="updatedAt-description"
+            class="usa-select"
+            id="updatedAt"
+            name="dataType"
+          >
+            <option
+              value=""
+            >
+              Select an option
+            </option>
+            <option
+              value="Text"
+            >
+              Text
+            </option>
+            <option
+              value="Number"
+            >
+              Number
+            </option>
+            <option
+              value="Date"
+            >
+              Date
+            </option>
+          </select>
+        </div>
+      </div>
+      <br />
+      <hr />
+    </div>
+  </div>
+  <br />
+  <button
+    class="usa-button usa-button--outline margin-top-1"
+    type="button"
+  >
+    Back
+  </button>
+  <button
+    class="usa-button usa-button--base margin-top-1"
+    type="button"
+  >
+    Continue
+  </button>
+  <button
+    class="usa-button usa-button--unstyled text-base-dark hover:text-base-darker active:text-base-darkest margin-top-1"
+    type="button"
+  >
+    Cancel
+  </button>
 </div>
 `;

--- a/frontend/src/components/__tests__/__snapshots__/ChooseData.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/ChooseData.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`renders the ChooseData component 1`] = `
         >
           <div
             class="usa-radio"
-            role="contentinfo"
+            role="radio"
           >
             <div
               class="tablet:grid-col"
@@ -92,7 +92,7 @@ exports[`renders the ChooseData component 1`] = `
         >
           <div
             class="usa-radio"
-            role="contentinfo"
+            role="radio"
           >
             <div
               class="tablet:grid-col"

--- a/frontend/src/containers/__tests__/__snapshots__/AddContent.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/AddContent.test.tsx.snap
@@ -81,7 +81,7 @@ Object {
               >
                 <div
                   class="usa-radio"
-                  role="contentinfo"
+                  role="radio"
                 >
                   <div
                     class="tablet:grid-col"
@@ -111,7 +111,7 @@ Object {
                 </div>
                 <div
                   class="usa-radio"
-                  role="contentinfo"
+                  role="radio"
                 >
                   <div
                     class="tablet:grid-col"
@@ -141,7 +141,7 @@ Object {
                 </div>
                 <div
                   class="usa-radio"
-                  role="contentinfo"
+                  role="radio"
                 >
                   <div
                     class="tablet:grid-col"
@@ -171,7 +171,7 @@ Object {
                 </div>
                 <div
                   class="usa-radio"
-                  role="contentinfo"
+                  role="radio"
                 >
                   <div
                     class="tablet:grid-col"
@@ -201,7 +201,7 @@ Object {
                 </div>
                 <div
                   class="usa-radio"
-                  role="contentinfo"
+                  role="radio"
                 >
                   <div
                     class="tablet:grid-col"
@@ -231,7 +231,7 @@ Object {
                 </div>
                 <div
                   class="usa-radio"
-                  role="contentinfo"
+                  role="radio"
                 >
                   <div
                     class="tablet:grid-col"
@@ -360,7 +360,7 @@ Object {
             >
               <div
                 class="usa-radio"
-                role="contentinfo"
+                role="radio"
               >
                 <div
                   class="tablet:grid-col"
@@ -390,7 +390,7 @@ Object {
               </div>
               <div
                 class="usa-radio"
-                role="contentinfo"
+                role="radio"
               >
                 <div
                   class="tablet:grid-col"
@@ -420,7 +420,7 @@ Object {
               </div>
               <div
                 class="usa-radio"
-                role="contentinfo"
+                role="radio"
               >
                 <div
                   class="tablet:grid-col"
@@ -450,7 +450,7 @@ Object {
               </div>
               <div
                 class="usa-radio"
-                role="contentinfo"
+                role="radio"
               >
                 <div
                   class="tablet:grid-col"
@@ -480,7 +480,7 @@ Object {
               </div>
               <div
                 class="usa-radio"
-                role="contentinfo"
+                role="radio"
               >
                 <div
                   class="tablet:grid-col"
@@ -510,7 +510,7 @@ Object {
               </div>
               <div
                 class="usa-radio"
-                role="contentinfo"
+                role="radio"
               >
                 <div
                   class="tablet:grid-col"

--- a/frontend/src/containers/__tests__/__snapshots__/AdminSiteSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/AdminSiteSettings.test.tsx.snap
@@ -57,6 +57,7 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                 class="usa-sidenav__item"
               >
                 <a
+                  aria-current="page"
                   class="usa-current"
                   href="/admin/settings"
                 >
@@ -69,6 +70,7 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class="usa-current"
                       href="/admin/settings/topicarea"
                     >
@@ -83,6 +85,7 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/publishingguidance"
                     >
@@ -97,6 +100,7 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/brandingandstyling"
                     >
@@ -111,6 +115,7 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/publishedsite"
                     >
@@ -125,6 +130,7 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/dateformat"
                     >
@@ -139,6 +145,7 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/adminsite"
                     >

--- a/frontend/src/containers/__tests__/__snapshots__/AdminSiteSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/AdminSiteSettings.test.tsx.snap
@@ -85,7 +85,6 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/publishingguidance"
                     >
@@ -100,7 +99,6 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/brandingandstyling"
                     >
@@ -115,7 +113,6 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/publishedsite"
                     >
@@ -130,7 +127,6 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/dateformat"
                     >
@@ -145,7 +141,6 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/adminsite"
                     >

--- a/frontend/src/containers/__tests__/__snapshots__/AdminSiteSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/AdminSiteSettings.test.tsx.snap
@@ -57,7 +57,6 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                 class="usa-sidenav__item"
               >
                 <a
-                  aria-current="page"
                   class="usa-current"
                   href="/admin/settings"
                 >

--- a/frontend/src/containers/__tests__/__snapshots__/BrandingAndStylingSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/BrandingAndStylingSettings.test.tsx.snap
@@ -85,7 +85,6 @@ exports[`branding and styling settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/publishingguidance"
                     >
@@ -100,7 +99,6 @@ exports[`branding and styling settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/brandingandstyling"
                     >
@@ -115,7 +113,6 @@ exports[`branding and styling settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/publishedsite"
                     >
@@ -130,7 +127,6 @@ exports[`branding and styling settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/dateformat"
                     >
@@ -145,7 +141,6 @@ exports[`branding and styling settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/adminsite"
                     >

--- a/frontend/src/containers/__tests__/__snapshots__/BrandingAndStylingSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/BrandingAndStylingSettings.test.tsx.snap
@@ -57,7 +57,6 @@ exports[`branding and styling settings should match snapshot 1`] = `
                 class="usa-sidenav__item"
               >
                 <a
-                  aria-current="page"
                   class="usa-current"
                   href="/admin/settings"
                 >

--- a/frontend/src/containers/__tests__/__snapshots__/BrandingAndStylingSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/BrandingAndStylingSettings.test.tsx.snap
@@ -57,6 +57,7 @@ exports[`branding and styling settings should match snapshot 1`] = `
                 class="usa-sidenav__item"
               >
                 <a
+                  aria-current="page"
                   class="usa-current"
                   href="/admin/settings"
                 >
@@ -69,6 +70,7 @@ exports[`branding and styling settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class="usa-current"
                       href="/admin/settings/topicarea"
                     >
@@ -83,6 +85,7 @@ exports[`branding and styling settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/publishingguidance"
                     >
@@ -97,6 +100,7 @@ exports[`branding and styling settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/brandingandstyling"
                     >
@@ -111,6 +115,7 @@ exports[`branding and styling settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/publishedsite"
                     >
@@ -125,6 +130,7 @@ exports[`branding and styling settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/dateformat"
                     >
@@ -139,6 +145,7 @@ exports[`branding and styling settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/adminsite"
                     >

--- a/frontend/src/containers/__tests__/__snapshots__/DateFormatSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/DateFormatSettings.test.tsx.snap
@@ -57,6 +57,7 @@ exports[`date format settings should match snapshot 1`] = `
                 class="usa-sidenav__item"
               >
                 <a
+                  aria-current="page"
                   class="usa-current"
                   href="/admin/settings"
                 >
@@ -69,6 +70,7 @@ exports[`date format settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class="usa-current"
                       href="/admin/settings/topicarea"
                     >
@@ -83,6 +85,7 @@ exports[`date format settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/publishingguidance"
                     >
@@ -97,6 +100,7 @@ exports[`date format settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/brandingandstyling"
                     >
@@ -111,6 +115,7 @@ exports[`date format settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/publishedsite"
                     >
@@ -125,6 +130,7 @@ exports[`date format settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/dateformat"
                     >
@@ -139,6 +145,7 @@ exports[`date format settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/adminsite"
                     >

--- a/frontend/src/containers/__tests__/__snapshots__/DateFormatSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/DateFormatSettings.test.tsx.snap
@@ -57,7 +57,6 @@ exports[`date format settings should match snapshot 1`] = `
                 class="usa-sidenav__item"
               >
                 <a
-                  aria-current="page"
                   class="usa-current"
                   href="/admin/settings"
                 >

--- a/frontend/src/containers/__tests__/__snapshots__/DateFormatSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/DateFormatSettings.test.tsx.snap
@@ -85,7 +85,6 @@ exports[`date format settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/publishingguidance"
                     >
@@ -100,7 +99,6 @@ exports[`date format settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/brandingandstyling"
                     >
@@ -115,7 +113,6 @@ exports[`date format settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/publishedsite"
                     >
@@ -130,7 +127,6 @@ exports[`date format settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/dateformat"
                     >
@@ -145,7 +141,6 @@ exports[`date format settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/adminsite"
                     >

--- a/frontend/src/containers/__tests__/__snapshots__/PublishedSiteSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/PublishedSiteSettings.test.tsx.snap
@@ -57,6 +57,7 @@ exports[`published site settings should match snapshot 1`] = `
                 class="usa-sidenav__item"
               >
                 <a
+                  aria-current="page"
                   class="usa-current"
                   href="/admin/settings"
                 >
@@ -69,6 +70,7 @@ exports[`published site settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class="usa-current"
                       href="/admin/settings/topicarea"
                     >
@@ -83,6 +85,7 @@ exports[`published site settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/publishingguidance"
                     >
@@ -97,6 +100,7 @@ exports[`published site settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/brandingandstyling"
                     >
@@ -111,6 +115,7 @@ exports[`published site settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/publishedsite"
                     >
@@ -125,6 +130,7 @@ exports[`published site settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/dateformat"
                     >
@@ -139,6 +145,7 @@ exports[`published site settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/adminsite"
                     >

--- a/frontend/src/containers/__tests__/__snapshots__/PublishedSiteSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/PublishedSiteSettings.test.tsx.snap
@@ -85,7 +85,6 @@ exports[`published site settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/publishingguidance"
                     >
@@ -100,7 +99,6 @@ exports[`published site settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/brandingandstyling"
                     >
@@ -115,7 +113,6 @@ exports[`published site settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/publishedsite"
                     >
@@ -130,7 +127,6 @@ exports[`published site settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/dateformat"
                     >
@@ -145,7 +141,6 @@ exports[`published site settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/adminsite"
                     >

--- a/frontend/src/containers/__tests__/__snapshots__/PublishedSiteSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/PublishedSiteSettings.test.tsx.snap
@@ -57,7 +57,6 @@ exports[`published site settings should match snapshot 1`] = `
                 class="usa-sidenav__item"
               >
                 <a
-                  aria-current="page"
                   class="usa-current"
                   href="/admin/settings"
                 >

--- a/frontend/src/containers/__tests__/__snapshots__/PublishingGuidanceSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/PublishingGuidanceSettings.test.tsx.snap
@@ -57,6 +57,7 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                 class="usa-sidenav__item"
               >
                 <a
+                  aria-current="page"
                   class="usa-current"
                   href="/admin/settings"
                 >
@@ -69,6 +70,7 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class="usa-current"
                       href="/admin/settings/topicarea"
                     >
@@ -83,6 +85,7 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/publishingguidance"
                     >
@@ -97,6 +100,7 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/brandingandstyling"
                     >
@@ -111,6 +115,7 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/publishedsite"
                     >
@@ -125,6 +130,7 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/dateformat"
                     >
@@ -139,6 +145,7 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/adminsite"
                     >

--- a/frontend/src/containers/__tests__/__snapshots__/PublishingGuidanceSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/PublishingGuidanceSettings.test.tsx.snap
@@ -85,7 +85,6 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/publishingguidance"
                     >
@@ -100,7 +99,6 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/brandingandstyling"
                     >
@@ -115,7 +113,6 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/publishedsite"
                     >
@@ -130,7 +127,6 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/dateformat"
                     >
@@ -145,7 +141,6 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/adminsite"
                     >

--- a/frontend/src/containers/__tests__/__snapshots__/PublishingGuidanceSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/PublishingGuidanceSettings.test.tsx.snap
@@ -57,7 +57,6 @@ exports[`publishing guidance settings should match snapshot 1`] = `
                 class="usa-sidenav__item"
               >
                 <a
-                  aria-current="page"
                   class="usa-current"
                   href="/admin/settings"
                 >

--- a/frontend/src/containers/__tests__/__snapshots__/TopicareaSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/TopicareaSettings.test.tsx.snap
@@ -85,7 +85,6 @@ exports[`topic area settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/publishingguidance"
                     >
@@ -100,7 +99,6 @@ exports[`topic area settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/brandingandstyling"
                     >
@@ -115,7 +113,6 @@ exports[`topic area settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/publishedsite"
                     >
@@ -130,7 +127,6 @@ exports[`topic area settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/dateformat"
                     >
@@ -145,7 +141,6 @@ exports[`topic area settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
-                      aria-current="page"
                       class=""
                       href="/admin/settings/adminsite"
                     >

--- a/frontend/src/containers/__tests__/__snapshots__/TopicareaSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/TopicareaSettings.test.tsx.snap
@@ -57,6 +57,7 @@ exports[`topic area settings should match snapshot 1`] = `
                 class="usa-sidenav__item"
               >
                 <a
+                  aria-current="page"
                   class="usa-current"
                   href="/admin/settings"
                 >
@@ -69,6 +70,7 @@ exports[`topic area settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class="usa-current"
                       href="/admin/settings/topicarea"
                     >
@@ -83,6 +85,7 @@ exports[`topic area settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/publishingguidance"
                     >
@@ -97,6 +100,7 @@ exports[`topic area settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/brandingandstyling"
                     >
@@ -111,6 +115,7 @@ exports[`topic area settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/publishedsite"
                     >
@@ -125,6 +130,7 @@ exports[`topic area settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/dateformat"
                     >
@@ -139,6 +145,7 @@ exports[`topic area settings should match snapshot 1`] = `
                     class="usa-sidenav__item"
                   >
                     <a
+                      aria-current="page"
                       class=""
                       href="/admin/settings/adminsite"
                     >

--- a/frontend/src/containers/__tests__/__snapshots__/TopicareaSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/TopicareaSettings.test.tsx.snap
@@ -57,7 +57,6 @@ exports[`topic area settings should match snapshot 1`] = `
                 class="usa-sidenav__item"
               >
                 <a
-                  aria-current="page"
                   class="usa-current"
                   href="/admin/settings"
                 >

--- a/frontend/src/layouts/Settings.tsx
+++ b/frontend/src/layouts/Settings.tsx
@@ -81,7 +81,11 @@ function SettingsLayout(props: LayoutProps) {
                 <nav aria-label="Left navigation">
                   <ul className="usa-sidenav">
                     <li className="usa-sidenav__item">
-                      <Link to="/admin/settings" className="usa-current">
+                      <Link
+                        to="/admin/settings"
+                        className="usa-current"
+                        aria-current="page"
+                      >
                         {t("Settings")}
                       </Link>
                       <ul className="usa-sidenav__sublist">
@@ -93,6 +97,7 @@ function SettingsLayout(props: LayoutProps) {
                                 : ""
                             }
                             to="/admin/settings/topicarea"
+                            aria-current="page"
                           >
                             {`${validSettings["topicarea"]}`}
                           </Link>
@@ -107,6 +112,7 @@ function SettingsLayout(props: LayoutProps) {
                                 : ""
                             }
                             to="/admin/settings/publishingguidance"
+                            aria-current="page"
                           >
                             {`${validSettings["publishingguidance"]}`}
                           </Link>
@@ -121,6 +127,7 @@ function SettingsLayout(props: LayoutProps) {
                                 : ""
                             }
                             to="/admin/settings/brandingandstyling"
+                            aria-current="page"
                           >
                             {`${validSettings["brandingandstyling"]}`}
                           </Link>
@@ -135,6 +142,7 @@ function SettingsLayout(props: LayoutProps) {
                                 : ""
                             }
                             to="/admin/settings/publishedsite"
+                            aria-current="page"
                           >
                             {`${validSettings["publishedsite"]}`}
                           </Link>
@@ -149,6 +157,7 @@ function SettingsLayout(props: LayoutProps) {
                                 : ""
                             }
                             to="/admin/settings/dateformat"
+                            aria-current="page"
                           >
                             {`${validSettings["dateformat"]}`}
                           </Link>
@@ -163,6 +172,7 @@ function SettingsLayout(props: LayoutProps) {
                                 : ""
                             }
                             to="/admin/settings/adminsite"
+                            aria-current="page"
                           >
                             {`${validSettings["adminsite"]}`}
                           </Link>

--- a/frontend/src/layouts/Settings.tsx
+++ b/frontend/src/layouts/Settings.tsx
@@ -81,11 +81,7 @@ function SettingsLayout(props: LayoutProps) {
                 <nav aria-label="Left navigation">
                   <ul className="usa-sidenav">
                     <li className="usa-sidenav__item">
-                      <Link
-                        to="/admin/settings"
-                        className="usa-current"
-                        aria-current="page"
-                      >
+                      <Link to="/admin/settings" className="usa-current">
                         {t("Settings")}
                       </Link>
                       <ul className="usa-sidenav__sublist">

--- a/frontend/src/layouts/Settings.tsx
+++ b/frontend/src/layouts/Settings.tsx
@@ -97,7 +97,9 @@ function SettingsLayout(props: LayoutProps) {
                                 : ""
                             }
                             to="/admin/settings/topicarea"
-                            aria-current="page"
+                            {...(currentSetting === "topicarea" && {
+                              "aria-current": "page",
+                            })}
                           >
                             {`${validSettings["topicarea"]}`}
                           </Link>
@@ -112,7 +114,9 @@ function SettingsLayout(props: LayoutProps) {
                                 : ""
                             }
                             to="/admin/settings/publishingguidance"
-                            aria-current="page"
+                            {...(currentSetting === "publishingguidance" && {
+                              "aria-current": "page",
+                            })}
                           >
                             {`${validSettings["publishingguidance"]}`}
                           </Link>
@@ -127,7 +131,9 @@ function SettingsLayout(props: LayoutProps) {
                                 : ""
                             }
                             to="/admin/settings/brandingandstyling"
-                            aria-current="page"
+                            {...(currentSetting === "brandingandstyling" && {
+                              "aria-current": "page",
+                            })}
                           >
                             {`${validSettings["brandingandstyling"]}`}
                           </Link>
@@ -142,7 +148,9 @@ function SettingsLayout(props: LayoutProps) {
                                 : ""
                             }
                             to="/admin/settings/publishedsite"
-                            aria-current="page"
+                            {...(currentSetting === "publishedsite" && {
+                              "aria-current": "page",
+                            })}
                           >
                             {`${validSettings["publishedsite"]}`}
                           </Link>
@@ -157,7 +165,9 @@ function SettingsLayout(props: LayoutProps) {
                                 : ""
                             }
                             to="/admin/settings/dateformat"
-                            aria-current="page"
+                            {...(currentSetting === "dateformat" && {
+                              "aria-current": "page",
+                            })}
                           >
                             {`${validSettings["dateformat"]}`}
                           </Link>
@@ -172,7 +182,9 @@ function SettingsLayout(props: LayoutProps) {
                                 : ""
                             }
                             to="/admin/settings/adminsite"
-                            aria-current="page"
+                            {...(currentSetting === "adminsite" && {
+                              "aria-current": "page",
+                            })}
                           >
                             {`${validSettings["adminsite"]}`}
                           </Link>


### PR DESCRIPTION
## Description

**RadioButtonsTile** component
The `aria-role` attribute has been set to `radio`.

**Settings** page
The `aria-current` attribute has been set to `page`

**CheckData** component
Unnecessary `<fieldset>` and `<legend>` grouping elements were replaced by `<div>`


## Testing

Describe how you tested your changes and/or give instructions to the reviewers on how they can verify them.

1. Go to https://d2zdyv8kmq5ffn.cloudfront.net/admin/settings
2. Review that all the links under the left sidebar have the correct state information as follows: `aria-current="page"`
3. Go to https://d2zdyv8kmq5ffn.cloudfront.net/admin/dashboard/a2eb7bec-a8fc-4055-9d49-669dd178e540/edit-chart/8e6b659e-8361-4aeb-bb05-7304d58aface
4. Do click on `Check data` tab. Then inspect the html element that contains the text:
>Please make sure that the system formats your data correctly.....

and validate that the `<fieldset>` and `<legend>` grouping elements have been removed.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
