### PR TITLE
fix(npm): bump http-cache-semantics from 4.1.0 to 4.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "performance-dashboard-on-aws",
             "dependencies": {
                 "license-checker": "^25.0.1",
                 "license-report": "^6.3.0"
@@ -1745,9 +1746,9 @@
             }
         },
         "node_modules/http-cache-semantics": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-            "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+            "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
         },
         "node_modules/http2-wrapper": {
             "version": "2.2.0",


### PR DESCRIPTION
## Description

Bump `http-cache-semantics` from `4.1.0` to `4.1.1`

## Testing

`npm test`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
