### PR TITLE
fix(frontend): breadcrumbs have been removed from the settings layout.

### DIFF
--- a/frontend/src/containers/__tests__/__snapshots__/AdminSiteSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/AdminSiteSettings.test.tsx.snap
@@ -3,39 +3,6 @@
 exports[`publishing guidance settings should match snapshot 1`] = `
 <div>
   <div
-    class="padding-1"
-  >
-    <nav
-      aria-label="Breadcrumbs"
-      class="usa-breadcrumb usa-breadcrumb--wrap"
-    >
-      <ol
-        class="usa-breadcrumb__list"
-      >
-        <li
-          class="usa-breadcrumb__list-item"
-        >
-          <a
-            class="usa-breadcrumb__link"
-            href="/admin/settings/topicarea"
-          >
-            <span>
-              Settings
-            </span>
-          </a>
-        </li>
-        <li
-          aria-current="page"
-          class="usa-breadcrumb__list-item usa-current"
-        >
-          <span>
-            Topic areas
-          </span>
-        </li>
-      </ol>
-    </nav>
-  </div>
-  <div
     class="usa-section padding-top-3"
   >
     <div

--- a/frontend/src/containers/__tests__/__snapshots__/BrandingAndStylingSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/BrandingAndStylingSettings.test.tsx.snap
@@ -3,39 +3,6 @@
 exports[`branding and styling settings should match snapshot 1`] = `
 <div>
   <div
-    class="padding-1"
-  >
-    <nav
-      aria-label="Breadcrumbs"
-      class="usa-breadcrumb usa-breadcrumb--wrap"
-    >
-      <ol
-        class="usa-breadcrumb__list"
-      >
-        <li
-          class="usa-breadcrumb__list-item"
-        >
-          <a
-            class="usa-breadcrumb__link"
-            href="/admin/settings/topicarea"
-          >
-            <span>
-              Settings
-            </span>
-          </a>
-        </li>
-        <li
-          aria-current="page"
-          class="usa-breadcrumb__list-item usa-current"
-        >
-          <span>
-            Topic areas
-          </span>
-        </li>
-      </ol>
-    </nav>
-  </div>
-  <div
     class="usa-section padding-top-3"
   >
     <div

--- a/frontend/src/containers/__tests__/__snapshots__/DateFormatSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/DateFormatSettings.test.tsx.snap
@@ -3,39 +3,6 @@
 exports[`date format settings should match snapshot 1`] = `
 <div>
   <div
-    class="padding-1"
-  >
-    <nav
-      aria-label="Breadcrumbs"
-      class="usa-breadcrumb usa-breadcrumb--wrap"
-    >
-      <ol
-        class="usa-breadcrumb__list"
-      >
-        <li
-          class="usa-breadcrumb__list-item"
-        >
-          <a
-            class="usa-breadcrumb__link"
-            href="/admin/settings/topicarea"
-          >
-            <span>
-              Settings
-            </span>
-          </a>
-        </li>
-        <li
-          aria-current="page"
-          class="usa-breadcrumb__list-item usa-current"
-        >
-          <span>
-            Topic areas
-          </span>
-        </li>
-      </ol>
-    </nav>
-  </div>
-  <div
     class="usa-section padding-top-3"
   >
     <div

--- a/frontend/src/containers/__tests__/__snapshots__/PublishedSiteSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/PublishedSiteSettings.test.tsx.snap
@@ -3,39 +3,6 @@
 exports[`published site settings should match snapshot 1`] = `
 <div>
   <div
-    class="padding-1"
-  >
-    <nav
-      aria-label="Breadcrumbs"
-      class="usa-breadcrumb usa-breadcrumb--wrap"
-    >
-      <ol
-        class="usa-breadcrumb__list"
-      >
-        <li
-          class="usa-breadcrumb__list-item"
-        >
-          <a
-            class="usa-breadcrumb__link"
-            href="/admin/settings/topicarea"
-          >
-            <span>
-              Settings
-            </span>
-          </a>
-        </li>
-        <li
-          aria-current="page"
-          class="usa-breadcrumb__list-item usa-current"
-        >
-          <span>
-            Topic areas
-          </span>
-        </li>
-      </ol>
-    </nav>
-  </div>
-  <div
     class="usa-section padding-top-3"
   >
     <div

--- a/frontend/src/containers/__tests__/__snapshots__/PublishingGuidanceSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/PublishingGuidanceSettings.test.tsx.snap
@@ -3,39 +3,6 @@
 exports[`publishing guidance settings should match snapshot 1`] = `
 <div>
   <div
-    class="padding-1"
-  >
-    <nav
-      aria-label="Breadcrumbs"
-      class="usa-breadcrumb usa-breadcrumb--wrap"
-    >
-      <ol
-        class="usa-breadcrumb__list"
-      >
-        <li
-          class="usa-breadcrumb__list-item"
-        >
-          <a
-            class="usa-breadcrumb__link"
-            href="/admin/settings/topicarea"
-          >
-            <span>
-              Settings
-            </span>
-          </a>
-        </li>
-        <li
-          aria-current="page"
-          class="usa-breadcrumb__list-item usa-current"
-        >
-          <span>
-            Topic areas
-          </span>
-        </li>
-      </ol>
-    </nav>
-  </div>
-  <div
     class="usa-section padding-top-3"
   >
     <div

--- a/frontend/src/containers/__tests__/__snapshots__/TopicareaSettings.test.tsx.snap
+++ b/frontend/src/containers/__tests__/__snapshots__/TopicareaSettings.test.tsx.snap
@@ -3,39 +3,6 @@
 exports[`topic area settings should match snapshot 1`] = `
 <div>
   <div
-    class="padding-1"
-  >
-    <nav
-      aria-label="Breadcrumbs"
-      class="usa-breadcrumb usa-breadcrumb--wrap"
-    >
-      <ol
-        class="usa-breadcrumb__list"
-      >
-        <li
-          class="usa-breadcrumb__list-item"
-        >
-          <a
-            class="usa-breadcrumb__link"
-            href="/admin/settings/topicarea"
-          >
-            <span>
-              Settings
-            </span>
-          </a>
-        </li>
-        <li
-          aria-current="page"
-          class="usa-breadcrumb__list-item usa-current"
-        >
-          <span>
-            Topic areas
-          </span>
-        </li>
-      </ol>
-    </nav>
-  </div>
-  <div
     class="usa-section padding-top-3"
   >
     <div

--- a/frontend/src/layouts/Settings.tsx
+++ b/frontend/src/layouts/Settings.tsx
@@ -60,18 +60,6 @@ function SettingsLayout(props: LayoutProps) {
 
             <AlertContainer />
 
-            <Breadcrumbs
-                crumbs={[
-                    {
-                        label: t("Settings"),
-                        url: "/admin/settings/topicarea",
-                    },
-                    {
-                        label: `${validSettings[currentSetting]}`,
-                    },
-                ]}
-            />
-
             {loadingSettings ? (
                 ""
             ) : (

--- a/frontend/src/layouts/__tests__/__snapshots__/Settings.test.tsx.snap
+++ b/frontend/src/layouts/__tests__/__snapshots__/Settings.test.tsx.snap
@@ -3,39 +3,6 @@
 exports[`SettingsLayout renders the component 1`] = `
 <div>
   <div
-    class="padding-1"
-  >
-    <nav
-      aria-label="Breadcrumbs"
-      class="usa-breadcrumb usa-breadcrumb--wrap"
-    >
-      <ol
-        class="usa-breadcrumb__list"
-      >
-        <li
-          class="usa-breadcrumb__list-item"
-        >
-          <a
-            class="usa-breadcrumb__link"
-            href="/admin/settings/topicarea"
-          >
-            <span>
-              Settings
-            </span>
-          </a>
-        </li>
-        <li
-          aria-current="page"
-          class="usa-breadcrumb__list-item usa-current"
-        >
-          <span>
-            Topic areas
-          </span>
-        </li>
-      </ol>
-    </nav>
-  </div>
-  <div
     class="usa-section padding-top-3"
   >
     <div


### PR DESCRIPTION
## Description

**UI/UX recommendation**: to remove the breadcrumbs from this page to avoid user confusion, especially those using screen reader who may be confused why clicking back to (settings) takes them to a page called topic areas.

## Testing

Got to https://d3dd0mmx0g50vr.cloudfront.net/admin/settings and verify the breadcrumbs component has been removed.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
