### PR TITLE
fix(frontend): change global colors

### DIFF
--- a/frontend/src/components/Combobox.css
+++ b/frontend/src/components/Combobox.css
@@ -14,9 +14,9 @@
   content: "pla";
 }
 
-.usa-combo-box__list-option[data-value="#c05600"]::after {
-  background-color: #c05600;
-  color: #c05600;
+.usa-combo-box__list-option[data-value="#BC4D01"]::after {
+  background-color: #BC4D01;
+  color: #BC4D01;
   margin: 5px;
   border-radius: 4px;
   content: "pla";

--- a/frontend/src/components/PublishDashboardModal.tsx
+++ b/frontend/src/components/PublishDashboardModal.tsx
@@ -95,7 +95,7 @@ function PublishDashboardModal(props: PathParams) {
                 }
             } catch (err) {
                 setPublishError(
-                    err?.response?.status === 409
+                    (err as any)?.response?.status === 409
                         ? t("PublishDashboardModal.FailToPublishUrlAlreadyExists")
                         : t("PublishDashboardModal.FailToPublishError"),
                 );

--- a/frontend/src/containers/TopicareaListing.tsx
+++ b/frontend/src/containers/TopicareaListing.tsx
@@ -71,12 +71,6 @@ function TopicareaListing(props: Props) {
         }
     };
 
-    const sortTopicareas = (topicAreas: Array<TopicArea>): Array<TopicArea> => {
-        return [...topicAreas].sort((a, b) => {
-            return a.name > b.name ? -1 : 1;
-        });
-    };
-
     return (
         <>
             <Modal

--- a/frontend/src/layouts/SAMLAuthenticator.tsx
+++ b/frontend/src/layouts/SAMLAuthenticator.tsx
@@ -33,7 +33,6 @@ export function withSAMLAuthenticator(
 
             // checkUser returns an "unsubscribe" function to stop side-effects
             return checkUser();
-            // eslint-disable-next-line react-hooks/exhaustive-deps
         }, []);
 
         function checkUser() {

--- a/frontend/src/services/ColorPaletteService.ts
+++ b/frontend/src/services/ColorPaletteService.ts
@@ -6,7 +6,7 @@
 const defaultColors = [
     "#005ea2",
     "#54278f",
-    "#c05600",
+    "#BC4D01",
     "#002d3f",
     "#136c66",
     "#996600",
@@ -23,7 +23,7 @@ const getColors = (
     numberOfColors: number,
     primaryColor: string,
     secondaryColor: string,
-): Array<string> => {
+): string[] => {
     const colors = new Array<string>();
     colors.push(primaryColor);
     const secondaryIndex = defaultColors.indexOf(secondaryColor);
@@ -36,7 +36,7 @@ const getColors = (
     return colors;
 };
 
-const getSecondaryOptions = (primaryColor?: string) => {
+const getSecondaryOptions = (primaryColor?: string): any => {
     return defaultColors
         .filter((d) => d !== primaryColor)
         .map((c) => {

--- a/frontend/src/services/DatasetParsingService.ts
+++ b/frontend/src/services/DatasetParsingService.ts
@@ -39,7 +39,7 @@ function getFilteredJson(json: Array<any>, hiddenColumns: Set<string>): Array<an
             obj[key] = row[key];
             return obj;
         }, {});
-        if (filteredRow !== {}) {
+        if (Object.keys(filteredRow).length) {
             newFilteredJson.push(filteredRow);
         }
     }

--- a/frontend/src/services/UtilsService.ts
+++ b/frontend/src/services/UtilsService.ts
@@ -55,7 +55,7 @@ function emailIsValid(email: string): boolean {
     return /^[^\s@]+@[^\s@]+$/.test(email);
 }
 
-function timeout(delay: number) {
+async function timeout(delay: number) {
     return new Promise((res) => setTimeout(res, delay));
 }
 


### PR DESCRIPTION
## Description

 A global style change that increase the contrast ratio to 4.8:1.
Change `#C05600` to `#BC4D01` wherever the hex code occurs on the app within CSS.

## Testing

Describe how you tested your changes and/or give instructions to the reviewers on how they can verify them.
Go to https://d2zdyv8kmq5ffn.cloudfront.net/admin/settings/brandingandstyling/editcolors
Verify that `#C05600` has been replaced by  `#BC4D01` in the **Data visualization second color (optional)** dropdown.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
