### PR TITLE
Couple of accessibility issues fixed.

### DIFF
--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -39,7 +39,7 @@ const Markdown = (props: MarkdownProps) => {
         {props.label}
         {props.label && props.required && <span>&#42;</span>}
       </label>
-      <span className="usa-hint">
+      <span id="makdownSupportHint" className="usa-hint">
         {props.hint} {t("MarkdownSupport")}{" "}
         <Link target="_blank" to={"/admin/markdown"}>
           {t("AddTextScreen.ViewMarkdownSyntax")}
@@ -89,6 +89,7 @@ const Markdown = (props: MarkdownProps) => {
             text.current = e;
           }}
           className="usa-textarea"
+          aria-describedby="makdownSupportHint"
         />
       </div>
       <div

--- a/frontend/src/containers/__tests__/__snapshots__/AdminSiteSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/AdminSiteSettings.test.tsx.snap
@@ -151,7 +151,7 @@ exports[`publishing guidance settings should match snapshot 1`] = `
             </ul>
           </nav>
         </div>
-        <main
+        <div
           class="desktop:grid-col-9 usa-prose mobile-margin-top-2"
           id="main-content"
         >
@@ -197,7 +197,7 @@ exports[`publishing guidance settings should match snapshot 1`] = `
               class="grid-col flex-3 text-right"
             />
           </div>
-        </main>
+        </div>
       </div>
     </div>
   </div>

--- a/frontend/src/containers/__tests__/__snapshots__/BrandingAndStylingSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/BrandingAndStylingSettings.test.tsx.snap
@@ -151,7 +151,7 @@ exports[`branding and styling settings should match snapshot 1`] = `
             </ul>
           </nav>
         </div>
-        <main
+        <div
           class="desktop:grid-col-9 usa-prose mobile-margin-top-2"
           id="main-content"
         >
@@ -275,7 +275,7 @@ exports[`branding and styling settings should match snapshot 1`] = `
               </button>
             </div>
           </div>
-        </main>
+        </div>
       </div>
     </div>
   </div>

--- a/frontend/src/containers/__tests__/__snapshots__/DateFormatSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/DateFormatSettings.test.tsx.snap
@@ -151,7 +151,7 @@ exports[`date format settings should match snapshot 1`] = `
             </ul>
           </nav>
         </div>
-        <main
+        <div
           class="desktop:grid-col-9 usa-prose mobile-margin-top-2"
           id="main-content"
         >
@@ -217,7 +217,7 @@ exports[`date format settings should match snapshot 1`] = `
               class="grid-col flex-3 text-right"
             />
           </div>
-        </main>
+        </div>
       </div>
     </div>
   </div>

--- a/frontend/src/containers/__tests__/__snapshots__/PublishedSiteSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/PublishedSiteSettings.test.tsx.snap
@@ -151,7 +151,7 @@ exports[`published site settings should match snapshot 1`] = `
             </ul>
           </nav>
         </div>
-        <main
+        <div
           class="desktop:grid-col-9 usa-prose mobile-margin-top-2"
           id="main-content"
         >
@@ -402,7 +402,7 @@ exports[`published site settings should match snapshot 1`] = `
               </button>
             </div>
           </div>
-        </main>
+        </div>
       </div>
     </div>
   </div>

--- a/frontend/src/containers/__tests__/__snapshots__/PublishingGuidanceSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/PublishingGuidanceSettings.test.tsx.snap
@@ -151,7 +151,7 @@ exports[`publishing guidance settings should match snapshot 1`] = `
             </ul>
           </nav>
         </div>
-        <main
+        <div
           class="desktop:grid-col-9 usa-prose mobile-margin-top-2"
           id="main-content"
         >
@@ -205,7 +205,7 @@ exports[`publishing guidance settings should match snapshot 1`] = `
               class="grid-col flex-3 text-right"
             />
           </div>
-        </main>
+        </div>
       </div>
     </div>
   </div>

--- a/frontend/src/containers/__tests__/__snapshots__/TopicareaSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/TopicareaSettings.test.tsx.snap
@@ -151,7 +151,7 @@ exports[`topic area settings should match snapshot 1`] = `
             </ul>
           </nav>
         </div>
-        <main
+        <div
           class="desktop:grid-col-9 usa-prose mobile-margin-top-2"
           id="main-content"
         >
@@ -459,7 +459,7 @@ exports[`topic area settings should match snapshot 1`] = `
               </tr>
             </tbody>
           </table>
-        </main>
+        </div>
       </div>
     </div>
   </div>

--- a/frontend/src/layouts/Settings.tsx
+++ b/frontend/src/layouts/Settings.tsx
@@ -191,12 +191,12 @@ function SettingsLayout(props: LayoutProps) {
                 </nav>
               </div>
 
-              <main
+              <div
                 className="desktop:grid-col-9 usa-prose mobile-margin-top-2"
                 id="main-content"
               >
                 {props.children}
-              </main>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Description

GTT-2008: There are instructions that are not programmatically associated with their corresponding fields
GTT-1994: There are multiple `<main>` landmarks on this page

## Testing


GTT-2008: There are instructions that are not programmatically associated with their corresponding fields
* Go to https://d2zdyv8kmq5ffn.cloudfront.net/admin/settings/publishedsite/contentedit
* Inspect the DOM of the page and verify that the `<textarea>` element has the `aria-describedby` attribute.

GTT-1994: There are multiple `<main>` landmarks on this page
* Go to https://d2zdyv8kmq5ffn.cloudfront.net/admin/settings
* Inspect the DOM of the page and verify that there is only one occurrence of the `<main>` html tag.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
