### PR TITLE
fix(frontend): show parent link only in breadcrumbs

### DIFF
--- a/frontend/src/components/Breadcrumbs.scss
+++ b/frontend/src/components/Breadcrumbs.scss
@@ -1,3 +1,72 @@
+@import "../styles/base";
+
 .usa-breadcrumb {
     background-color: transparent !important;
+    @include u-padding-bottom($theme-breadcrumb-padding-bottom);
+    @include u-padding-top($theme-breadcrumb-padding-top);
+}
+
+// Breadcrumb wrap
+.usa-breadcrumb--wrap {
+    @include u-line-height($theme-breadcrumb-font-family, 4);
+    
+}
+.usa-breadcrumb__list-item {
+    @include u-white-space("wrap");
+
+    // If parent link only, only show parent of current link
+    &:nth-last-child(2) {
+      @include not-sr-only;
+
+      .usa-breadcrumb__link {
+        @include button-unstyled;
+        @include exdent-icon;
+        @include place-icon(
+          $icon-breadcrumb-back,
+          "before",
+          0,
+          baseline,
+          $theme-breadcrumb-background-color
+        );
+
+        // Override link colors from button-unstyled()
+        @include set-link-from-bg(
+          $theme-breadcrumb-background-color,
+          $theme-breadcrumb-link-color,
+          $context: $breadcrumb-context
+        );
+
+        @include u-display("inline-block");
+        @include u-padding-bottom($theme-breadcrumb-padding-bottom);
+        @include u-padding-top($theme-breadcrumb-padding-top);
+
+        &:before {
+          bottom: $icon-vertical-spacer;
+          // Magic number to center icon
+          height: $breadcrumb-icon-display-height;
+          position: relative;
+        }
+
+        // Prevent underline that extends beyond text
+        &,
+        &:hover,
+        &:active {
+          @include u-text("no-underline");
+        }
+        span {
+          @include u-text("underline");
+        }
+      }
+
+      // Override icon spacing from place-icon() with non-token value
+      .usa-breadcrumb__link::before {
+        margin-right: $breadcrumb-icon-spacing;
+      }
+    }
+    &:not(:last-child)::after {
+        display: none !important;
+    }
+    &:not(:nth-last-child(2)) {
+        display: none !important;
+    }
 }

--- a/frontend/src/containers/EditColors.tsx
+++ b/frontend/src/containers/EditColors.tsx
@@ -27,7 +27,7 @@ interface FormValues {
 const EDIT_COLORS_CSV_COLUMN = "EditColors-CSV-Column.csv";
 const EDIT_COLORS_CSV_BAR = "EditColors-CSV-Bar.csv";
 
-function EditColors() {
+function EditColors(): any {
     const { t } = useTranslation();
     const history = useHistory();
     const { settings, loadingSettings } = useSettings();
@@ -37,7 +37,7 @@ function EditColors() {
     const primaryColor = watch("primary");
     const secondaryColor = watch("secondary");
 
-    const onSubmit = async (values: FormValues) => {
+    const onSubmit = async (values: FormValues): Promise<void> => {
         await BackendService.updateSetting(
             "colors",
             {
@@ -55,7 +55,7 @@ function EditColors() {
         });
     };
 
-    const onCancel = () => {
+    const onCancel = (): void => {
         history.push("/admin/settings/brandingandstyling");
     };
 
@@ -82,11 +82,11 @@ function EditColors() {
                 <p>{t("SettingsColorsDescription")}</p>
             </div>
 
-            {loadingSettings && datasetColumn && datasetBar ? (
+            {loadingSettings && datasetColumn.loading && datasetBar.loading ? (
                 <Spinner className="text-center margin-top-9" label={t("LoadingSpinnerLabel")} />
             ) : (
                 <div className="grid-row width-desktop">
-                    <div className="grid-col-6">
+                    <div className="tablet:grid-col-6">
                         <form
                             onSubmit={handleSubmit(onSubmit)}
                             className="edit-homepage-content-form usa-form usa-form--large"
@@ -100,12 +100,12 @@ function EditColors() {
                                         name="primary"
                                         label={t("SettingsColorsPrimaryColor")}
                                         error={
-                                            errors.primary &&
-                                            (errors.primary.type === "validate"
+                                            errors?.primary &&
+                                            (errors?.primary?.type === "validate"
                                                 ? t("SettingsColorsPrimaryColorInvalid")
                                                 : t("SettingsColorsPrimaryColorEmpty"))
                                         }
-                                        defaultValue={settings.colors && settings.colors.primary}
+                                        defaultValue={settings?.colors?.primary}
                                         register={register}
                                         required
                                         validate={ColorPaletteService.rgbHexColorIsValid}
@@ -154,7 +154,7 @@ function EditColors() {
                                         options={ColorPaletteService.getSecondaryOptions(
                                             primaryColor,
                                         )}
-                                        defaultValue={settings.colors && settings.colors.secondary}
+                                        defaultValue={settings?.colors?.secondary}
                                         register={register}
                                     />
                                 </div>
@@ -185,9 +185,9 @@ function EditColors() {
                             </Button>
                         </form>
                     </div>
-                    <div className="grid-col-6">
+                    <div className="tablet:grid-col-6">
                         <div className="grid-row">
-                            <div className="grid-col-5">
+                            <div className="tablet:grid-col-5">
                                 <BarChartWidget
                                     id="edit-color-bar-chart-sample"
                                     title=""
@@ -206,7 +206,7 @@ function EditColors() {
                                     hideDataLabels={true}
                                 />
                             </div>
-                            <div className="grid-col-7">
+                            <div className="tablet:grid-col-7">
                                 <ColumnChartWidget
                                     id="edit-color-column-chart-sample"
                                     title=""

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -567,7 +567,7 @@
     "SettingsColorsEdit": "Edit colors",
     "SettingsColorsDescription": "Customize these colors to make your dashboards appear similar in style to your organization's brand or color palette.",
     "SettingsColorsPrimaryColor": "Primary color",
-    "SettingsColorsPrimaryColorDescription": "This color will be the first color used in data visualizations and the color of buttons. Must be a valid HEX color (Ex. #00FF00, #0f0).",
+    "SettingsColorsPrimaryColorDescription": "This color will be the first color used in data visualizations. Must be a valid HEX color (Ex. #00FF00, #0f0).",
     "SettingsColorsPrimaryColorLink": "Learn more about how color relates to accessibility.",
     "SettingsColorsPrimaryColorInvalid": "Color is not a valid HEX color value",
     "SettingsColorsPrimaryColorEmpty": "Please specify a color",


### PR DESCRIPTION
## Description

* `Breadcrumbs` have been changed to show always only the parent link of the current page.
* `EditColors` component layout changed to stack the visual charts at the bottom on mobile devices.

## Testing

Describe how you tested your changes and/or give instructions to the reviewers on how they can verify them.

Go to https://d2zdyv8kmq5ffn.cloudfront.net/
Verify the color changes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
