### PR TITLE
fix(npm): bump sideway from 3.0.0 to 3.0.1

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10927,9 +10927,9 @@
             }
         },
         "node_modules/@sideway/formula": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
-            "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+            "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
             "peer": true
         },
         "node_modules/@sideway/pinpoint": {


### PR DESCRIPTION
## Description

Bump `@sideway/formula` from `3.0.0` to `3.0.1` in `/frontend`

## Testing

`npm test`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
