### PR TITLE
fix: moved ingest api before the before doubleCsrfProtection middleware

### DIFF
--- a/backend/src/lib/api/index.ts
+++ b/backend/src/lib/api/index.ts
@@ -36,13 +36,15 @@ app.get("/public/csrf-token", (req, res) => {
     });
 });
 
+// the ingest api goes before doubleCsrfProtection.
+app.use("/ingestapi", ingestapi);
+
 app.use(doubleCsrfProtection);
 app.use(csrfErrorHandler);
 
 app.use("/dashboard", dashboard);
 app.use("/topicarea", topicarea);
 app.use("/dataset", dataset);
-app.use("/ingestapi", ingestapi);
 app.use("/public", publicapi);
 app.use("/settings", settingsapi);
 app.use("/user", userapi);


### PR DESCRIPTION
## Description

* `doubleCsrfProtection` is intended for ui endpoints not for the ingest api.

## Testing

Tested locally

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
