### PR TITLE
a11y: aria-attributes were added to Tabs & TabsVertical components.

### DIFF
--- a/frontend/src/components/SectionWidget.tsx
+++ b/frontend/src/components/SectionWidget.tsx
@@ -49,6 +49,7 @@ function SectionWidget(props: Props) {
   }
 
   const chartId = `chart-${Utils.getShorterId(props.widget.id)}`;
+  const sectionHeaderId = `section-header-${props.widget.id}`;
   return (
     <div aria-label={content.title}>
       {!content.showWithTabs ? (
@@ -90,7 +91,7 @@ function SectionWidget(props: Props) {
       ) : (
         <>
           {showTitle && (
-            <h2>
+            <h2 id={sectionHeaderId}>
               {content.title}
               <ShareButton
                 id={`${chartId}a`}
@@ -160,7 +161,7 @@ function SectionWidget(props: Props) {
           <Tabs
             defaultActive={activeTabId}
             showArrows
-            ariaLabel={content.title}
+            ariaLabelledById={sectionHeaderId}
           >
             {content.widgetIds.map((id: string, index: number) => {
               const widget = props.widgets?.find((w) => w.id === id);
@@ -185,7 +186,10 @@ function SectionWidget(props: Props) {
         !props.showMobilePreview &&
         windowSize.width > 600 &&
         content.widgetIds && (
-          <TabsVertical defaultActive={activeTabId} ariaLabel={content.title}>
+          <TabsVertical
+            defaultActive={activeTabId}
+            ariaLabelledById={sectionHeaderId}
+          >
             {content.widgetIds.map((id: string, index: number) => {
               const widget = props.widgets?.find((w) => w.id === id);
               if (widget) {

--- a/frontend/src/components/Tab.tsx
+++ b/frontend/src/components/Tab.tsx
@@ -46,7 +46,7 @@ function Tab(props: Props) {
       className={className}
       onClick={onClick}
       onKeyDown={onKeyDown}
-      tabIndex={0}
+      tabIndex={props.activeTab === props.itemId ? 0 : -1}
     >
       {props.label}
     </div>

--- a/frontend/src/components/TabVertical.tsx
+++ b/frontend/src/components/TabVertical.tsx
@@ -48,7 +48,7 @@ function TabVertical(props: Props) {
       className={className}
       onClick={onClick}
       onKeyDown={onKeyDown}
-      tabIndex={0}
+      tabIndex={props.activeTab === props.itemId ? 0 : -1}
     >
       {props.label}
     </li>

--- a/frontend/src/components/Tabs.tsx
+++ b/frontend/src/components/Tabs.tsx
@@ -11,8 +11,8 @@ import { LeftArrow, RightArrow } from "./Arrows";
 interface Props {
   children: React.ReactNode;
   defaultActive: string;
-  ariaLabel: string;
   showArrows?: boolean;
+  ariaLabelledById: string;
 }
 
 type scrollVisibilityApiType = React.ContextType<typeof VisibilityContext>;
@@ -71,7 +71,7 @@ function Tabs(props: Props) {
       className="tabs"
       onKeyDown={onKeyDown}
       role="tablist"
-      aria-label={props.ariaLabel}
+      aria-labelledbyid={props.ariaLabelledById}
     >
       <ScrollMenu
         LeftArrow={props.showArrows && LeftArrow}
@@ -101,7 +101,13 @@ function Tabs(props: Props) {
           return <div id={`${childId}-panel`} role="tabpanel"></div>;
         }
         return (
-          <div id={`${childId}-panel`} className="tab-content" role="tabpanel">
+          <div
+            id={`${childId}-panel`}
+            className="tab-content"
+            role="tabpanel"
+            tabIndex={0}
+            aria-labelledbyid={`${childId}-tab`}
+          >
             {(child as any).props.children}
           </div>
         );

--- a/frontend/src/components/TabsVertical.tsx
+++ b/frontend/src/components/TabsVertical.tsx
@@ -9,7 +9,7 @@ import TabVertical from "./TabVertical";
 interface Props {
   children: React.ReactNode;
   defaultActive: string;
-  ariaLabel: string;
+  ariaLabelledById: string;
 }
 
 function TabsVertical(props: Props) {
@@ -58,7 +58,7 @@ function TabsVertical(props: Props) {
         onKeyDown={onKeyDown}
         role="tablist"
         aria-orientation="vertical"
-        aria-label={props.ariaLabel}
+        aria-labelledbyid={props.ariaLabelledById}
       >
         {React.Children.map(props.children, (child: any, index) => {
           tabsMap.set(index, child.props.id);
@@ -85,6 +85,8 @@ function TabsVertical(props: Props) {
             id={`${childId}-panel`}
             className="grid-col-10 tab-content padding-left-4"
             role="tabpanel"
+            tabIndex={0}
+            aria-labelledbyid={`${childId}-tab`}
           >
             {(child as any).props.children}
           </div>

--- a/frontend/src/components/__tests__/__snapshots__/Tab.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/Tab.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`renders the Tab component 1`] = `
     class="tab display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md"
     id="undefined-tab"
     role="tab"
-    tabindex="0"
+    tabindex="-1"
   >
     Tab 1
   </div>
@@ -25,7 +25,7 @@ exports[`renders the Tab component with default tab 2 selected 1`] = `
     class="tab display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md"
     id="undefined-tab"
     role="tab"
-    tabindex="0"
+    tabindex="-1"
   >
     Tab 1
   </div>

--- a/frontend/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`Tabs tests renders the Tabs component 1`] = `
             class="tab display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md"
             id="tab2-tab"
             role="tab"
-            tabindex="0"
+            tabindex="-1"
           >
             Tab 2
           </div>
@@ -54,9 +54,11 @@ exports[`Tabs tests renders the Tabs component 1`] = `
       </div>
     </div>
     <div
+      aria-labelledbyid="tab1-tab"
       class="tab-content"
       id="tab1-panel"
       role="tabpanel"
+      tabindex="0"
     >
       Tab 1
     </div>
@@ -92,7 +94,7 @@ exports[`Tabs tests renders the Tabs component with default tab 2 selected 1`] =
             class="tab display-inline-block padding-x-2 padding-y-105 text-bold font-sans-md"
             id="tab1-tab"
             role="tab"
-            tabindex="0"
+            tabindex="-1"
           >
             Tab 1
           </div>
@@ -126,9 +128,11 @@ exports[`Tabs tests renders the Tabs component with default tab 2 selected 1`] =
       role="tabpanel"
     />
     <div
+      aria-labelledbyid="tab2-tab"
       class="tab-content"
       id="tab2-panel"
       role="tabpanel"
+      tabindex="0"
     >
       Tab 2
     </div>

--- a/frontend/src/containers/DashboardListing.tsx
+++ b/frontend/src/containers/DashboardListing.tsx
@@ -164,7 +164,7 @@ function DashboardListing() {
   return (
     <>
       <AlertContainer />
-      <h1>{t("DashboardListing.Dashboards")}</h1>
+      <h1 id="dashboard-listing-title">{t("DashboardListing.Dashboards")}</h1>
       <Modal
         isOpen={isOpenArchiveModal}
         closeModal={closeArchiveModal}
@@ -212,7 +212,7 @@ function DashboardListing() {
           <Tabs
             defaultActive={activeTab}
             showArrows={windowSize.width <= 600}
-            ariaLabel={t("DashboardListing.Dashboard")}
+            ariaLabelledById="dashboard-listing-title"
           >
             <div
               id="drafts"


### PR DESCRIPTION
## Description

Tabs & TabsVertical components had missing some `aria-attributes` as described in the [aria best practices](https://www.w3.org/WAI/ARIA/apg/example-index/tabs/tabs-automatic.html). The following issues were  addressed:
- role="tablist" element has no accessible name.
- role="tabpanel" element has no `aria-labelledby` set to the ID of the corresponding tab.
- No aria-controls on role="tab" elements

## Testing

Describe how you tested your changes and/or give instructions to the reviewers on how they can verify them.

Go to https://d2zdyv8kmq5ffn.cloudfront.net/example-dashboard

Verify that the section widget tab shown there follows the best practices described at: https://www.w3.org/WAI/ARIA/apg/example-index/tabs/tabs-automatic.html

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
