### PR TITLE
fix(frontend): add unique aria label values

### DIFF
--- a/frontend/src/components/BarChartWidget.tsx
+++ b/frontend/src/components/BarChartWidget.tsx
@@ -276,6 +276,7 @@ const BarChartWidget = (props: Props) => {
                     columnsMetadata={props.columnsMetadata}
                     fileName={props.downloadTitle}
                     showMobilePreview={showMobilePreview}
+                    title={props.title}
                 />
             </div>
             {props.summaryBelow && (

--- a/frontend/src/components/ColumnChartWidget.tsx
+++ b/frontend/src/components/ColumnChartWidget.tsx
@@ -287,6 +287,7 @@ function ColumnChartWidget(props: Props) {
                     columnsMetadata={props.columnsMetadata}
                     fileName={props.downloadTitle}
                     showMobilePreview={showMobilePreview}
+                    title={props.title}
                 />
             </div>
             {props.summaryBelow && (

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -24,9 +24,10 @@ interface Props {
     columnsMetadata?: ColumnMetadata[];
     fileName?: string;
     showMobilePreview?: boolean;
+    title: string;
 }
 
-function DataTable({ rows, columns, columnsMetadata, fileName, showMobilePreview }: Props) {
+function DataTable({ rows, columns, columnsMetadata, fileName, showMobilePreview, title }: Props) {
     const history = useHistory();
     const { t } = useTranslation();
     const [showDataTable, setShowDataTable] = useState(false);
@@ -67,7 +68,7 @@ function DataTable({ rows, columns, columnsMetadata, fileName, showMobilePreview
                     buttonText={t("Actions")}
                     disabled={false}
                     variant="unstyled"
-                    ariaLabel={t("ARIA.DataTableActions")}
+                    ariaLabel={`${title} - ${t("ARIA.DataTableActions")}`}
                 >
                     <MenuItem
                         onSelect={() =>

--- a/frontend/src/components/DonutChartWidget.tsx
+++ b/frontend/src/components/DonutChartWidget.tsx
@@ -349,6 +349,7 @@ const DonutChartWidget = (props: Props) => {
                     fileName={props.downloadTitle}
                     columnsMetadata={props.columnsMetadata}
                     showMobilePreview={showMobilePreview}
+                    title={props.title}
                 />
             </div>
             {props.summaryBelow && (

--- a/frontend/src/components/LineChartWidget.tsx
+++ b/frontend/src/components/LineChartWidget.tsx
@@ -231,6 +231,7 @@ function LineChartWidget(props: Props) {
                     columnsMetadata={props.columnsMetadata}
                     fileName={props.downloadTitle}
                     showMobilePreview={showMobilePreview}
+                    title={props.title}
                 />
             </div>
             {props.summaryBelow && (

--- a/frontend/src/components/PartWholeChartWidget.tsx
+++ b/frontend/src/components/PartWholeChartWidget.tsx
@@ -254,6 +254,7 @@ const PartWholeChartWidget = (props: Props) => {
                     fileName={props.downloadTitle}
                     columnsMetadata={props.columnsMetadata}
                     showMobilePreview={showMobilePreview}
+                    title={props.title}
                 />
             </div>
             {props.summaryBelow && (

--- a/frontend/src/components/PieChartWidget.tsx
+++ b/frontend/src/components/PieChartWidget.tsx
@@ -323,6 +323,7 @@ const PieChartWidget = (props: Props) => {
                     fileName={props.downloadTitle}
                     columnsMetadata={props.columnsMetadata}
                     showMobilePreview={showMobilePreview}
+                    title={props.title}
                 />
             </div>
             {props.summaryBelow && (

--- a/frontend/src/components/__tests__/DataTable.test.tsx
+++ b/frontend/src/components/__tests__/DataTable.test.tsx
@@ -57,6 +57,7 @@ test("table should be hidden by default", async () => {
             columnsMetadata={columnsMetadata}
             fileName={"test-file-name"}
             showMobilePreview={false}
+            title={"test-title"}
         />,
     );
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
@@ -70,6 +71,7 @@ test("shows and hides table when button is clicked", async () => {
             columnsMetadata={columnsMetadata}
             fileName={"test-file-name"}
             showMobilePreview={false}
+            title={"test-title"}
         />,
     );
     const showTableBtn = screen.getByText("Show data table");
@@ -89,6 +91,7 @@ test("displays a table with values properly formatted", async () => {
             columnsMetadata={columnsMetadata}
             fileName={"test-file-name"}
             showMobilePreview={false}
+            title={"test-title"}
         />,
     );
     const showTableBtn = screen.getByText("Show data table");
@@ -118,6 +121,7 @@ test("renders a Data Table element with hidden table", async () => {
             columnsMetadata={columnsMetadata}
             fileName={"test-file-name"}
             showMobilePreview={false}
+            title={"test-title"}
         />,
     );
 
@@ -132,6 +136,7 @@ test("renders a Data Table element with hidden table on mobile", async () => {
             columnsMetadata={columnsMetadata}
             fileName={"test-file-name"}
             showMobilePreview={true}
+            title={"test-title"}
         />,
     );
 
@@ -146,6 +151,7 @@ test("renders a Data Table element", async () => {
             columnsMetadata={columnsMetadata}
             fileName={"test-file-name"}
             showMobilePreview={false}
+            title={"test-title"}
         />,
     );
 
@@ -163,6 +169,7 @@ test("renders a Data Table element on mobile", async () => {
             columnsMetadata={columnsMetadata}
             fileName={"test-file-name"}
             showMobilePreview={true}
+            title={"test-title"}
         />,
     );
 

--- a/frontend/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`renders a Data Table element 1`] = `
     <button
       aria-controls="menu--33"
       aria-haspopup="true"
-      aria-label="Data table actions"
+      aria-label="test-title - Data table actions"
       class="usa-button usa-button--unstyled text-base"
       data-reach-menu-button=""
       id="menu-button--menu--33"
@@ -225,7 +225,7 @@ exports[`renders a Data Table element on mobile 1`] = `
     <button
       aria-controls="menu--40"
       aria-haspopup="true"
-      aria-label="Data table actions"
+      aria-label="test-title - Data table actions"
       class="usa-button usa-button--unstyled text-base"
       data-reach-menu-button=""
       id="menu-button--menu--40"
@@ -442,7 +442,7 @@ exports[`renders a Data Table element with hidden table 1`] = `
     <button
       aria-controls="menu--23"
       aria-haspopup="true"
-      aria-label="Data table actions"
+      aria-label="test-title - Data table actions"
       class="usa-button usa-button--unstyled text-base"
       data-reach-menu-button=""
       id="menu-button--menu--23"
@@ -477,7 +477,7 @@ exports[`renders a Data Table element with hidden table on mobile 1`] = `
     <button
       aria-controls="menu--28"
       aria-haspopup="true"
-      aria-label="Data table actions"
+      aria-label="test-title - Data table actions"
       class="usa-button usa-button--unstyled text-base"
       data-reach-menu-button=""
       id="menu-button--menu--28"

--- a/frontend/src/components/__tests__/__snapshots__/VisualizeChart.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/VisualizeChart.test.tsx.snap
@@ -536,7 +536,7 @@ exports[`renders the VisualizeChart component 1`] = `
                 <button
                   aria-controls="menu--1"
                   aria-haspopup="true"
-                  aria-label="Data table actions"
+                  aria-label="title - Data table actions"
                   class="usa-button usa-button--unstyled text-base"
                   data-reach-menu-button=""
                   id="menu-button--menu--1"
@@ -1104,7 +1104,7 @@ exports[`renders the VisualizeChart component without horizontal scrolling 1`] =
                 <button
                   aria-controls="menu--7"
                   aria-haspopup="true"
-                  aria-label="Data table actions"
+                  aria-label="title - Data table actions"
                   class="usa-button usa-button--unstyled text-base"
                   data-reach-menu-button=""
                   id="menu-button--menu--7"

--- a/frontend/src/services/DatasetParsingService.ts
+++ b/frontend/src/services/DatasetParsingService.ts
@@ -39,7 +39,7 @@ function getFilteredJson(json: Array<any>, hiddenColumns: Set<string>): Array<an
             obj[key] = row[key];
             return obj;
         }, {});
-        if (Object.keys(filteredRow).length) {
+        if (Object.keys(filteredRow).length > 0) {
             newFilteredJson.push(filteredRow);
         }
     }


### PR DESCRIPTION
## Description

 Multiple chart widgets had aria labels saying: "Data table actions". They need to be distinguishable, so the aria label values for them have been changed to `{content-item-name} – data table actions`

## Testing

Describe how you tested your changes and/or give instructions to the reviewers on how they can verify them.

Go to https://d2zdyv8kmq5ffn.cloudfront.net/example-dashboard
Verify the `Actions` buttons in the bottom right of every chart widget has a unique `aria-label` attribute value.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
